### PR TITLE
Automatic specifications

### DIFF
--- a/groups/bal/balb/balb_controlmanager.cpp
+++ b/groups/bal/balb/balb_controlmanager.cpp
@@ -55,6 +55,7 @@ ControlManager::~ControlManager()
 }
 
 // ACCESSORS
+// ensures: (__out == true ==> d_defaultHandler.has_value()) && (__out == false ==> !d_defaultHandler.has_value())
 bool ControlManager::hasDefaultHandler() const
 {
     bslmt::ReadLockGuard<bslmt::RWMutex> registryGuard(&d_registryMutex);
@@ -62,6 +63,7 @@ bool ControlManager::hasDefaultHandler() const
 }
 
 // MANIPULATORS
+// ensures: __out == 0 || __out == 1
 int ControlManager::registerHandler(const bsl::string_view& prefix,
                                     const bsl::string_view& arguments,
                                     const bsl::string_view& description,

--- a/groups/bal/balb/balb_leakybucket.cpp
+++ b/groups/bal/balb/balb_leakybucket.cpp
@@ -22,6 +22,7 @@ namespace {
 /// `timeInterval.seconds() * drainRate <= ULLONG_MAX`.  Note that
 /// `fractionalUnitDrainedInNanoUnits` is represented in nano-units to avoid
 /// using a floating point representation.
+// ensures: __out >= 0 && *fractionalUnitDrainedInNanoUnits < 1000000000
 bsls::Types::Uint64 calculateNumberOfUnitsToDrain(
                     bsls::Types::Uint64*      fractionalUnitDrainedInNanoUnits,
                     bsls::Types::Uint64       drainRate,
@@ -161,6 +162,7 @@ LeakyBucket::LeakyBucket(bsls::Types::Uint64       drainRate,
 }
 
 // MANIPULATORS
+// ensures: __out.totalNanoseconds() >= 0
 bsls::TimeInterval LeakyBucket::calculateTimeToSubmit(
                                          const bsls::TimeInterval& currentTime)
 {

--- a/groups/bal/balb/balb_pipetaskmanager.cpp
+++ b/groups/bal/balb/balb_pipetaskmanager.cpp
@@ -25,6 +25,7 @@ namespace u {
 /// `basicAllocator`, of a `balb::PipeControlChannel` object configured to
 /// invoke the `dispatchMethod` function of the specified `controlManager`
 /// and that uses `basicAllocator` to supply memory.
+// ensures: __out != 0
 static
 PipeControlChannel *makeControlChannel(ControlManager   *controlManager,
                                        bslma::Allocator *basicAllocator)

--- a/groups/bal/balb/balb_ratelimiter.cpp
+++ b/groups/bal/balb/balb_ratelimiter.cpp
@@ -51,6 +51,7 @@ namespace {
 /// with which to initialize a `balb::LeakyBucket` object, and if so,
 /// whether a `balb::LeakyBucket` object so initialized would preserve the
 /// value of `window`.
+// ensures: (__out == true ==> (limit > 0 && window > bsls::TimeInterval() && (limit == 1 || window <= LeakyBucket::calculateDrainTime(ULLONG_MAX, limit, true)) && window == LeakyBucket::calculateTimeWindow(limit, LeakyBucket::calculateCapacity(limit, window)))) && (__out == false ==> !(limit > 0 && window > bsls::TimeInterval() && (limit == 1 || window <= LeakyBucket::calculateDrainTime(ULLONG_MAX, limit, true)) && window == LeakyBucket::calculateTimeWindow(limit, LeakyBucket::calculateCapacity(limit, window))))
 bool supportsExactly(bsls::Types::Uint64       limit,
                      const bsls::TimeInterval& window)
 {

--- a/groups/bal/balber/balber_berdecoder.cpp
+++ b/groups/bal/balber/balber_berdecoder.cpp
@@ -179,6 +179,7 @@ void BerDecoder_Node::print(bsl::ostream&  out,
 }
 
 // MANIPULATORS
+// ensures: __out == d_decoder->logError(msg)
 int BerDecoder_Node::logError(const char *msg)
 {
     BerDecoder::ErrorSeverity rc = d_decoder->logError(msg);

--- a/groups/bal/balber/balber_berdecoderoptions.cpp
+++ b/groups/bal/balber/balber_berdecoderoptions.cpp
@@ -74,6 +74,7 @@ const bdlat_AttributeInfo balber::BerDecoderOptions::ATTRIBUTE_INFO_ARRAY[] = {
 namespace balber {
 
 // CLASS METHODS
+// ensures: (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_MAX_DEPTH] || __out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_TRACE_LEVEL] || __out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_MAX_SEQUENCE_SIZE] || __out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_SKIP_UNKNOWN_ELEMENTS] || __out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_DEFAULT_EMPTY_STRINGS] || __out == 0)
 const bdlat_AttributeInfo *BerDecoderOptions::lookupAttributeInfo(
                                                         const char *name,
                                                         int         nameLength)

--- a/groups/bal/balber/balber_berencoder.cpp
+++ b/groups/bal/balber/balber_berencoder.cpp
@@ -46,6 +46,7 @@ BerEncoder::~BerEncoder()
 }
 
 // PRIVATE MANIPULATORS
+// ensures: (static_cast<int>(d_severity) >= static_cast<int>(e_BER_ERROR)) && (__out == logMsg("ERROR", tagClass, tagNumber, name, index))
 BerEncoder::ErrorSeverity
 BerEncoder::logError(BerConstants::TagClass  tagClass,
                      int                     tagNumber,

--- a/groups/bal/balber/balber_beruniversaltagnumber.cpp
+++ b/groups/bal/balber/balber_beruniversaltagnumber.cpp
@@ -14,6 +14,7 @@ namespace balber {
                         // ----------------------------
 
 // CLASS METHODS
+// ensures: (value == e_BER_BOOL ==> __out == "BOOL") && (value == e_BER_INT ==> __out == "INT") && (value == e_BER_OCTET_STRING ==> __out == "OCTET_STRING") && (value == e_BER_REAL ==> __out == "REAL") && (value == e_BER_ENUMERATION ==> __out == "ENUMERATION") && (value == e_BER_UTF8_STRING ==> __out == "UTF8_STRING") && (value == e_BER_SEQUENCE ==> __out == "SEQUENCE") && (value == e_BER_VISIBLE_STRING ==> __out == "VISIBLE_STRING") && (value != e_BER_BOOL && value != e_BER_INT && value != e_BER_OCTET_STRING && value != e_BER_REAL && value != e_BER_ENUMERATION && value != e_BER_UTF8_STRING && value != e_BER_SEQUENCE && value != e_BER_VISIBLE_STRING ==> __out == "(* UNKNOWN *)")
 const char *BerUniversalTagNumber::toString(BerUniversalTagNumber::Value value)
 {
 #ifdef CASE

--- a/groups/bal/balber/balber_berutil.cpp
+++ b/groups/bal/balber/balber_berutil.cpp
@@ -100,6 +100,7 @@ ReadRestFunctor::ReadRestFunctor(bsl::streambuf *streamBuf, int oldSize)
 }
 
 // MODIFIERS
+// ensures: __out == (d_oldSize + static_cast<size_t>(nRead))
 size_t ReadRestFunctor::operator()(char *buf, size_t newSize)
 {
     bsl::streamsize nRead = d_streamBuf->sgetn(
@@ -134,6 +135,7 @@ namespace balber {
                                // --------------
 
 // CLASS METHODS
+// ensures: (tagClass != 0) && (tagType != 0) && (tagNumber != 0) && (accumNumBytesConsumed != 0)
 int BerUtil::getIdentifierOctets(bsl::streambuf         *streamBuf,
                                  BerConstants::TagClass *tagClass,
                                  BerConstants::TagType  *tagType,
@@ -158,6 +160,7 @@ int BerUtil::putIdentifierOctets(bsl::streambuf         *streamBuf,
                       // --------------------------------
 
 // CLASS METHODS
+// ensures: __out == 0 || __out == -1
 int BerUtil_IdentifierImpUtil::getIdentifierOctets(
                                  BerConstants::TagClass *tagClass,
                                  BerConstants::TagType  *tagType,
@@ -209,6 +212,7 @@ int BerUtil_IdentifierImpUtil::getIdentifierOctets(
 }
 
 /// Write the specified `tag*` to the specified `streamBuf`.
+// ensures: (__out == SUCCESS) || (__out == FAILURE)
 int BerUtil_IdentifierImpUtil::putIdentifierOctets(
                                              bsl::streambuf         *streamBuf,
                                              BerConstants::TagClass  tagClass,
@@ -432,6 +436,7 @@ int BerUtil_LengthImpUtil::putEndOfContentOctets(bsl::streambuf *streamBuf)
                        // -----------------------------
 
 // CLASS METHODS
+// ensures: (value == 0 ==> __out == 1) && (value != 0 ==> (__out == 1 || __out == 2))
 int BerUtil_IntegerImpUtil::getNumOctetsToStream(short value)
 {
     // This overload of 'numBytesToStream' is optimized for a 16-bit 'value'.
@@ -1238,6 +1243,7 @@ int BerUtil_Iso8601ImpUtil::putTimeTzValue(bsl::streambuf          *streamBuf,
                     // ------------------------------------
 
 // CLASS METHODS
+// ensures: (__out == true ==> (k_MIN_OFFSET <= value && k_MAX_OFFSET >= value)) && (__out == false ==> !(k_MIN_OFFSET <= value && k_MAX_OFFSET >= value))
 bool BerUtil_TimezoneOffsetImpUtil::isValidTimezoneOffsetInMinutes(int value)
 {
     return (k_MIN_OFFSET <= value) && (k_MAX_OFFSET >= value);

--- a/groups/bal/balcl/balcl_commandline.cpp
+++ b/groups/bal/balcl/balcl_commandline.cpp
@@ -100,6 +100,7 @@ EnvironmentVariableAccessor::EnvironmentVariableAccessor(
 #endif
 
 // ACCESSORS
+// ensures: __out == d_returnValue
 inline
 const char *EnvironmentVariableAccessor::value() const
 {
@@ -215,6 +216,7 @@ Ordinal::Ordinal(bsl::size_t n)
 }  // close namespace u
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& u::operator<<(bsl::ostream& stream, Ordinal position)
 {
     // ranks start at 0, but are displayed as 1st, 2nd, etc.
@@ -1186,6 +1188,7 @@ void CommandLine::validateAndInitialize(bsl::ostream& errorStream)
 }
 
 // PRIVATE ACCESSORS
+// ensures: (__out != -1 ==> (0 <= __out && __out < d_options.size() && d_options[__out].name() == name)) && (__out == -1 ==> FORALL(0, d_options.size(), i, d_options[i].name() != name))
 int CommandLine::findName(const bsl::string_view& name) const
 {
     for (unsigned int i = 0; i < d_options.size(); ++i) {
@@ -1284,6 +1287,7 @@ int CommandLine::missing(bool checkAlsoNonOptions) const
 }
 
 // CLASS METHODS
+// ensures: (__out == true ==> status == 0) && (__out == false ==> status != 0)
 bool CommandLine::isValidOptionSpecificationTable(
                                                  const OptionInfo *specTable,
                                                  int               length,
@@ -1393,6 +1397,7 @@ CommandLine::~CommandLine()
 }
 
 // MANIPULATORS
+// ensures: (__out.d_state == e_NOT_PARSED && rhs.d_state == e_NOT_PARSED) || (__out.d_state == e_PARSED && rhs.d_state == e_PARSED && __out.d_arguments == rhs.d_arguments) && __out.d_options == rhs.d_options && __out != rhs
 CommandLine& CommandLine::operator=(const CommandLine& rhs)
 {
     BSLS_ASSERT(d_state != e_INVALID);
@@ -1438,6 +1443,7 @@ int CommandLine::parse(int                argc,
 }
 
 // ACCESSORS
+// ensures: (__out == true ==> (0 <= findName(name))) && (__out == false ==> (findName(name) < 0))
 bool CommandLine::hasOption(const bsl::string_view& name) const
 {
     return 0 <= findName(name);
@@ -2011,6 +2017,7 @@ bsl::ostream& CommandLine::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.isParsed() && rhs.isParsed() && lhs.options() == rhs.options())) && (__out == false ==> !(lhs.isParsed() && rhs.isParsed() && lhs.options() == rhs.options()))
 bool balcl::operator==(const CommandLine& lhs, const CommandLine& rhs)
 {
     return lhs.isParsed() && rhs.isParsed() && lhs.options() == rhs.options();
@@ -2042,6 +2049,7 @@ namespace balcl {
                           // ------------------------------
 
 // ACCESSORS
+// ensures: (__out >= 0 ==> EXISTS(d_schema_p->cbegin(), d_schema_p->cend(), itr, (itr->d_name_p == name))) && (__out == -1 ==> FORALL(d_schema_p->cbegin(), d_schema_p->cend(), itr, (itr->d_name_p != name)))
 int CommandLineOptionsHandle::index(const bsl::string_view& name) const
 {
     for (CommandLine_Schema::const_iterator itr  = d_schema_p->cbegin(),

--- a/groups/bal/balcl/balcl_occurrenceinfo.cpp
+++ b/groups/bal/balcl/balcl_occurrenceinfo.cpp
@@ -197,6 +197,7 @@ OccurrenceInfo::~OccurrenceInfo()
 }
 
 // MANIPULATORS
+// ensures: (__out == *this) && ((&rhs != this) ==> (d_defaultValue ↦ rhs.d_defaultValue ⋆ d_isRequired ↦ rhs.d_isRequired ⋆ d_isHidden ↦ rhs.d_isHidden))
 OccurrenceInfo& OccurrenceInfo::operator=(const OccurrenceInfo& rhs)
 {
     if (&rhs != this) {
@@ -225,6 +226,7 @@ void OccurrenceInfo::setHidden()
 }
 
 // ACCESSORS
+// ensures: __out == d_defaultValue
 const OptionValue& OccurrenceInfo::defaultValue() const
 {
     return d_defaultValue;
@@ -309,6 +311,7 @@ bsl::ostream& OccurrenceInfo::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.occurrenceType() == rhs.occurrenceType() && lhs.hasDefaultValue() == rhs.hasDefaultValue() && (!lhs.hasDefaultValue() || lhs.defaultValue() == rhs.defaultValue()))) && (__out == false ==> !(lhs.occurrenceType() == rhs.occurrenceType() && lhs.hasDefaultValue() == rhs.hasDefaultValue() && (!lhs.hasDefaultValue() || lhs.defaultValue() == rhs.defaultValue())))
 bool balcl::operator==(const OccurrenceInfo& lhs, const OccurrenceInfo& rhs)
 {
     return lhs.occurrenceType()  == rhs.occurrenceType()

--- a/groups/bal/balcl/balcl_option.cpp
+++ b/groups/bal/balcl/balcl_option.cpp
@@ -159,6 +159,7 @@ Option::~Option()
 }
 
 // MANIPULATORS
+// ensures: __out == *this ⋆ (__out == rhs)
 Option& Option::operator=(const Option& rhs)
 {
     const OptionInfo& optionInfo = rhs;
@@ -417,6 +418,7 @@ bsl::ostream& Option::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs == rhs)) && (__out == false ==> (lhs != rhs))
 bool balcl::operator==(const Option& lhs, const Option& rhs)
 {
     return static_cast<const OptionInfo&>(lhs)

--- a/groups/bal/balcl/balcl_optioninfo.cpp
+++ b/groups/bal/balcl/balcl_optioninfo.cpp
@@ -13,6 +13,7 @@ namespace BloombergLP {
                      // -----------------
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& balcl::operator<<(bsl::ostream& stream, const OptionInfo& rhs)
 {
     static const char NL = '\n';

--- a/groups/bal/balcl/balcl_optiontype.cpp
+++ b/groups/bal/balcl/balcl_optiontype.cpp
@@ -65,6 +65,7 @@ const Ot::Enum Ot::TypeToEnum<Ot::DateArray>    ::value = Ot::e_DATE_ARRAY;
 const Ot::Enum Ot::TypeToEnum<Ot::TimeArray>    ::value = Ot::e_TIME_ARRAY;
 
 // CLASS METHODS
+// ensures: (__out == &stream) && (__out ↦ _)
 bsl::ostream& OptionType::print(bsl::ostream&    stream,
                                 OptionType::Enum value,
                                 int              level,

--- a/groups/bal/balcl/balcl_typeinfo.cpp
+++ b/groups/bal/balcl/balcl_typeinfo.cpp
@@ -187,6 +187,7 @@ bsl::ostream& u::operator<<(bsl::ostream& stream, Ordinal position)
 /// for values of the specified `type`.  Return `true` if the parse
 /// succeeds, and `false` otherwise.  Note that on success `value` can be
 /// legitimately cast to a pointer of the type associated with `type`.
+// ensures: (type == OptionType::e_STRING ==> __out == true) && (type != OptionType::e_STRING ==> (__out == true || __out == false))
 bool parseValue(void                    *value,
                 const bsl::string_view&  input,
                 OptionType::Enum         type)
@@ -378,6 +379,7 @@ BoolConstraint::~BoolConstraint()
 // BDE_VERIFY pragma: -FABC01  // not in alphabetic order
 
 // ACCESSORS
+// ensures: __out == OptionType::e_BOOL
 OptionType::Enum BoolConstraint::type() const
 {
     return OptionType::e_BOOL;
@@ -1594,6 +1596,7 @@ TypeInfo::~TypeInfo()
 }
 
 // MANIPULATORS
+// ensures: (__out == *this) && (this != &rhs ==> (d_elemType ↦ rhs.d_elemType ⋆ d_linkedVariable_p ↦ rhs.d_linkedVariable_p ⋆ d_isOptionalLinkedVariable ↦ rhs.d_isOptionalLinkedVariable ⋆ d_constraint_p ↦ rhs.d_constraint_p))
 TypeInfo& TypeInfo::operator=(const TypeInfo& rhs)
 {
     if (this != &rhs) {
@@ -2107,6 +2110,7 @@ void TypeInfo::setLinkedVariable(bsl::optional<bdlt::Time> *variable)
 }
 
 // ACCESSORS
+// ensures: __out == d_constraint_p
 bsl::shared_ptr<TypeInfoConstraint> TypeInfo::constraint() const
 {
     return d_constraint_p;
@@ -2171,6 +2175,7 @@ bsl::ostream& TypeInfo::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.type() == rhs.type() && lhs.linkedVariable() == rhs.linkedVariable() && lhs.constraint() == rhs.constraint())) && (__out == false ==> !(lhs.type() == rhs.type() && lhs.linkedVariable() == rhs.linkedVariable() && lhs.constraint() == rhs.constraint()))
 bool balcl::operator==(const TypeInfo& lhs, const TypeInfo& rhs)
 {
     return lhs.type()           == rhs.type()

--- a/groups/bal/baljsn/baljsn_datumutil.cpp
+++ b/groups/bal/baljsn/baljsn_datumutil.cpp
@@ -63,6 +63,7 @@ int encodeValue(baljsn::SimpleFormatter    *formatter,
 /// Decode into the specified `*result` the JSON object in the specified
 /// `*tokenizer`, updating the specified `*errorStream` if any errors are
 /// detected, including if the specified `maxNestedDepth` is exceeded.
+// ensures: __out == -4 || __out == -1 || __out == -2 || __out == -3 || __out == 0
 int decodeObject(bdld::ManagedDatum *result,
                  bsl::ostream       *errorStream,
                  baljsn::Tokenizer  *tokenizer,
@@ -142,6 +143,7 @@ int decodeObject(bdld::ManagedDatum *result,
 /// Decode into the specified `*result` the JSON array in the specified
 /// `*tokenizer`, updating the specified `*errorStream` if any errors are
 /// detected, including if the specified `maxNestedDepth` is exceeded.
+// ensures: __out == -4 || __out == -1 || __out == -2 || __out == 0
 int decodeArray(bdld::ManagedDatum *result,
                 bsl::ostream       *errorStream,
                 baljsn::Tokenizer  *tokenizer,
@@ -214,6 +216,7 @@ int encodeImp(STRING                             *result,
 
 /// Extract into the specified `*result` the current value in the specified
 /// `*tokenizer`.
+// ensures: (__out == 0 || __out == -1)
 int extractValue(bdld::ManagedDatum *result,
                  baljsn::Tokenizer  *tokenizer)
 {
@@ -305,6 +308,7 @@ int decodeValue(bdld::ManagedDatum *result,
 /// unsupported types or values are encountered.  Optionally specify the
 /// `name` to be used for this array.  Return 0 on success, and a negative
 /// value if `datum` cannot be encoded, which should stop further encoding.
+// ensures: (__out == 0 || __out != 0) && (formatter != 0) && (strictTypesCheckStatus != 0)
 int encodeArray(baljsn::SimpleFormatter    *formatter,
                 const bdld::DatumArrayRef&  datum,
                 int                        *strictTypesCheckStatus,
@@ -475,6 +479,7 @@ namespace baljsn {
                               // ----------------
 
 // CLASS METHODS
+// ensures: __out == 0 || __out == -1 || __out == -2 || __out == -3
 int DatumUtil::decode(bdld::ManagedDatum         *result,
                       bsl::ostream               *errorStream,
                       bsl::streambuf             *jsonBuffer,

--- a/groups/bal/baljsn/baljsn_decoder.cpp
+++ b/groups/bal/baljsn/baljsn_decoder.cpp
@@ -18,6 +18,7 @@ namespace baljsn {
                                // -------------
 
 // PRIVATE MANIPULATORS
+// ensures: __out == d_logStream
 bsl::ostream& Decoder::logTokenizerError(const char *alternateString)
 {
     const int sts = d_tokenizer.readStatus();

--- a/groups/bal/baljsn/baljsn_encoder_testtypes.cpp
+++ b/groups/bal/baljsn/baljsn_encoder_testtypes.cpp
@@ -134,6 +134,7 @@ EncoderTestAddress::~EncoderTestAddress()
 
 // MANIPULATORS
 
+// ensures: (this != &rhs ==> (d_street ↦ rhs.d_street ⋆ d_city ↦ rhs.d_city ⋆ d_state ↦ rhs.d_state)) && (this == &rhs ==> true)
 EncoderTestAddress&
 EncoderTestAddress::operator=(const EncoderTestAddress& rhs)
 {
@@ -266,6 +267,7 @@ EncoderTestChoiceWithAllCategoriesChoice::EncoderTestChoiceWithAllCategoriesChoi
 
 // MANIPULATORS
 
+// ensures: &__out == this && (rhs.d_selectionId == SELECTION_ID_SELECTION0 ==> d_selectionId == SELECTION_ID_SELECTION0) && (rhs.d_selectionId != SELECTION_ID_SELECTION0 ==> d_selectionId == SELECTION_ID_UNDEFINED)
 EncoderTestChoiceWithAllCategoriesChoice&
 EncoderTestChoiceWithAllCategoriesChoice::operator=(const EncoderTestChoiceWithAllCategoriesChoice& rhs)
 {
@@ -316,6 +318,7 @@ void EncoderTestChoiceWithAllCategoriesChoice::reset()
     d_selectionId = SELECTION_ID_UNDEFINED;
 }
 
+// ensures: (__out == 0 && (selectionId == SELECTION_ID_SELECTION0 || selectionId == SELECTION_ID_UNDEFINED)) || (__out == -1 && selectionId != SELECTION_ID_SELECTION0 && selectionId != SELECTION_ID_UNDEFINED)
 int EncoderTestChoiceWithAllCategoriesChoice::makeSelection(int selectionId)
 {
     switch (selectionId) {
@@ -331,6 +334,7 @@ int EncoderTestChoiceWithAllCategoriesChoice::makeSelection(int selectionId)
     return 0;
 }
 
+// ensures: (__out == -1 ==> selectionInfo == 0) && (__out != -1 ==> selectionInfo != 0 && __out == makeSelection(selectionInfo->d_id))
 int EncoderTestChoiceWithAllCategoriesChoice::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -357,6 +361,7 @@ int& EncoderTestChoiceWithAllCategoriesChoice::makeSelection0()
     return d_selection0.object();
 }
 
+// ensures: (d_selectionId == SELECTION_ID_SELECTION0 ==> (d_selection0.object() ↦ value)) && (d_selectionId != SELECTION_ID_SELECTION0 ==> (d_selectionId == SELECTION_ID_SELECTION0 ⋆ d_selection0.object() ↦ value)) && (__out ↦ value)
 int& EncoderTestChoiceWithAllCategoriesChoice::makeSelection0(int value)
 {
     if (SELECTION_ID_SELECTION0 == d_selectionId) {
@@ -393,6 +398,7 @@ bsl::ostream& EncoderTestChoiceWithAllCategoriesChoice::print(
 }
 
 
+// ensures: (d_selectionId == SELECTION_ID_SELECTION0 ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SELECTION0].name()) && (d_selectionId != SELECTION_ID_SELECTION0 ==> __out == "(* UNDEFINED *)")
 const char *EncoderTestChoiceWithAllCategoriesChoice::selectionName() const
 {
     switch (d_selectionId) {
@@ -462,6 +468,7 @@ const bdlat_EnumeratorInfo EncoderTestChoiceWithAllCategoriesEnumeration::ENUMER
 
 // CLASS METHODS
 
+// ensures: (__out == 0 ==> ((*result ↦ static_cast<EncoderTestChoiceWithAllCategoriesEnumeration::Value>(number)) && (number == EncoderTestChoiceWithAllCategoriesEnumeration::A || number == EncoderTestChoiceWithAllCategoriesEnumeration::B))) && (__out == -1 ==> true)
 int EncoderTestChoiceWithAllCategoriesEnumeration::fromInt(EncoderTestChoiceWithAllCategoriesEnumeration::Value *result, int number)
 {
     switch (number) {
@@ -494,6 +501,7 @@ int EncoderTestChoiceWithAllCategoriesEnumeration::fromString(
     return -1;
 }
 
+// ensures: (value == A ==> __out == "A") && (value == B ==> __out == "B") && (value != A && value != B ==> __out == 0)
 const char *EncoderTestChoiceWithAllCategoriesEnumeration::toString(EncoderTestChoiceWithAllCategoriesEnumeration::Value value)
 {
     switch (value) {
@@ -717,6 +725,7 @@ EncoderTestSequenceWithAllCategoriesChoice::EncoderTestSequenceWithAllCategories
 
 // MANIPULATORS
 
+// ensures: (this != &rhs) ==> ((rhs.d_selectionId == SELECTION_ID_SELECTION0) ==> (d_selectionId == SELECTION_ID_SELECTION0 ⋆ d_selection0.object() ↦ rhs.d_selection0.object()) ⋆ (rhs.d_selectionId == SELECTION_ID_UNDEFINED) ==> (d_selectionId == SELECTION_ID_UNDEFINED && d_selection0.object() ↦ _))
 EncoderTestSequenceWithAllCategoriesChoice&
 EncoderTestSequenceWithAllCategoriesChoice::operator=(const EncoderTestSequenceWithAllCategoriesChoice& rhs)
 {
@@ -767,6 +776,7 @@ void EncoderTestSequenceWithAllCategoriesChoice::reset()
     d_selectionId = SELECTION_ID_UNDEFINED;
 }
 
+// ensures: (__out == 0 && (selectionId == SELECTION_ID_SELECTION0 || selectionId == SELECTION_ID_UNDEFINED)) || (__out == -1 && selectionId != SELECTION_ID_SELECTION0 && selectionId != SELECTION_ID_UNDEFINED)
 int EncoderTestSequenceWithAllCategoriesChoice::makeSelection(int selectionId)
 {
     switch (selectionId) {
@@ -782,6 +792,7 @@ int EncoderTestSequenceWithAllCategoriesChoice::makeSelection(int selectionId)
     return 0;
 }
 
+// ensures: (__out == -1 ==> selectionInfo == 0) && (__out != -1 ==> selectionInfo != 0 && __out == makeSelection(selectionInfo->d_id))
 int EncoderTestSequenceWithAllCategoriesChoice::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -844,6 +855,7 @@ bsl::ostream& EncoderTestSequenceWithAllCategoriesChoice::print(
 }
 
 
+// ensures: (d_selectionId == SELECTION_ID_SELECTION0 ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SELECTION0].name()) && (d_selectionId == SELECTION_ID_UNDEFINED ==> __out == "(* UNDEFINED *)")
 const char *EncoderTestSequenceWithAllCategoriesChoice::selectionName() const
 {
     switch (d_selectionId) {
@@ -913,6 +925,7 @@ const bdlat_EnumeratorInfo EncoderTestSequenceWithAllCategoriesEnumeration::ENUM
 
 // CLASS METHODS
 
+// ensures: (__out == 0 ==> ((*result ↦ static_cast<EncoderTestSequenceWithAllCategoriesEnumeration::Value>(number)) && (number == EncoderTestSequenceWithAllCategoriesEnumeration::A || number == EncoderTestSequenceWithAllCategoriesEnumeration::B))) && (__out == -1 ==> (number != EncoderTestSequenceWithAllCategoriesEnumeration::A && number != EncoderTestSequenceWithAllCategoriesEnumeration::B))
 int EncoderTestSequenceWithAllCategoriesEnumeration::fromInt(EncoderTestSequenceWithAllCategoriesEnumeration::Value *result, int number)
 {
     switch (number) {
@@ -925,6 +938,7 @@ int EncoderTestSequenceWithAllCategoriesEnumeration::fromInt(EncoderTestSequence
     }
 }
 
+// ensures: (__out == 0 ==> SEPEXISTS(0, 2, i, (stringLength == EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength && 0 == bsl::memcmp(EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength) && (*result ↦ static_cast<EncoderTestSequenceWithAllCategoriesEnumeration::Value>(EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_value))))) && (__out == -1 ==> *result ↦ old_result)
 int EncoderTestSequenceWithAllCategoriesEnumeration::fromString(
         EncoderTestSequenceWithAllCategoriesEnumeration::Value *result,
         const char         *string,
@@ -945,6 +959,7 @@ int EncoderTestSequenceWithAllCategoriesEnumeration::fromString(
     return -1;
 }
 
+// ensures: (value == A ==> __out == "A") && (value == B ==> __out == "B") && (value != A && value != B ==> __out == 0)
 const char *EncoderTestSequenceWithAllCategoriesEnumeration::toString(EncoderTestSequenceWithAllCategoriesEnumeration::Value value)
 {
     switch (value) {
@@ -2385,6 +2400,7 @@ EncoderTestChoiceWithAllCategories::EncoderTestChoiceWithAllCategories(
 
 // MANIPULATORS
 
+// ensures: &__out == this
 EncoderTestChoiceWithAllCategories&
 EncoderTestChoiceWithAllCategories::operator=(const EncoderTestChoiceWithAllCategories& rhs)
 {
@@ -2482,6 +2498,7 @@ void EncoderTestChoiceWithAllCategories::reset()
     d_selectionId = SELECTION_ID_UNDEFINED;
 }
 
+// ensures: (__out == 0) || (__out == -1 && selectionId != SELECTION_ID_CHAR_ARRAY && selectionId != SELECTION_ID_CHOICE && selectionId != SELECTION_ID_CUSTOMIZED_TYPE && selectionId != SELECTION_ID_ENUMERATION && selectionId != SELECTION_ID_SEQUENCE && selectionId != SELECTION_ID_SIMPLE && selectionId != SELECTION_ID_UNDEFINED)
 int EncoderTestChoiceWithAllCategories::makeSelection(int selectionId)
 {
     switch (selectionId) {
@@ -2512,6 +2529,7 @@ int EncoderTestChoiceWithAllCategories::makeSelection(int selectionId)
     return 0;
 }
 
+// ensures: (selectionInfo == 0 ==> __out == -1) && (selectionInfo != 0 ==> __out == makeSelection(selectionInfo->d_id))
 int EncoderTestChoiceWithAllCategories::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -2682,6 +2700,7 @@ EncoderTestChoiceWithAllCategoriesEnumeration::Value& EncoderTestChoiceWithAllCa
     return d_enumeration.object();
 }
 
+// ensures: (d_selectionId == SELECTION_ID_ENUMERATION) && (d_enumeration.object() == value)
 EncoderTestChoiceWithAllCategoriesEnumeration::Value& EncoderTestChoiceWithAllCategories::makeEnumeration(EncoderTestChoiceWithAllCategoriesEnumeration::Value value)
 {
     if (SELECTION_ID_ENUMERATION == d_selectionId) {
@@ -2760,6 +2779,7 @@ int& EncoderTestChoiceWithAllCategories::makeSimple()
     return d_simple.object();
 }
 
+// ensures: d_selectionId == SELECTION_ID_SIMPLE && (__out ↦ value)
 int& EncoderTestChoiceWithAllCategories::makeSimple(int value)
 {
     if (SELECTION_ID_SIMPLE == d_selectionId) {
@@ -2920,6 +2940,7 @@ EncoderTestDegenerateChoice1::EncoderTestDegenerateChoice1(EncoderTestDegenerate
 
 // MANIPULATORS
 
+// ensures: (this != &rhs ==> ((d_selectionId == SELECTION_ID_SEQUENCE && d_sequence.object() == rhs.d_sequence.object()) ⋆ (d_selectionId == SELECTION_ID_UNDEFINED ==> __out == *this))) && (this == &rhs ==> true)
 EncoderTestDegenerateChoice1&
 EncoderTestDegenerateChoice1::operator=(const EncoderTestDegenerateChoice1& rhs)
 {
@@ -2970,6 +2991,7 @@ void EncoderTestDegenerateChoice1::reset()
     d_selectionId = SELECTION_ID_UNDEFINED;
 }
 
+// ensures: (__out == 0 ==> (selectionId == SELECTION_ID_SEQUENCE || selectionId == SELECTION_ID_UNDEFINED)) && (__out == -1 ==> (selectionId != SELECTION_ID_SEQUENCE && selectionId != SELECTION_ID_UNDEFINED))
 int EncoderTestDegenerateChoice1::makeSelection(int selectionId)
 {
     switch (selectionId) {
@@ -2985,6 +3007,7 @@ int EncoderTestDegenerateChoice1::makeSelection(int selectionId)
     return 0;
 }
 
+// ensures: (__out == -1 ==> selectionInfo == 0) && (__out != -1 ==> selectionInfo != 0)
 int EncoderTestDegenerateChoice1::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -3065,6 +3088,7 @@ bsl::ostream& EncoderTestDegenerateChoice1::print(
 }
 
 
+// ensures: (d_selectionId == SELECTION_ID_SEQUENCE ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SEQUENCE].name()) && (d_selectionId != SELECTION_ID_SEQUENCE ==> __out == "(* UNDEFINED *)")
 const char *EncoderTestDegenerateChoice1::selectionName() const
 {
     switch (d_selectionId) {
@@ -3183,6 +3207,7 @@ EncoderTestEmployee::~EncoderTestEmployee()
 
 // MANIPULATORS
 
+// ensures: (this != &rhs ==> (d_name ↦ rhs.d_name ⋆ d_homeAddress ↦ rhs.d_homeAddress ⋆ d_age ↦ rhs.d_age)) && (this == &rhs ==> true)
 EncoderTestEmployee&
 EncoderTestEmployee::operator=(const EncoderTestEmployee& rhs)
 {
@@ -3421,6 +3446,7 @@ EncoderTestSequenceWithAllCategories::~EncoderTestSequenceWithAllCategories()
 
 // MANIPULATORS
 
+// ensures: (this != &rhs ==> (d_charArray ↦ rhs.d_charArray ⋆ d_aString ↦ rhs.d_aString ⋆ d_array ↦ rhs.d_array ⋆ d_choice ↦ rhs.d_choice ⋆ d_customizedType ↦ rhs.d_customizedType ⋆ d_enumeration ↦ rhs.d_enumeration ⋆ d_nullableValue ↦ rhs.d_nullableValue ⋆ d_sequence ↦ rhs.d_sequence ⋆ d_simple ↦ rhs.d_simple)) && (this == &rhs)
 EncoderTestSequenceWithAllCategories&
 EncoderTestSequenceWithAllCategories::operator=(const EncoderTestSequenceWithAllCategories& rhs)
 {

--- a/groups/bal/baljsn/baljsn_parserutil.cpp
+++ b/groups/bal/baljsn/baljsn_parserutil.cpp
@@ -147,6 +147,7 @@ namespace baljsn {
                              // -----------------
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> (value != 0 ⋆ *value ↦ _)) && (__out != 0 ==> true)
 int ParserUtil::getUnquotedString(bsl::string             *value,
                                   const bsl::string_view&  data)
 {

--- a/groups/bal/ball/ball_administration.cpp
+++ b/groups/bal/ball/ball_administration.cpp
@@ -18,6 +18,7 @@ namespace ball {
                       // ---------------------
 
 // CLASS METHODS
+// ensures: (__out == 0) || (__out != 0)
 int Administration::addCategory(const char *categoryName,
                                 int         recordLevel,
                                 int         passLevel,

--- a/groups/bal/ball/ball_asyncfileobserver.cpp
+++ b/groups/bal/ball/ball_asyncfileobserver.cpp
@@ -144,6 +144,7 @@ AsyncFileObserver_Record createStopRecord()
 /// Return `true` if the specified `record` was created by
 /// `createStopRecord` and `false` otherwise.  Note that this record is used
 /// by `stopThread` to signal to the publication thread to stop.
+// ensures: (__out == true ==> (record.d_record.get() == 0)) && (__out == false ==> (record.d_record.get() != 0))
 bool isStopRecord(const AsyncFileObserver_Record& record)
 {
     return 0 == record.d_record.get();

--- a/groups/bal/ball/ball_attribute.cpp
+++ b/groups/bal/ball/ball_attribute.cpp
@@ -53,6 +53,7 @@ namespace ball {
                         // ---------------
 
 // CLASS METHODS
+// ensures: (attribute.d_hashValue < 0 || attribute.d_hashSize != size) ==> (__out == attribute.d_hashValue % size && attribute.d_hashValue == __out && attribute.d_hashSize == size) && (0 <= __out && __out < size)
 int Attribute::hash(const Attribute& attribute, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -71,6 +72,7 @@ int Attribute::hash(const Attribute& attribute, int size)
 }
 
 // ACCESSORS
+// ensures: __out == stream
 bsl::ostream& Attribute::print(bsl::ostream& stream,
                                int           level,
                                int           spacesPerLevel) const
@@ -107,6 +109,7 @@ bsl::ostream& Attribute::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == output
 bsl::ostream& ball::operator<<(bsl::ostream&    output,
                                const Attribute& attribute)
 {

--- a/groups/bal/ball/ball_attributecollectorregistry.cpp
+++ b/groups/bal/ball/ball_attributecollectorregistry.cpp
@@ -15,6 +15,7 @@ namespace ball {
                          // --------------------------------
 
 // MANIPULATORS
+// ensures: (__out == 0 || __out == 1)
 int AttributeCollectorRegistry::addCollector(const Collector&        collector,
                                              const bsl::string_view& name)
 {

--- a/groups/bal/ball/ball_attributecontainerlist.cpp
+++ b/groups/bal/ball/ball_attributecontainerlist.cpp
@@ -44,6 +44,7 @@ AttributeContainerList::AttributeContainerList(
 }
 
 // MANIPULATORS
+// ensures: &__out == this && __out == rhs
 AttributeContainerList& AttributeContainerList::operator=(
                                              const AttributeContainerList& rhs)
 {
@@ -189,6 +190,7 @@ AttributeContainerList::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.numContainers() == rhs.numContainers() && SEPFORALL(0, lhs.numContainers(), i, (*lhs.begin()[i] == *rhs.begin()[i])))) && (__out == false ==> (lhs.numContainers() != rhs.numContainers() || SEPEXISTS(0, lhs.numContainers(), i, (*lhs.begin()[i] != *rhs.begin()[i]))))
 bool ball::operator==(const AttributeContainerList& lhs,
                       const AttributeContainerList& rhs)
 {

--- a/groups/bal/ball/ball_attributecontext.cpp
+++ b/groups/bal/ball/ball_attributecontext.cpp
@@ -65,6 +65,7 @@ namespace ball {
                // ------------------------------------------
 
 // MANIPULATORS
+// ensures: (d_sequenceNumber ↦ sequenceNumber) ⋆ (__out == d_resultMask) ⋆ (SEPFORALL(0, RuleSet::e_MAX_NUM_RULES, i, ((~d_evalMask & relevantRulesMask) & (1 << i)) == 0 || (d_evalMask & (1 << i)) != 0))
 RuleSet::MaskType
 AttributeContext_RuleEvaluationCache::update(
                                bsls::Types::Int64            sequenceNumber,
@@ -106,6 +107,7 @@ AttributeContext_RuleEvaluationCache::update(
 }
 
 // ACCESSORS
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream&
 AttributeContext_RuleEvaluationCache::print(bsl::ostream& stream,
                                             int           level,
@@ -183,6 +185,7 @@ AttributeContext::~AttributeContext()
 }
 
 // PRIVATE CLASS METHODS
+// ensures: __out == &s_contextKey
 const bslmt::ThreadUtil::Key& AttributeContext::contextKey()
 {
     static bslmt::ThreadUtil::Key s_contextKey;
@@ -213,6 +216,7 @@ void AttributeContext::removeContext(void *arg)
 }
 
 // CLASS METHODS
+// ensures: __out != 0
 AttributeContext *AttributeContext::getContext()
 {
 #ifdef BSLMT_THREAD_LOCAL_VARIABLE
@@ -422,6 +426,7 @@ AttributeContext::determineThresholdLevels(ThresholdAggregate *levels,
 }
 
 // ACCESSORS
+// ensures: (__out == stream) && (__out ↦ _)
 bsl::ostream& AttributeContext::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const

--- a/groups/bal/ball/ball_broadcastobserver.cpp
+++ b/groups/bal/ball/ball_broadcastobserver.cpp
@@ -26,6 +26,7 @@ BroadcastObserver::~BroadcastObserver()
 }
 
 // MANIPULATORS
+// ensures: (__out == 1 ==> !(d_observers.find(observerName) != d_observers.end())) && (__out == 0 ==> (d_observers.find(observerName) == d_observers.end()))
 int BroadcastObserver::deregisterObserver(const bsl::string_view& observerName)
 {
     bslmt::WriteLockGuard<bslmt::ReaderWriterMutex> guard(&d_rwMutex);
@@ -109,6 +110,7 @@ void BroadcastObserver::releaseRecords()
 }
 
 // ACCESSORS
+// ensures: (__out.use_count() == 0) ==> (__out.get() == nullptr) && (__out.use_count() > 0) ==> (__out.get() != nullptr)
 bsl::shared_ptr<const Observer>
 BroadcastObserver::findObserver(const bsl::string_view& observerName) const
 {

--- a/groups/bal/ball/ball_category.cpp
+++ b/groups/bal/ball/ball_category.cpp
@@ -105,6 +105,7 @@ void Category::updateThresholdForHolders()
 }
 
 // MANIPULATORS
+// ensures: (__out == 0 ==> Category::areValidThresholdLevels(recordLevel, passLevel, triggerLevel, triggerAllLevel)) && (__out == -1 ==> !Category::areValidThresholdLevels(recordLevel, passLevel, triggerLevel, triggerAllLevel))
 int Category::setLevels(int recordLevel,
                         int passLevel,
                         int triggerLevel,

--- a/groups/bal/ball/ball_categorymanager.cpp
+++ b/groups/bal/ball/ball_categorymanager.cpp
@@ -147,6 +147,7 @@ void CategoryProctor::release()
                     // ---------------------
 
 // PRIVATE MANIPULATORS
+// ensures: __out != NULL
 Category *CategoryManager::addNewCategory(const char *categoryName,
                                           int         recordLevel,
                                           int         passLevel,
@@ -491,6 +492,7 @@ void CategoryManager::removeAllRules()
 // BDE_VERIFY pragma: pop
 
 // ACCESSORS
+// ensures: (__out == 0 ==> !(d_registry.find(categoryName) != d_registry.end())) && (__out != 0 ==> (d_registry.find(categoryName) != d_registry.end() && __out == d_categories[d_registry.find(categoryName)->second]))
 const Category *CategoryManager::lookupCategory(const char *categoryName) const
 {
     bslmt::ReadLockGuard<bslmt::ReaderWriterLock> registryGuard(

--- a/groups/bal/ball/ball_context.cpp
+++ b/groups/bal/ball/ball_context.cpp
@@ -16,6 +16,7 @@ namespace ball {
                         // -------------
 
 // CLASS METHODS
+// ensures: (transmissionCause == Transmission::e_PASSTHROUGH && __out == (recordIndex == 0 && sequenceLength == 1)) || (transmissionCause != Transmission::e_PASSTHROUGH && (__out == (0 <= recordIndex && 1 <= sequenceLength && recordIndex < sequenceLength) || __out == false))
 bool Context::isValid(Transmission::Cause transmissionCause,
                       int                 recordIndex,
                       int                 sequenceLength)
@@ -42,6 +43,7 @@ bool Context::isValid(Transmission::Cause transmissionCause,
 }
 
 // ACCESSORS
+// ensures: __out == &stream
 bsl::ostream& Context::print(bsl::ostream& stream,
                              int           level,
                              int           spacesPerLevel) const

--- a/groups/bal/ball/ball_defaultattributecontainer.cpp
+++ b/groups/bal/ball/ball_defaultattributecontainer.cpp
@@ -21,6 +21,7 @@ int DefaultAttributeContainer::AttributeHash::s_hashtableSize = INT_MAX;
 int DefaultAttributeContainer::s_initialSize = 8;
 
 // MANIPULATORS
+// ensures: (this != &rhs) ==> (__out == *this)
 DefaultAttributeContainer&
 DefaultAttributeContainer::operator=(const DefaultAttributeContainer& rhs)
 {
@@ -36,6 +37,7 @@ DefaultAttributeContainer::operator=(const DefaultAttributeContainer& rhs)
 }
 
 // ACCESSORS
+// ensures: (__out == true ==> d_attributeSet.find(value) != d_attributeSet.end()) && (__out == false ==> d_attributeSet.find(value) == d_attributeSet.end())
 bool DefaultAttributeContainer::hasValue(const Attribute& value) const
 {
     return d_attributeSet.find(value) != d_attributeSet.end();
@@ -66,6 +68,7 @@ void DefaultAttributeContainer::visitAttributes(
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (lhs.numAttributes() != rhs.numAttributes() ==> __out == false) && (lhs.numAttributes() == rhs.numAttributes() && std::equal(lhs.begin(), lhs.end(), rhs.begin()) ==> __out == true)
 bool ball::operator==(const DefaultAttributeContainer& lhs,
                       const DefaultAttributeContainer& rhs)
 {

--- a/groups/bal/ball/ball_fileobserver.cpp
+++ b/groups/bal/ball/ball_fileobserver.cpp
@@ -257,6 +257,7 @@ void FileObserver::setStdoutThreshold(Severity::Level stdoutThreshold)
 }
 
 // ACCESSORS
+// ensures: __out != 0
 bslma::Allocator *FileObserver::allocator() const
 {
     return d_stdoutLongFormat.get_allocator().mechanism();

--- a/groups/bal/ball/ball_fileobserver2.cpp
+++ b/groups/bal/ball/ball_fileobserver2.cpp
@@ -110,6 +110,7 @@ enum {
 };
 
 /// Return the system-specific error code.
+// ensures: __out >= 0
 static int getErrorCode(void)
 {
 #ifdef BSLS_PLATFORM_OS_WINDOWS
@@ -121,6 +122,7 @@ static int getErrorCode(void)
 }
 
 /// Return the specified `timestamp` in the `YYYYMMDD_hhmmss` format.
+// ensures: __out == bsl::string(buffer)
 static bsl::string getTimestampSuffix(const bdlt::Datetime& timestamp)
 {
     char buffer[16];
@@ -219,6 +221,7 @@ static void getLogFileName(bsl::string    *logFileName,
 /// Return `true` if the specified `logFilePattern` contains a recognized
 /// `%`-escape sequence, and false otherwise.  The recognized escape
 /// sequence are "%Y", "%M", "%D", "%h", "%m", "%s", and "%%".
+// ensures: (EXISTS(0, strlen(logFilePattern), i, (logFilePattern[i] == '%' && (logFilePattern[i+1] == 'Y' || logFilePattern[i+1] == 'M' || logFilePattern[i+1] == 'D' || logFilePattern[i+1] == 'h' || logFilePattern[i+1] == 'm' || logFilePattern[i+1] == 's' || logFilePattern[i+1] == '%'))) ==> __out == true) && (FORALL(0, strlen(logFilePattern), i, (i+1 < strlen(logFilePattern)) ==> !(logFilePattern[i] == '%' && (logFilePattern[i+1] == 'Y' || logFilePattern[i+1] == 'M' || logFilePattern[i+1] == 'D' || logFilePattern[i+1] == 'h' || logFilePattern[i+1] == 'm' || logFilePattern[i+1] == 's' || logFilePattern[i+1] == '%'))) ==> __out == false)
 static bool hasEscapePattern(const char *logFilePattern)
 
 {
@@ -248,6 +251,7 @@ static bool hasEscapePattern(const char *logFilePattern)
 /// Open a file stream referred to by the specified `stream` for the file
 /// with the specified `filename` in append mode.  Return 0 on success, and
 /// a non-zero value otherwise.
+// ensures: (__out == 0) || (__out == -1)
 static int openLogFile(bsl::ostream *stream, const char *filename)
 {
     BSLS_ASSERT(stream);
@@ -312,6 +316,7 @@ static int openLogFile(bsl::ostream *stream, const char *filename)
 /// Return `true` if the specified `a` and `b` times are within 10% of the
 /// specified `interval` from each other, and `false` otherwise.  The
 /// behavior is undefined unless `0 <= interval.totalMilliseconds()`.
+// ensures: (__out == true ==> (abs((a - b).totalMilliseconds()) < (interval.totalMilliseconds() / 10))) && (__out == false ==> (abs((a - b).totalMilliseconds()) >= (interval.totalMilliseconds() / 10)))
 bool fuzzyEqual(const bdlt::Datetime&         a,
                 const bdlt::Datetime&         b,
                 const bdlt::DatetimeInterval& interval)
@@ -847,6 +852,7 @@ void FileObserver2::setOnFileRotationCallback(
 }
 
 // ACCESSORS
+// ensures: __out == d_logStreamBuf.isOpened()
 bool FileObserver2::isFileLoggingEnabled() const
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);

--- a/groups/bal/ball/ball_loggercategoryutil.cpp
+++ b/groups/bal/ball/ball_loggercategoryutil.cpp
@@ -71,6 +71,7 @@ static void accumulateLongerPrefixCategory(const Category **result,
                             // -------------------------
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> (loggerManager->lookupCategory(categoryName) != 0 || (loggerManager->thresholdLevelsForNewCategory(nullptr, categoryName) != 0))) && (__out != 0 ==> true)
 Category *LoggerCategoryUtil::addCategoryHierarchically(
                                                   LoggerManager *loggerManager,
                                                   const char    *categoryName)

--- a/groups/bal/ball/ball_loggermanager.cpp
+++ b/groups/bal/ball/ball_loggermanager.cpp
@@ -234,6 +234,7 @@ void bufferPoolDeleter(void *buffer, void *pool)
 /// result in the specified `filteredNameBuffer`, and return the address of
 /// the non-modifiable data of `filteredNameBuffer`; return `originalName`
 /// otherwise (i.e., if `nameFilter` is null).
+// ensures: (nameFilter != nullptr ==> __out == filteredNameBuffer->c_str()) && (nameFilter == nullptr ==> __out == originalName)
 const char *filterName(
    bsl::string                                             *filteredNameBuffer,
    const char                                              *originalName,
@@ -434,6 +435,7 @@ Logger::~Logger()
 }
 
 // PRIVATE MANIPULATORS
+// ensures: __out != nullptr
 bsl::shared_ptr<Record> Logger::getRecordPtr(const char *fileName,
                                              int         lineNumber)
 {
@@ -602,6 +604,7 @@ void Logger::publish(const bsl::shared_ptr<Record>& record,
 }
 
 // MANIPULATORS
+// ensures: __out != 0 && (__out ↦ _)
 Record *Logger::getRecord(const char *fileName, int lineNumber)
 {
    // The shared pointer returned by 'getRecordPtr' is reconstituted in the
@@ -1605,6 +1608,7 @@ void LoggerManager::setDefaultThresholdLevelsCallback(
 }
 
 // ACCESSORS
+// ensures: (__out == true ==> (category->relevantRuleMask() && category->maxLevel() >= severity) || (!category->relevantRuleMask() && category->maxLevel() >= severity)) && (__out == false ==> (category->relevantRuleMask() && category->maxLevel() < severity) || (!category->relevantRuleMask() && category->maxLevel() < severity))
 bool LoggerManager::isCategoryEnabled(const Category *category,
                                       int             severity) const
 {

--- a/groups/bal/ball/ball_loggermanagerconfiguration.cpp
+++ b/groups/bal/ball/ball_loggermanagerconfiguration.cpp
@@ -84,6 +84,7 @@ LoggerManagerConfiguration::LoggerManagerConfiguration(
 }
 
 // MANIPULATORS
+// ensures: __out == *this
 LoggerManagerConfiguration&
 LoggerManagerConfiguration::operator=(const LoggerManagerConfiguration& rhs)
 {
@@ -160,6 +161,7 @@ void LoggerManagerConfiguration::setTriggerMarkers(TriggerMarkers value)
 }
 
 // ACCESSORS
+// ensures: __out == d_defaults
 const LoggerManagerDefaults& LoggerManagerConfiguration::defaults() const
 {
     return d_defaults;
@@ -281,6 +283,7 @@ LoggerManagerConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == (lhs.d_defaults == rhs.d_defaults && (bool)lhs.d_userPopulator == (bool)rhs.d_userPopulator && (bool)lhs.d_categoryNameFilter == (bool)rhs.d_categoryNameFilter && (bool)lhs.d_defaultThresholdsCb == (bool)rhs.d_defaultThresholdsCb && lhs.d_logOrder == rhs.d_logOrder && lhs.d_triggerMarkers == rhs.d_triggerMarkers)
 bool ball::operator==(const ball::LoggerManagerConfiguration& lhs,
                       const ball::LoggerManagerConfiguration& rhs)
 {   // TBD: Note that we are casting the three 'bsl::function' data members to

--- a/groups/bal/ball/ball_loggermanagerdefaults.cpp
+++ b/groups/bal/ball/ball_loggermanagerdefaults.cpp
@@ -30,6 +30,7 @@ namespace ball {
                          // ---------------------------
 
 // CLASS METHODS
+// ensures: (__out == true ==> numBytes > 0) && (__out == false ==> numBytes <= 0)
 bool LoggerManagerDefaults::isValidDefaultRecordBufferSize(int numBytes)
 {
     return 0 < numBytes;
@@ -119,6 +120,7 @@ LoggerManagerDefaults::~LoggerManagerDefaults()
 }
 
 // MANIPULATORS
+// ensures: __out == *this ⋆ d_recordBufferSize ↦ rhs.d_recordBufferSize ⋆ d_loggerBufferSize ↦ rhs.d_loggerBufferSize ⋆ d_defaultRecordLevel ↦ rhs.d_defaultRecordLevel ⋆ d_defaultPassLevel ↦ rhs.d_defaultPassLevel ⋆ d_defaultTriggerLevel ↦ rhs.d_defaultTriggerLevel ⋆ d_defaultTriggerAllLevel ↦ rhs.d_defaultTriggerAllLevel
 LoggerManagerDefaults& LoggerManagerDefaults::operator=(
                                               const LoggerManagerDefaults& rhs)
 {
@@ -182,6 +184,7 @@ int LoggerManagerDefaults::setDefaultThresholdLevelsIfValid(
 }
 
 // ACCESSORS
+// ensures: __out == d_recordBufferSize
 int LoggerManagerDefaults::defaultRecordBufferSize() const
 {
     return d_recordBufferSize;
@@ -255,6 +258,7 @@ LoggerManagerDefaults::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.d_recordBufferSize == rhs.d_recordBufferSize ⋆ lhs.d_loggerBufferSize == rhs.d_loggerBufferSize ⋆ lhs.d_defaultRecordLevel == rhs.d_defaultRecordLevel ⋆ lhs.d_defaultPassLevel == rhs.d_defaultPassLevel ⋆ lhs.d_defaultTriggerLevel == rhs.d_defaultTriggerLevel ⋆ lhs.d_defaultTriggerAllLevel == rhs.d_defaultTriggerAllLevel)) && (__out == false ==> (lhs.d_recordBufferSize != rhs.d_recordBufferSize || lhs.d_loggerBufferSize != rhs.d_loggerBufferSize || lhs.d_defaultRecordLevel != rhs.d_defaultRecordLevel || lhs.d_defaultPassLevel != rhs.d_defaultPassLevel || lhs.d_defaultTriggerLevel != rhs.d_defaultTriggerLevel || lhs.d_defaultTriggerAllLevel != rhs.d_defaultTriggerAllLevel))
 bool ball::operator==(const LoggerManagerDefaults& lhs,
                       const LoggerManagerDefaults& rhs)
 {

--- a/groups/bal/ball/ball_managedattribute.cpp
+++ b/groups/bal/ball/ball_managedattribute.cpp
@@ -16,6 +16,7 @@ namespace ball {
                         // ----------------------
 
 // ACCESSORS
+// ensures: __out == stream ⋆ d_attribute.print(stream, level, spacesPerLevel)
 bsl::ostream& ManagedAttribute::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const
@@ -27,6 +28,7 @@ bsl::ostream& ManagedAttribute::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == output
 bsl::ostream& ball::operator<<(bsl::ostream&                 output,
                                const ball::ManagedAttribute& attribute)
 {

--- a/groups/bal/ball/ball_managedattributeset.cpp
+++ b/groups/bal/ball/ball_managedattributeset.cpp
@@ -27,6 +27,7 @@ int ManagedAttributeSet::AttributeHash::s_hashtableSize = INT_MAX;
 int ManagedAttributeSet::s_initialSize = 8;
 
 // CLASS METHODS
+// ensures: __out == (hashValue % size)
 int ManagedAttributeSet::hash(const ManagedAttributeSet& set, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -40,6 +41,7 @@ int ManagedAttributeSet::hash(const ManagedAttributeSet& set, int size)
 }
 
 // MANIPULATORS
+// ensures: (this != &rhs ==> d_attributeSet ↦ rhs.d_attributeSet) && (__out == *this)
 ManagedAttributeSet&
 ManagedAttributeSet::operator=(const ManagedAttributeSet& rhs)
 {
@@ -79,6 +81,7 @@ ManagedAttributeSet::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (lhs.numAttributes() != rhs.numAttributes() ==> __out == false) && (lhs.numAttributes() == rhs.numAttributes() && FORALL(0, lhs.numAttributes(), i, rhs.isMember(*(lhs.begin() + i))) ==> __out == true)
 bool ball::operator==(const ManagedAttributeSet& lhs,
                       const ManagedAttributeSet& rhs)
 {

--- a/groups/bal/ball/ball_patternutil.cpp
+++ b/groups/bal/ball/ball_patternutil.cpp
@@ -41,6 +41,7 @@ namespace ball {
                         // ------------------
 
 // CLASS METHODS
+// ensures: (__out == true || __out == false)
 bool PatternUtil::isValidPattern(const char *pattern)
 {
     while (*pattern) {

--- a/groups/bal/ball/ball_record.cpp
+++ b/groups/bal/ball/ball_record.cpp
@@ -23,6 +23,7 @@ namespace ball {
                            // ------------
 
 // ACCESSORS
+// ensures: __out == stream
 bsl::ostream& Record::print(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel) const

--- a/groups/bal/ball/ball_recordattributes.cpp
+++ b/groups/bal/ball/ball_recordattributes.cpp
@@ -103,6 +103,7 @@ RecordAttributes& RecordAttributes::operator=(const RecordAttributes& rhs)
 }
 
 // ACCESSORS
+// ensures: *__out != '\0' || __out[0] == '\0'
 const char *RecordAttributes::message() const
 {
     const bsl::size_t length = d_messageStreamBuf.length();
@@ -254,6 +255,7 @@ bsl::ostream& RecordAttributes::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.d_timestamp == rhs.d_timestamp && lhs.d_processID == rhs.d_processID && lhs.d_threadID == rhs.d_threadID && lhs.d_severity == rhs.d_severity && lhs.d_lineNumber == rhs.d_lineNumber && lhs.d_fileName == rhs.d_fileName && lhs.d_category == rhs.d_category && lhs.messageRef() == rhs.messageRef())) && (__out == false ==> !(lhs.d_timestamp == rhs.d_timestamp && lhs.d_processID == rhs.d_processID && lhs.d_threadID == rhs.d_threadID && lhs.d_severity == rhs.d_severity && lhs.d_lineNumber == rhs.d_lineNumber && lhs.d_fileName == rhs.d_fileName && lhs.d_category == rhs.d_category && lhs.messageRef() == rhs.messageRef()))
 bool ball::operator==(const RecordAttributes& lhs, const RecordAttributes& rhs)
 {
     return lhs.d_timestamp  == rhs.d_timestamp

--- a/groups/bal/ball/ball_recordjsonformatter.cpp
+++ b/groups/bal/ball/ball_recordjsonformatter.cpp
@@ -1137,6 +1137,7 @@ int ThreadIdFormatter::parse(bdld::DatumMapRef v)
                    // -------------------------
 
 // MANIPULATORS
+// ensures: (__out == -1 ==> EXISTS(0, v.size(), i, !v[i].value().isString())) && (__out == 0 ==> FORALL(0, v.size(), i, v[i].value().isString()))
 int FixedFieldFormatter::parse(bdld::DatumMapRef v)
 {
     for (bdld::Datum::SizeType i = 0; i < v.size(); ++ i) {
@@ -1151,6 +1152,7 @@ int FixedFieldFormatter::parse(bdld::DatumMapRef v)
 }
 
 // ACCESSORS
+// ensures: __out ↦ d_name
 inline
 const bsl::string& FixedFieldFormatter::name() const
 {
@@ -1354,6 +1356,7 @@ int AttributeFormatter::parse(bdld::DatumMapRef v)
 }
 
 // ACCESSORS
+// ensures: __out ↦ d_key
 const bsl::string& AttributeFormatter::key() const
 {
     return d_key;
@@ -1422,6 +1425,7 @@ int AttributesFormatter::parse(bdld::DatumMapRef v)
                        // -----------------
 
 // CLASS METHODS
+// ensures: __out != 0
 RecordJsonFormatter_FieldFormatter *
 DatumParser::make(const bslstl::StringRef& v)
 {
@@ -1614,6 +1618,7 @@ RecordJsonFormatter::~RecordJsonFormatter()
 }
 
 // MANIPULATORS
+// ensures: (__out == -1 ==> format.empty()) && (__out != -1 ==> (__out == 0 ==> (d_formatSpec ↦ format ⋆ d_fieldFormatters ↦ _)) && (__out != 0 ==> true))
 int RecordJsonFormatter::setFormat(const bsl::string_view& format)
 {
     if (format.empty()) {

--- a/groups/bal/ball/ball_recordstringformatter.cpp
+++ b/groups/bal/ball/ball_recordstringformatter.cpp
@@ -1296,6 +1296,7 @@ void RecordStringFormatter::operator()(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (bsl::strcmp(lhs.format(), rhs.format()) == 0 && lhs.timestampOffset() == rhs.timestampOffset())) && (__out == false ==> (bsl::strcmp(lhs.format(), rhs.format()) != 0 || lhs.timestampOffset() != rhs.timestampOffset()))
 bool ball::operator==(const RecordStringFormatter& lhs,
                       const RecordStringFormatter& rhs)
 {

--- a/groups/bal/ball/ball_rule.cpp
+++ b/groups/bal/ball/ball_rule.cpp
@@ -23,6 +23,7 @@ namespace ball {
                          // ----------
 
 // CLASS METHODS
+// ensures: (rule.d_hashValue < 0 || rule.d_hashSize != size) ==> (rule.d_hashValue == (ManagedAttributeSet::hash(rule.d_attributeSet, size) + ThresholdAggregate::hash(rule.d_thresholds, size) + bdlb::HashUtil::hash0(rule.d_pattern.c_str(), size)) % size ⋆ rule.d_hashSize == size) ⋆ __out == rule.d_hashValue
 int Rule::hash(const Rule& rule, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -42,6 +43,7 @@ int Rule::hash(const Rule& rule, int size)
 }
 
 // MANIPULATORS
+// ensures: __out.d_pattern ↦ rhs.d_pattern ⋆ __out.d_thresholds ↦ rhs.d_thresholds ⋆ __out.d_attributeSet ↦ rhs.d_attributeSet ⋆ __out.d_hashValue ↦ rhs.d_hashValue ⋆ __out.d_hashSize ↦ rhs.d_hashSize
 Rule& Rule::operator=(const Rule& rhs)
 {
     d_pattern      = rhs.d_pattern,
@@ -53,6 +55,7 @@ Rule& Rule::operator=(const Rule& rhs)
 }
 
 // ACCESSORS
+// ensures: __out == &stream && (__out ↦ _)
 bsl::ostream& Rule::print(bsl::ostream& stream,
                           int           level,
                           int           spacesPerLevel) const

--- a/groups/bal/ball/ball_ruleset.cpp
+++ b/groups/bal/ball/ball_ruleset.cpp
@@ -182,6 +182,7 @@ RuleSet& RuleSet::operator=(const RuleSet& rhs)
 }
 
 // ACCESSORS
+// ensures: (__out == -1 ==> (d_ruleHashtable.find(value) == d_ruleHashtable.end() || FORALL(0, d_ruleAddresses.size(), i, d_ruleAddresses[i] != &*d_ruleHashtable.find(value)))) && (__out != -1 ==> EXISTS(0, d_ruleAddresses.size(), i, d_ruleAddresses[i] == &*d_ruleHashtable.find(value) && __out == i))
 int RuleSet::ruleId(const Rule& value) const
 {
     HashtableType::const_iterator iter = d_ruleHashtable.find(value);
@@ -222,6 +223,7 @@ bsl::ostream& RuleSet::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.numRules() == rhs.numRules() && FORALL(0, lhs.numRules(), i, rhs.ruleId(*lhs.getRuleById(i)) >= 0))) && (__out == false ==> (lhs.numRules() != rhs.numRules() || SEPEXISTS(0, lhs.numRules(), i, rhs.ruleId(*lhs.getRuleById(i)) < 0)))
 bool ball::operator==(const RuleSet& lhs, const RuleSet& rhs)
 {
     if (lhs.numRules() != rhs.numRules()) {

--- a/groups/bal/ball/ball_scopedattribute.cpp
+++ b/groups/bal/ball/ball_scopedattribute.cpp
@@ -21,6 +21,7 @@ ScopedAttribute_Container::~ScopedAttribute_Container()
 }
 
 // ACCESSORS
+// ensures: __out == stream ⋆ (stream ↦ _)
 bsl::ostream&
 ScopedAttribute_Container::print(bsl::ostream& stream,
                                  int           level,

--- a/groups/bal/ball/ball_severity.cpp
+++ b/groups/bal/ball/ball_severity.cpp
@@ -22,6 +22,7 @@ void Severity::print(bsl::ostream& stream, Severity::Level value)
 }
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> (*level == Severity::e_OFF || *level == Severity::e_INFO || *level == Severity::e_WARN || *level == Severity::e_DEBUG || *level == Severity::e_ERROR || *level == Severity::e_FATAL || *level == Severity::e_TRACE)) && (__out == -1 ==> true)
 int Severity::fromAscii(Severity::Level *level,
                         const char      *string,
                         int              stringLength)

--- a/groups/bal/ball/ball_severityutil.cpp
+++ b/groups/bal/ball/ball_severityutil.cpp
@@ -18,6 +18,7 @@ namespace ball {
                         // -------------------
 
 // CLASS METHODS
+// ensures: (__out == BALL_SUCCESS ==> ((*level == Severity::e_OFF) || (*level == Severity::e_FATAL) || (*level == Severity::e_ERROR) || (*level == Severity::e_WARN) || (*level == Severity::e_INFO) || (*level == Severity::e_DEBUG) || (*level == Severity::e_TRACE))) && (__out == BALL_FAILURE ==> true)
 int SeverityUtil::fromAsciiCaseless(Severity::Level *level, const char *name)
 {
     BSLS_ASSERT(level);

--- a/groups/bal/ball/ball_thresholdaggregate.cpp
+++ b/groups/bal/ball/ball_thresholdaggregate.cpp
@@ -28,6 +28,7 @@ namespace ball {
                         // ------------------------
 
 // CLASS METHODS
+// ensures: (0 <= __out) && (__out < size)
 int ThresholdAggregate::hash(const ThresholdAggregate& aggregate, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -62,6 +63,7 @@ int ThresholdAggregate::maxLevel(int recordLevel,
 }
 
 // MANIPULATORS
+// ensures: __out.d_recordLevel ↦ rhs.d_recordLevel ⋆ __out.d_passLevel ↦ rhs.d_passLevel ⋆ __out.d_triggerLevel ↦ rhs.d_triggerLevel ⋆ __out.d_triggerAllLevel ↦ rhs.d_triggerAllLevel
 ThresholdAggregate&
 ThresholdAggregate::operator=(const ThresholdAggregate& rhs)
 {
@@ -94,6 +96,7 @@ int ThresholdAggregate::setLevels(int recordLevel,
 }
 
 // ACCESSORS
+// ensures: __out == stream
 bsl::ostream&
 ThresholdAggregate::print(bsl::ostream& stream,
                           int           level,

--- a/groups/bal/ball/ball_userfields.cpp
+++ b/groups/bal/ball/ball_userfields.cpp
@@ -16,6 +16,7 @@ namespace ball {
                              // ----------------
 
 // ACCESSORS
+// ensures: __out == &stream && (__out ↦ _)
 bsl::ostream& UserFields::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bal/ball/ball_userfieldtype.cpp
+++ b/groups/bal/ball/ball_userfieldtype.cpp
@@ -16,6 +16,7 @@ namespace ball {
                      // --------------------
 
 // CLASS METHODS
+// ensures: (__out == &stream) && (__out ↦ _)
 bsl::ostream& UserFieldType::print(bsl::ostream&       stream,
                                    UserFieldType::Enum value,
                                    int                 level,

--- a/groups/bal/ball/ball_userfieldvalue.cpp
+++ b/groups/bal/ball/ball_userfieldvalue.cpp
@@ -16,6 +16,7 @@ namespace ball {
                              // --------------------
 
 // ACCESSORS
+// ensures: (__out == ball::UserFieldType::e_VOID) || (__out == ball::UserFieldType::e_INT64) || (__out == ball::UserFieldType::e_DOUBLE) || (__out == ball::UserFieldType::e_STRING) || (__out == ball::UserFieldType::e_DATETIMETZ) || (__out == ball::UserFieldType::e_CHAR_ARRAY)
 ball::UserFieldType::Enum UserFieldValue::type() const
 {
     switch (d_value.typeIndex()) {

--- a/groups/bal/balm/balm_category.cpp
+++ b/groups/bal/balm/balm_category.cpp
@@ -54,6 +54,7 @@ void Category::registerCategoryHolder(CategoryHolder *holder)
 }
 
 // ACCESSORS
+// ensures: __out == stream ⋆ stream ↦ _
 bsl::ostream& Category::print(bsl::ostream& stream) const
 {
     stream << "[ " << d_name_p << (d_enabled ? " ENABLED ]" : " DISABLED ]");

--- a/groups/bal/balm/balm_collectorrepository.cpp
+++ b/groups/bal/balm/balm_collectorrepository.cpp
@@ -371,6 +371,7 @@ CollectorRepository_MetricCollectors::
 }
 
 // MANIPULATORS
+// ensures: &__out == &d_collectors
 inline
 CollectorRepository_Collectors<Collector>&
 CollectorRepository_MetricCollectors::collectors()
@@ -403,6 +404,7 @@ void CollectorRepository_MetricCollectors::collect(MetricRecord *record)
 }
 
 // ACCESSORS
+// ensures: __out == d_collectors
 inline
 const CollectorRepository_Collectors<Collector>&
 CollectorRepository_MetricCollectors::collectors() const

--- a/groups/bal/balm/balm_configurationutil.cpp
+++ b/groups/bal/balm/balm_configurationutil.cpp
@@ -26,6 +26,7 @@ namespace balm {
                           // ------------------------
 
 // CLASS METHODS
+// ensures: (__out == -1 ==> manager == 0) && (__out == 0 ==> manager != 0)
 int ConfigurationUtil::setFormat(const char          *category,
                                  const char          *metricName,
                                  const MetricFormat&  format,

--- a/groups/bal/balm/balm_defaultmetricsmanager.cpp
+++ b/groups/bal/balm/balm_defaultmetricsmanager.cpp
@@ -29,6 +29,7 @@ bslma::Allocator     *balm::DefaultMetricsManager::s_allocator_p = 0;
 
 namespace balm {
 // CLASS METHODS
+// ensures: (__out != 0) && (s_allocator_p ↦ bslma::Default::globalAllocator(basicAllocator)) ⋆ (s_singleton_p ↦ __out)
 MetricsManager *DefaultMetricsManager::create(bslma::Allocator *basicAllocator)
 {
     BSLS_ASSERT(0 == s_singleton_p);

--- a/groups/bal/balm/balm_metricdescription.cpp
+++ b/groups/bal/balm/balm_metricdescription.cpp
@@ -17,6 +17,7 @@ namespace balm {
                           // -----------------------
 
 // ACCESSORS
+// ensures: (__out == &stream) && (stream ↦ _)
 bsl::ostream& MetricDescription::print(bsl::ostream& stream) const
 {
     stream << d_category_p->name() << "." << d_name_p;

--- a/groups/bal/balm/balm_metricformat.cpp
+++ b/groups/bal/balm/balm_metricformat.cpp
@@ -29,6 +29,7 @@ const char *balm::MetricFormatSpec::k_DEFAULT_FORMAT = "%f";
 namespace balm {
 
 // CLASS METHODS
+// ensures: __out == &stream
 bsl::ostream& MetricFormatSpec::formatValue(bsl::ostream&           stream,
                                             double                  value,
                                             const MetricFormatSpec& format)
@@ -66,6 +67,7 @@ bsl::ostream& MetricFormatSpec::formatValue(bsl::ostream&           stream,
 }
 
 // ACCESSORS
+// ensures: __out == stream ⋆ (stream ↦ _)
 bsl::ostream& MetricFormatSpec::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const
@@ -104,6 +106,7 @@ void MetricFormat::clearFormatSpec(
 }
 
 // ACCESSORS
+// ensures: __out == stream
 bsl::ostream& MetricFormat::print(bsl::ostream& stream,
                                   int      level,
                                   int      spacesPerLevel) const

--- a/groups/bal/balm/balm_metricid.cpp
+++ b/groups/bal/balm/balm_metricid.cpp
@@ -19,6 +19,7 @@ BSLMF_ASSERT(bslmf::IsTriviallyCopyableCheck<MetricId>::value);
                                // --------------
 
 // ACCESSORS
+// ensures: __out == stream && (d_description_p == 0 ==> stream.str().find("INVALID_ID") != std::string::npos) && (d_description_p != 0 ==> stream.str().find(*d_description_p) != std::string::npos)
 bsl::ostream& MetricId::print(bsl::ostream& stream) const
 {
     if (0 == d_description_p) {

--- a/groups/bal/balm/balm_metricrecord.cpp
+++ b/groups/bal/balm/balm_metricrecord.cpp
@@ -48,6 +48,7 @@ BSLMF_ASSERT(bsl::is_trivially_copyable<MetricRecord>::value);
 BSLMF_ASSERT(bslmf::IsBitwiseCopyable<MetricRecord>::value);
 
 // ACCESSORS
+// ensures: __out == &stream
 bsl::ostream& MetricRecord::print(bsl::ostream& stream) const
 {
     stream << "[ " << d_metricId << ": " << d_count

--- a/groups/bal/balm/balm_metricregistry.cpp
+++ b/groups/bal/balm/balm_metricregistry.cpp
@@ -46,6 +46,7 @@ void combineUserData(bsl::vector<const void *>        *result,
 
 /// Return `true` if the specified `candidatePrefix` is a prefix of the
 /// specified `string`, and `false` otherwise.
+// ensures: (__out == true ==> SEPFORALL(0, strlen(candidatePrefix), i, (candidatePrefix + i ↦ _ ⋆ string + i ↦ _ ⋆ *(candidatePrefix + i) == *(string + i)))) && (__out == false ==> SEPEXISTS(0, strlen(candidatePrefix), i, (candidatePrefix + i ↦ _ ⋆ string + i ↦ _ ⋆ *(candidatePrefix + i) != *(string + i))))
 bool isPrefix(const char *candidatePrefix, const char *string)
 {
     while (*candidatePrefix == *string && *candidatePrefix) {
@@ -172,6 +173,7 @@ MetricRegistry::~MetricRegistry()
 }
 
 // MANIPULATORS
+// ensures: (__out != MetricId() ==> ret.second) && (__out == MetricId() ==> !ret.second)
 MetricId MetricRegistry::addId(const char *category,
                                const char *name)
 {
@@ -393,6 +395,7 @@ MetricDescription::UserDataKey MetricRegistry::createUserDataKey()
 }
 
 // ACCESSORS
+// ensures: __out == d_metrics.size()
 bsl::size_t MetricRegistry::numMetrics() const
 {
     bslmt::ReadLockGuard<bslmt::RWMutex> guard(&d_lock);

--- a/groups/bal/balm/balm_metricsample.cpp
+++ b/groups/bal/balm/balm_metricsample.cpp
@@ -16,6 +16,7 @@ namespace balm {
                           // -----------------------
 
 // ACCESSORS
+// ensures: __out == &stream
 bsl::ostream&
 MetricSampleGroup::print(bsl::ostream& stream,
                          int           level,
@@ -56,6 +57,7 @@ MetricSample::MetricSample(const MetricSample&  original,
 }
 
 // MANIPULATORS
+// ensures: (__out == *this) && ((this != &rhs) ==> (d_records ↦ rhs.d_records ⋆ d_timeStamp ↦ rhs.d_timeStamp ⋆ d_numRecords ↦ rhs.d_numRecords))
 MetricSample& MetricSample::operator=(const MetricSample& rhs)
 {
     if (this != &rhs) {
@@ -67,6 +69,7 @@ MetricSample& MetricSample::operator=(const MetricSample& rhs)
 }
 
 // ACCESSORS
+// ensures: __out == stream
 bsl::ostream& MetricSample::print(bsl::ostream& stream,
                                   int           level,
                                   int           spacesPerLevel) const

--- a/groups/bal/balm/balm_metricsmanager.cpp
+++ b/groups/bal/balm/balm_metricsmanager.cpp
@@ -801,6 +801,7 @@ MetricsManager_PublisherRegistry::~MetricsManager_PublisherRegistry()
 }
 
 // MANIPULATORS
+// ensures: (__out == -1 ==> (d_generalPublishers.end() != d_generalPublishers.find(publisher) || (d_registry.find(publisher) != d_registry.end() && !d_registry.find(publisher)->second.empty()))) && (__out == 0 ==> d_generalPublishers.end() != d_generalPublishers.find(publisher))
 int MetricsManager_PublisherRegistry::addGeneralPublisher(
                               const bsl::shared_ptr<Publisher>& publisher)
 {
@@ -1007,6 +1008,7 @@ MetricsManager_CallbackRegistry::~MetricsManager_CallbackRegistry()
 }
 
 // MANIPULATORS
+// ensures: __out == d_nextHandle - 1 && d_callbacks.find(category) != d_callbacks.end() && d_handles.find(__out) != d_handles.end()
 MetricsManager_CallbackRegistry::CallbackHandle
 MetricsManager_CallbackRegistry::registerCollectionCallback(
                                     const Category                   *category,

--- a/groups/bal/balm/balm_publicationscheduler.cpp
+++ b/groups/bal/balm/balm_publicationscheduler.cpp
@@ -59,6 +59,7 @@ struct IsPair {
 
 /// Return the invalid scheduling interval value.  Note that this function
 /// is provided to avoid creating a statically initialized constant.
+// ensures: (__out.seconds() == 0) && (__out.nanoseconds() == 0)
 inline
 bsls::TimeInterval makeInvalidInterval()
 {
@@ -92,6 +93,7 @@ struct CategorySort {
 
 /// Print, to the specified `stream` the specified `categories` in
 /// alphabetic order.
+// ensures: __out == &stream
 bsl::ostream& printCategorySet(
                             bsl::ostream&                           stream,
                             const bsl::set<const balm::Category *>& categories)
@@ -272,6 +274,7 @@ PublicationScheduler_ClockData::~PublicationScheduler_ClockData()
 }
 
 // MANIPULATORS
+// ensures: __out == &d_mutex
 inline
 bslmt::Mutex *PublicationScheduler_ClockData::mutex()
 {
@@ -688,6 +691,7 @@ int PublicationScheduler::clearDefaultSchedule()
 }
 
 // ACCESSORS
+// ensures: (__out == true ==> (*result ↦ catIt->second)) && (__out == false ==> (*result ↦ old_result))
 bool
 PublicationScheduler::findCategorySchedule(bsls::TimeInterval *result,
                                            const Category     *category) const

--- a/groups/bal/balst/balst_stacktrace.cpp
+++ b/groups/bal/balst/balst_stacktrace.cpp
@@ -16,6 +16,7 @@ namespace balst {
                               // ----------------
 
 // ACCESSORS
+// ensures: __out == &stream
 bsl::ostream& StackTrace::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bal/balst/balst_stacktraceframe.cpp
+++ b/groups/bal/balst/balst_stacktraceframe.cpp
@@ -16,6 +16,7 @@ namespace balst {
                            // ---------------------
 
 // ACCESSORS
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream& StackTraceFrame::print(bsl::ostream& stream,
                                      int           level,
                                      int           spacesPerLevel) const
@@ -57,6 +58,7 @@ void StackTraceFrame::swap(StackTraceFrame& other)
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (stream.bad() ==> __out == stream) && (!stream.bad() ==> __out == stream)
 bsl::ostream& balst::operator<<(bsl::ostream&          stream,
                                 const StackTraceFrame& object)
 {

--- a/groups/bal/balst/balst_stacktraceprinter.cpp
+++ b/groups/bal/balst/balst_stacktraceprinter.cpp
@@ -36,6 +36,7 @@ StackTracePrinter::StackTracePrinter(int  maxFrames,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& balst::operator<<(bsl::ostream&            stream,
                                 const StackTracePrinter& object)
 {

--- a/groups/bal/balst/balst_stacktraceprintutil.cpp
+++ b/groups/bal/balst/balst_stacktraceprintutil.cpp
@@ -32,6 +32,7 @@ namespace balst {
                          // -------------------------
 
 // CLASS METHOD
+// ensures: __out == &stream
 bsl::ostream& StackTracePrintUtil::printStackTrace(
                                          bsl::ostream& stream,
                                          int           maxFrames,

--- a/groups/bal/balst/balst_stacktracetestallocator.cpp
+++ b/groups/bal/balst/balst_stacktracetestallocator.cpp
@@ -89,6 +89,7 @@ static const UintPtr k_DEALLOCATED_BLOCK_MAGIC = 1999999991 + HIGH_ONES;
 /// `specifiedMaxRecordedFrames`.  The specify value may need to be
 /// adjusted upward to include room for ignored frames, and for the buffer
 /// size in bytes being a multiple of `k_MAX_ALIGNMENT`.
+// ensures: __out >= specifiedMaxRecordedFrames && (__out % k_PTRS_PER_MAX == 0)
 static
 int getTraceBufferLength(int specifiedMaxRecordedFrames)
 {
@@ -175,6 +176,7 @@ StackTraceTestAllocator::BlockHeader::BlockHeader(
                  // ------------------------------------------
 
 // PRIVATE ACCESSORS
+// ensures: (__out == -1 ==> (k_ALLOCATED_BLOCK_MAGIC != blockHdr->d_magic || (this != blockHdr->d_allocator_p && k_STACK_TRACE_TEST_ALLOCATOR_MAGIC != blockHdr->d_allocator_p->d_magic) || (0 == d_blocks || 0 == blockHdr->d_prevNext_p || 0 == *blockHdr->d_prevNext_p) || (blockHdr->d_next_p && k_ALLOCATED_BLOCK_MAGIC != blockHdr->d_next_p->d_magic))) && (__out == 0 ==> (k_ALLOCATED_BLOCK_MAGIC == blockHdr->d_magic && (this == blockHdr->d_allocator_p || k_STACK_TRACE_TEST_ALLOCATOR_MAGIC == blockHdr->d_allocator_p->d_magic) && (d_blocks != 0 && blockHdr->d_prevNext_p != 0 && *blockHdr->d_prevNext_p != 0) && (!blockHdr->d_next_p || (blockHdr->d_next_p && k_ALLOCATED_BLOCK_MAGIC == blockHdr->d_next_p->d_magic))))
 int StackTraceTestAllocator::checkBlockHeader(
                                              const BlockHeader *blockHdr) const
 {
@@ -337,6 +339,7 @@ StackTraceTestAllocator::~StackTraceTestAllocator()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 && (__out ↦ _)))
 void *StackTraceTestAllocator::allocate(size_type size)
 {
     // All updates are protected by a mutex lock, so as to not interleave the
@@ -526,6 +529,7 @@ void StackTraceTestAllocator::setOstream(bsl::ostream *ostream)
 }
 
 // ACCESSORS
+// ensures: __out == d_allocationLimit.loadRelaxed()
 bsls::Types::Int64 StackTraceTestAllocator::allocationLimit() const
 {
     return d_allocationLimit.loadRelaxed();

--- a/groups/bal/balst/balst_stacktraceutil.cpp
+++ b/groups/bal/balst/balst_stacktraceutil.cpp
@@ -37,6 +37,7 @@ BSLS_IDENT_RCSID(balst_stacktraceutil_cpp,"$Id$ $CSID$")
 /// address.  If there are no separator characters, return the address of
 /// the first character of `pathName`.  If the last character of `pathName`
 /// is a separator charactor, return the address of the terminating '\0'.
+// ensures: (__out == pathName) || (__out[-1] == separator)
 static
 const char *findBasename(const char *pathName)
 {
@@ -73,7 +74,8 @@ class ResolverImpl<ObjectFileFormat::Dummy>
     /// which is to be used for memory allocation.  The behavior is
     /// undefined unless all the `address` field in `stackFrames` are valid
     /// and other fields are invalid, and `basicAllocator != 0`.
-    static
+    // ensures: __out == -1
+static
     int resolve(StackTrace *,    // 'stackTrace'
                 bool        )    // 'demangle'
     {

--- a/groups/bal/baltzo/baltzo_datafileloader.cpp
+++ b/groups/bal/baltzo/baltzo_datafileloader.cpp
@@ -94,6 +94,7 @@ void concatenatePath(STRING             *result,
 
 /// Returns 0 if the specified `timeZoneId` contains only valid characters
 /// and does not start with `/`, and a non-zero value otherwise.
+// ensures: (__out == -1 ==> timeZoneId[0] == '/') && (__out == -2 ==> SEPEXISTS(0, strlen(timeZoneId), i, !(bsl::strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890/_+-", timeZoneId[i])))) && (__out == 0 ==> SEPFORALL(0, strlen(timeZoneId), i, bsl::strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890/_+-", timeZoneId[i])))
 int validateTimeZoneId(const char *timeZoneId)
 {
     BSLS_ASSERT(timeZoneId);
@@ -151,6 +152,7 @@ int loadTimeZoneFilePath_Impl(STRING             *result,
 /// A return status of `ErrorCode::k_UNSUPPORTED_ID` indicates that
 /// `timeZoneId` is not recognized.  If an error occurs during this
 /// operation, `result` will be left in a valid, but unspecified state.
+// ensures: (__out == u::UNSUPPORTED_ID || __out == u::UNSPECIFIED_ERROR) || (result->identifier() == timeZoneId)
 int loadTimeZoneImpl(baltzo::Zoneinfo              *result,
                      const baltzo::DataFileLoader&  loader,
                      const char                    *timeZoneId,
@@ -206,6 +208,7 @@ namespace baltzo {
                             // --------------------
 
 // CLASS METHODS
+// ensures: (__out == true ==> (bdls::FilesystemUtil::isDirectory(path, true) && bdls::FilesystemUtil::isRegularFile(bsl::string(path) + "/GMT", true))) && (__out == false ==> !(bdls::FilesystemUtil::isDirectory(path, true) && bdls::FilesystemUtil::isRegularFile(bsl::string(path) + "/GMT", true)))
 bool DataFileLoader::isPlausibleZoneinfoRootPath(const char *path)
 {
     BSLS_ASSERT(path);

--- a/groups/bal/baltzo/baltzo_defaultzoneinfocache.cpp
+++ b/groups/bal/baltzo/baltzo_defaultzoneinfocache.cpp
@@ -62,6 +62,7 @@ static baltzo::ZoneinfoCache *userSingletonCachePtr   = 0; // default usr cache
 /// not previously been called.  Subsequent calls to this method return the
 /// previously created (singleton) instance with no other effect.  This
 /// methods is *not* thread safe.
+// ensures: __out != 0
 static
 baltzo::ZoneinfoCache *initSystemDefaultCache()
 {
@@ -100,6 +101,7 @@ namespace baltzo {
                          // --------------------------
 
 // PRIVATE CLASS METHODS
+// ensures: __out != 0
 ZoneinfoCache *DefaultZoneinfoCache::instance()
 {
     if (u::userSingletonCachePtr) {
@@ -116,6 +118,7 @@ ZoneinfoCache *DefaultZoneinfoCache::instance()
 }
 
 // CLASS METHODS
+// ensures: (__out != 0) && ((__out == getenv("BDE_ZONEINFO_ROOT_PATH")) || SEPEXISTS(0, u::k_NUM_BALTZO_DATA_LOCATIONS, ii, __out == u::BALTZO_DATA_LOCATIONS[ii]) || __out == ".")
 const char *DefaultZoneinfoCache::defaultZoneinfoDataLocation()
 {
     const char *envValue = getenv("BDE_ZONEINFO_ROOT_PATH");

--- a/groups/bal/baltzo/baltzo_dstpolicy.cpp
+++ b/groups/bal/baltzo/baltzo_dstpolicy.cpp
@@ -17,6 +17,7 @@ namespace baltzo {
                               // ----------------
 
 // CLASS METHODS
+// ensures: __out == stream ⋆ (stream ↦ _)
 bsl::ostream& DstPolicy::print(bsl::ostream&   stream,
                                DstPolicy::Enum value,
                                int             level,

--- a/groups/bal/baltzo/baltzo_errorcode.cpp
+++ b/groups/bal/baltzo/baltzo_errorcode.cpp
@@ -17,6 +17,7 @@ namespace baltzo {
                               // ----------------
 
 // CLASS METHODS
+// ensures: __out == stream ⋆ (stream ↦ _)
 bsl::ostream& ErrorCode::print(bsl::ostream&   stream,
                                ErrorCode::Enum value,
                                int             level,

--- a/groups/bal/baltzo/baltzo_localdatetime.cpp
+++ b/groups/bal/baltzo/baltzo_localdatetime.cpp
@@ -38,6 +38,7 @@ bsl::ostream& LocalDatetime::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& baltzo::operator<<(bsl::ostream&        stream,
                                  const LocalDatetime& object)
 {

--- a/groups/bal/baltzo/baltzo_localtimedescriptor.cpp
+++ b/groups/bal/baltzo/baltzo_localtimedescriptor.cpp
@@ -37,6 +37,7 @@ bsl::ostream& LocalTimeDescriptor::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& baltzo::operator<<(bsl::ostream&              stream,
                                  const LocalTimeDescriptor& object)
 {

--- a/groups/bal/baltzo/baltzo_localtimeoffsetutil.cpp
+++ b/groups/bal/baltzo/baltzo_localtimeoffsetutil.cpp
@@ -30,6 +30,7 @@ namespace baltzo {
                          // --------------------------
 
 // PRIVATE CLASS METHODS
+// ensures: (retval == 0 ==> __out == 0) && (retval != 0 ==> __out != 0)
 inline
 int LocalTimeOffsetUtil::configureImp(const char            *timezone,
                                       const bdlt::Datetime&  utcDatetime)

--- a/groups/bal/baltzo/baltzo_localtimeperiod.cpp
+++ b/groups/bal/baltzo/baltzo_localtimeperiod.cpp
@@ -18,6 +18,7 @@ namespace baltzo {
                         // Aspects
 
 // ACCESSORS
+// ensures: (__out == stream) && (stream ↦ _)
 bsl::ostream& LocalTimePeriod::print(bsl::ostream& stream,
                                      int           level,
                                      int           spacesPerLevel) const

--- a/groups/bal/baltzo/baltzo_localtimevalidity.cpp
+++ b/groups/bal/baltzo/baltzo_localtimevalidity.cpp
@@ -16,6 +16,7 @@ namespace baltzo {
                           // ------------------------
 
 // CLASS METHODS
+// ensures: __out == &stream ⋆ stream ↦ _
 bsl::ostream& LocalTimeValidity::print(bsl::ostream&           stream,
                                        LocalTimeValidity::Enum value,
                                        int                     level,

--- a/groups/bal/baltzo/baltzo_timezoneutil.cpp
+++ b/groups/bal/baltzo/baltzo_timezoneutil.cpp
@@ -26,6 +26,7 @@ namespace baltzo {
                              // ------------------
 
 // CLASS METHODS
+// ensures: (result->datetimeTz().utcDatetime() == (originalTime.datetimeTz().utcDatetime() + bdlt::IntervalConversionUtil::convertToDatetimeInterval(interval))) ⋆ (result != 0)
 int TimeZoneUtil::addInterval(LocalDatetime             *result,
                               const LocalDatetime&       originalTime,
                               const bsls::TimeInterval&  interval)

--- a/groups/bal/baltzo/baltzo_timezoneutilimp.cpp
+++ b/groups/bal/baltzo/baltzo_timezoneutilimp.cpp
@@ -36,6 +36,7 @@ namespace BloombergLP {
 /// `cache`.  Return 0 on success, and a non-zero value otherwise.  A return
 /// status of `baltzo::ErrorCode::k_UNSUPPORTED_ID` indicates that
 /// `timeZoneId` is not recognized.
+// ensures: (__out == 0 ==> (*timeZone != 0)) && (__out != 0 ==> (*timeZone == 0))
 static
 int lookupTimeZone(const baltzo::Zoneinfo **timeZone,
                    const char              *timeZoneId,
@@ -65,6 +66,7 @@ int lookupTimeZone(const baltzo::Zoneinfo **timeZone,
 /// `timeZone.endTransition()` if `timeZone` does not contain any transition
 /// having a local-time descriptor with `dstFlag`.  The behavior is
 /// undefined unless `start` is a valid iterator in `timeZone`.
+// ensures: (__out != timeZone.endTransitions() ==> __out->descriptor().dstInEffectFlag() == dstFlag) || (__out == timeZone.endTransitions())
 static
 baltzo::Zoneinfo::TransitionConstIterator findTransitionWithDstFlag(
                      const bool                                       dstFlag,
@@ -206,6 +208,7 @@ namespace baltzo {
                            // ---------------------
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> (result != 0)) && (__out != 0 ==> true)
 int TimeZoneUtilImp::convertUtcToLocalTime(
                                        bdlt::DatetimeTz      *result,
                                        const char            *resultTimeZoneId,

--- a/groups/bal/baltzo/baltzo_windowstimezoneutil.cpp
+++ b/groups/bal/baltzo/baltzo_windowstimezoneutil.cpp
@@ -42,6 +42,7 @@ typedef struct TimeZoneIdEntry {
 
 /// Return `true` if the "key" field of the specified `a` is lexically less
 /// that the "key" field of the specified `b`, and 'false otherwise.
+// ensures: (__out == true ==> bsl::strcmp(a.d_key, b.d_key) < 0) && (__out == false ==> bsl::strcmp(a.d_key, b.d_key) >= 0)
 static bool isLessThan(const TimeZoneIdEntry& a,
                        const TimeZoneIdEntry& b)
 {
@@ -286,6 +287,7 @@ namespace baltzo {
                          // --------------------------
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> (*result ↦ ptr->d_value)) && (__out == -1 ==> true)
 int WindowsTimeZoneUtil::getZoneinfoId(const char **result,
                                        const char  *windowsTimeZoneId)
 {

--- a/groups/bal/baltzo/baltzo_zoneinfo.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfo.cpp
@@ -22,6 +22,7 @@ namespace BloombergLP {
 
 /// Return `true` if the specified `transitions` contain a transition with
 /// the specified `descriptor`, and `false` otherwise.
+// ensures: (__out == true ==> SEPEXISTS(0, transitions.size(), i, transitions[i].descriptor() == descriptor)) && (__out == false ==> SEPFORALL(0, transitions.size(), i, transitions[i].descriptor() != descriptor))
 static
 bool containsDescriptor(
                     const bsl::vector<baltzo::ZoneinfoTransition>& transitions,
@@ -44,6 +45,7 @@ namespace baltzo {
                           // ------------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (!stream.bad())
 bsl::ostream&
 ZoneinfoTransition::print(bsl::ostream& stream,
                           int           level,
@@ -98,6 +100,7 @@ ZoneinfoTransition::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == stream && (__out << "[ " << (rc ? object.utcTime() : utcDatetime) << " " << object.descriptor() << " ]")
 bsl::ostream& baltzo::operator<<(bsl::ostream&             stream,
                                  const ZoneinfoTransition& object)
 {
@@ -125,6 +128,7 @@ namespace baltzo {
                        // ------------------------------
 
 // ACCESSORS
+// ensures: (__out == true ==> ((lhs.utcOffsetInSeconds() < rhs.utcOffsetInSeconds()) || ((lhs.utcOffsetInSeconds() == rhs.utcOffsetInSeconds()) && (lhs.description() < rhs.description())) || ((lhs.utcOffsetInSeconds() == rhs.utcOffsetInSeconds()) && (lhs.description() == rhs.description()) && (lhs.dstInEffectFlag() < rhs.dstInEffectFlag())))) && (__out == false ==> ((lhs.utcOffsetInSeconds() >= rhs.utcOffsetInSeconds()) && ((lhs.utcOffsetInSeconds() != rhs.utcOffsetInSeconds()) || (lhs.description() >= rhs.description()) && ((lhs.description() != rhs.description()) || (lhs.dstInEffectFlag() >= rhs.dstInEffectFlag())))))
 bool Zoneinfo::DescriptorLess::operator()(const LocalTimeDescriptor& lhs,
                                           const LocalTimeDescriptor& rhs) const
 {
@@ -346,6 +350,7 @@ bsl::ostream& Zoneinfo::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& baltzo::operator<<(bsl::ostream& stream, const Zoneinfo& object)
 {
     stream << "[ \"" << object.identifier() << "\" "

--- a/groups/bal/baltzo/baltzo_zoneinfobinaryreader.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfobinaryreader.cpp
@@ -130,6 +130,7 @@ const bsls::Types::Int64 MINIMUM_ZIC_TRANSITION = -576460752303423488LL;
 
 /// Return `true` if every character in the specified `buffer` of the
 /// specified `length` is printable, and `false` otherwise.
+// ensures: (__out == true ==> FORALL(0, length, i, bdlb::CharType::isPrint(buffer[i]))) && (__out == false ==> EXISTS(0, length, i, !bdlb::CharType::isPrint(buffer[i])))
 static
 bool areAllPrintable(const char *buffer, int length)
 {
@@ -229,6 +230,7 @@ bool validIndex(const bsl::vector<TYPE>& vector, int index)
 /// Read the 32-bit big-endian integer in the array of bytes located at the
 /// specified `address` and return that value.  The behavior is undefined
 /// unless `address` points to an accessible memory location.
+// ensures: __out == BSLS_BYTEORDER_BE_U32_TO_HOST(*((int*)address))
 static inline
 int decode32(const char *address)
 {
@@ -243,6 +245,7 @@ int decode32(const char *address)
 /// meets the requirements of the Zoneinfo binary file format, populate the
 /// specified `result` with the extracted information.  Return 0 if `result`
 /// is successfully read, and a non-zero value otherwise.
+// ensures: (__out == 0 ==> (result->version() == *rawHeader.d_version ⋆ result->numLocalTimeTypes() == decode32(rawHeader.d_numLocalTimeTypes) ⋆ result->numIsGmt() == decode32(rawHeader.d_numIsGmt) ⋆ result->numIsStd() == decode32(rawHeader.d_numIsStd) ⋆ result->numLeaps() == decode32(rawHeader.d_numLeaps) ⋆ result->numTransitions() == decode32(rawHeader.d_numTransitions) ⋆ result->abbrevDataSize() == decode32(rawHeader.d_abbrevDataSize))) && (__out < 0 ==> true)
 static inline
 int readHeader(baltzo::ZoneinfoBinaryHeader *result, bsl::istream& stream)
 {
@@ -406,6 +409,7 @@ int loadLocalTimeDescriptors(
 /// (which typically follows the version '\0' format data in a Zoneinfo binary
 /// file).  If an error occurs during the operation, the resulting value of
 /// `zoneinfoResult` is unspecified.
+// ensures: (__out == 0 ==> (zoneinfoResult != 0)) && (__out != 0 ==> true)
 static int readVersionTwoOrHigherFormatData(
                                   baltzo::Zoneinfo             *zoneinfoResult,
                                   baltzo::ZoneinfoBinaryHeader *headerResult,
@@ -690,6 +694,7 @@ namespace baltzo {
                          // --------------------------
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> true) && (__out != 0 ==> true)
 int ZoneinfoBinaryReader::read(Zoneinfo *zoneinfoResult, bsl::istream& stream)
 {
     ZoneinfoBinaryHeader description;

--- a/groups/bal/baltzo/baltzo_zoneinfocache.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfocache.cpp
@@ -39,6 +39,7 @@ ZoneinfoCache::~ZoneinfoCache()
 }
 
 // MANIPULATORS
+// ensures: (__out != nullptr ==> *rc == 0) && (__out == nullptr ==> *rc != 0)
 const Zoneinfo *ZoneinfoCache::getZoneinfo(int *rc, const char *timeZoneId)
 {
     BSLS_ASSERT(0 != rc);
@@ -124,6 +125,7 @@ const Zoneinfo *ZoneinfoCache::getZoneinfo(int *rc, const char *timeZoneId)
 }
 
 // ACCESSORS
+// ensures: (__out != 0 ==> (d_cache.find(timeZoneId) != d_cache.end() && __out == d_cache.find(timeZoneId)->second)) && (__out == 0 ==> d_cache.find(timeZoneId) == d_cache.end())
 const Zoneinfo *ZoneinfoCache::lookupZoneinfo(const char *timeZoneId) const
 {
     BSLS_ASSERT(0 != timeZoneId);

--- a/groups/bal/baltzo/baltzo_zoneinfoutil.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfoutil.cpp
@@ -28,6 +28,7 @@ namespace baltzo {
                              // ------------------
 
 // CLASS METHODS
+// ensures: (__out == 0) || (__out == ErrorCode::k_OUT_OF_RANGE)
 int ZoneinfoUtil::convertUtcToLocalTime(
                            bdlt::DatetimeTz                  *resultTime,
                            Zoneinfo::TransitionConstIterator *resultTransition,

--- a/groups/bal/balxml/balxml_decoder.cpp
+++ b/groups/bal/balxml/balxml_decoder.cpp
@@ -378,6 +378,7 @@ Decoder::checkForErrors(const ErrorInfo& errInfo)
 }
 
 // MANIPULATORS
+// ensures: (__out == BAEXML_SUCCESS || __out == BAEXML_FAILURE)
 int
 Decoder::parse(Decoder_ElementContext *context)
 {

--- a/groups/bal/balxml/balxml_elementattribute.cpp
+++ b/groups/bal/balxml/balxml_elementattribute.cpp
@@ -85,6 +85,7 @@ void ElementAttribute::reset(const PrefixStack *prefixStack,
 }
 
 // ACCESSORS
+// ensures: __out == d_prefix
 const char *ElementAttribute::prefix() const
 {
     if (d_prefix || ! d_qualifiedName) {

--- a/groups/bal/balxml/balxml_encoder.cpp
+++ b/groups/bal/balxml/balxml_encoder.cpp
@@ -97,6 +97,7 @@ Encoder_Context::Encoder_Context(
                   // ---------------------------------------
 
 // PRIVATE CLASS METHODS
+// ensures: (options.encodingStyle() == balxml::EncodingStyle::COMPACT ==> __out == 0) && (options.encodingStyle() == balxml::EncodingStyle::PRETTY ==> __out == options.initialIndentLevel())
 int Encoder_OptionsCompatibilityUtil::getFormatterInitialIndentLevel(
                                          const balxml::EncoderOptions& options)
 {

--- a/groups/bal/balxml/balxml_formatter_compactimpl.cpp
+++ b/groups/bal/balxml/balxml_formatter_compactimpl.cpp
@@ -46,6 +46,7 @@ void Formatter_CompactImplUtil::addCommentImpl(
 
 
 // CLASS METHODS
+// ensures: (__out == stream) && (state->column() == 0) && ((old_state->id() == StateId::e_IN_TAG) ==> (state->id() == StateId::e_FIRST_DATA_BETWEEN_TAGS))
 bsl::ostream& Formatter_CompactImplUtil::addBlankLine(bsl::ostream&  stream,
                                                       State         *state)
 {

--- a/groups/bal/balxml/balxml_formatter_prettyimpl.cpp
+++ b/groups/bal/balxml/balxml_formatter_prettyimpl.cpp
@@ -260,6 +260,7 @@ void Formatter_PrettyImplUtil::addListDataImpl(bsl::ostream&            stream,
 }
 
 // CLASS METHODS
+// ensures: (__out == stream) && (state->column() == 0) && ((state->id() == StateId::e_FIRST_DATA_AT_LINE_BETWEEN_TAGS) || (state->id() == old_state->id()))
 bsl::ostream& Formatter_PrettyImplUtil::addBlankLine(bsl::ostream&  stream,
                                                      State         *state)
 {

--- a/groups/bal/balxml/balxml_minireader.cpp
+++ b/groups/bal/balxml/balxml_minireader.cpp
@@ -104,6 +104,7 @@ namespace {
 
 /// Return the specified `s` if `s` != 0, or "" otherwise.  Never returns a
 /// null pointer.
+// ensures: (s != 0 ==> __out == s) && (s == 0 ==> __out == "")
 inline
 const char* nonNullStr(const char *s)
 {
@@ -112,6 +113,7 @@ const char* nonNullStr(const char *s)
 
 /// Return the specified `val` cast to a `char`.  Bits of `val` that are
 /// too high-order to fit in a `char` will be discarded.
+// ensures: __out == static_cast<char>(val)
 inline
 char toChar(unsigned val)
 {
@@ -122,6 +124,7 @@ char toChar(unsigned val)
 /// and write the characters to the character array at the specified
 /// `output` address.  Return the number of characters output or 0 if `val`
 /// is not in the legal range.
+// ensures: (val >= 0x110000U ==> __out == 0) && (val < 0x110000U ==> __out > 0)
 int unicodeToUtf8(char *output, unsigned val)
 {
     /*
@@ -465,6 +468,7 @@ MiniReader::~MiniReader()
 }
 
 // MANIPULATORS
+// ensures: (__out == -1 || __out == 0)
 int MiniReader::setError(ErrorInfo::Severity error, const bsl::string &msg)
 {
     Node&  node = currentNode();
@@ -641,6 +645,7 @@ int MiniReader::open(bsl::streambuf *stream,
 }
 
 // ACCESSORS
+// ensures: __out == d_errorInfo
 const ErrorInfo&
 MiniReader::errorInfo () const
 {
@@ -1220,6 +1225,7 @@ MiniReader::advanceToNextNode()
 // ----------------------------------------------------------------------------
 //                              PRIVATE methods
 // ----------------------------------------------------------------------------
+// ensures: (__out == 0 ==> d_scanPtr == d_endPtr) && (__out != 0 ==> ((*d_scanPtr != 32) && (*d_scanPtr != 9) && (*d_scanPtr != 13) && (*d_scanPtr != 10)))
 int
 MiniReader::skipSpaces()
 {

--- a/groups/bal/balxml/balxml_namespaceregistry.cpp
+++ b/groups/bal/balxml/balxml_namespaceregistry.cpp
@@ -30,6 +30,7 @@ const char *const predefinedNamespaces[] =
 
 /// Private function.  Look up the specified `namespaceUri` in the list of
 /// preregistered namespaces and return the namespace ID or -1 if not found.
+// ensures: (EXISTS(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri == predefinedNamespaces[i]) ==> __out >= balxml::NamespaceRegistry::e_PREDEF_MIN) && (FORALL(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri != predefinedNamespaces[i]) ==> __out == -1)
 int lookupPredefinedId(const bsl::string_view& namespaceUri)
 {
     for (int i = 0; i < ARRAY_LEN(predefinedNamespaces); ++i) {

--- a/groups/bal/balxml/balxml_prefixstack.cpp
+++ b/groups/bal/balxml/balxml_prefixstack.cpp
@@ -34,6 +34,7 @@ const PredefinedPrefix nullPrefix = { "", -1 };
 /// Return the namespace ID for the specified predefined `prefix` or -1 if
 /// `prefix` is not predefined.  The behavior is undefined unless
 /// `prefix.data()` is non-null.
+// ensures: (__out.d_prefix == prefix) || (__out == nullPrefix)
 const PredefinedPrefix& lookupPredefinedPrefix(const bsl::string_view& prefix)
 {
     for (int i = 0; i < ARRAY_LEN(predefinedPrefixes); ++i) {
@@ -71,6 +72,7 @@ PrefixStack::PrefixStack(const PrefixStack&  original,
 }
 
 // MANIPULATORS
+// ensures: __out == d_namespaceRegistry->lookupOrRegister(namespaceUri) && (__out == -1 ==> namespaceUri.empty())
 int PrefixStack::pushPrefix(const bsl::string_view& prefix,
                             const bsl::string_view& namespaceUri)
 {
@@ -106,6 +108,7 @@ int PrefixStack::popPrefixes(int count)
 }
 
 // ACCESSORS
+// ensures: (SEPEXISTS(0, d_numPrefixes, i, (d_prefixes[i].first == prefix && __out == d_prefixes[i].second)) || (__out == lookupPredefinedPrefix(prefix).d_nsid))
 int
 PrefixStack::lookupNamespaceId(const bsl::string_view& prefix) const
 {

--- a/groups/bal/balxml/balxml_typesparserutil.cpp
+++ b/groups/bal/balxml/balxml_typesparserutil.cpp
@@ -35,6 +35,7 @@ namespace u {
 /// specified length `inputLength` is "1" or "true" and false if `input` is
 /// "0" or "false".  Strings are case-insensitive.  Return 0 on success and
 /// non-zero if `input` is not "1", "0", "true", or "false".
+// ensures: (__out == BAEXML_SUCCESS ==> ((*result == true && (input[0] == '1' || (inputLength == 4 && input[0] == 't' && input[1] == 'r' && input[2] == 'u' && input[3] == 'e'))) || (*result == false && (input[0] == '0' || (inputLength == 5 && input[0] == 'f' && input[1] == 'a' && input[2] == 'l' && input[3] == 's' && input[4] == 'e'))))) && (__out == BAEXML_FAILURE ==> *result == old_result)
 int parseBoolean(bool *result, const char *input, int inputLength)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -80,6 +81,7 @@ int parseBoolean(bool *result, const char *input, int inputLength)
 /// digits, period and sign characters (i.e., INF/NaN, and exponential
 /// notation are not allowed); otherwise `input` can contain any floating-
 /// point representation form.  Return 0 on success and non-zero otherwise.
+// ensures: (__out == BAEXML_SUCCESS ==> (result ↦ _)) && (__out == BAEXML_FAILURE ==> true)
 int parseDoubleImpl(double *result, const char *input, bool formatDecimal)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -155,6 +157,7 @@ int parseDoubleImpl(double *result, const char *input, bool formatDecimal)
 /// specified length `inputLength` should contain only decimal digits,
 /// period and sign characters; otherwise `input` can contain any floating-
 /// point representation form.  Return 0 on success and non-zero otherwise.
+// ensures: (__out == BAEXML_SUCCESS ==> (*result ↦ _)) && (__out == BAEXML_FAILURE ==> true)
 int parseDouble(double     *result,
                 const char *input,
                 int         inputLength,
@@ -185,6 +188,7 @@ int parseDouble(double     *result,
 }
 
 /// Parse an unsigned long decimal string
+// ensures: (__out == BAEXML_SUCCESS ==> consumed == inputLength && errno == 0) && (__out == BAEXML_FAILURE ==> consumed != inputLength || errno != 0)
 int parseInt(int *result, const char *input, int inputLength)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -225,6 +229,7 @@ int parseInt(int *result, const char *input, int inputLength)
 }
 
 /// Parse an unsigned long decimal string
+// ensures: (__out == BAEXML_SUCCESS ==> consumed == inputLength && errno == 0) && (__out == BAEXML_FAILURE ==> consumed != inputLength || errno != 0 || inputLength == 0)
 int parseUnsignedInt(unsigned int *result, const char *input, int inputLength)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -304,6 +309,7 @@ int parseUnsignedDecimal(INT_TYPE *result, const char *input, int inputLength)
 /// Load, into the specificed `result`, the `Decimal64` value represented by
 /// the specified `input` string.  Return 0 on success and non-zero
 /// otherwise.
+// ensures: (__out == BAEXML_SUCCESS || __out == BAEXML_FAILURE)
 int parseDecimal64Impl(bdldfp::Decimal64  *result,
                        const char         *input,
                        bool                decimalMode)

--- a/groups/bal/balxml/balxml_typesprintutil.cpp
+++ b/groups/bal/balxml/balxml_typesprintutil.cpp
@@ -217,6 +217,7 @@ bsl::ostream& encodeBase64(bsl::ostream&  stream,
 /// character and `dataLength` is not -1 (neither one being allowed for XML
 /// 1.0), then return the address of the first byte of the offending UTF-8
 /// character in `data`.
+// ensures: (__out == 0) || (__out != 0 ==> (__out >= data && __out <= data + dataLength))
 const char *printTextReplacingXMLEscapes(
                                      bsl::ostream&                 stream,
                                      const char                   *data,

--- a/groups/bal/balxml/balxml_utf8readerwrapper.cpp
+++ b/groups/bal/balxml/balxml_utf8readerwrapper.cpp
@@ -49,6 +49,7 @@ namespace {
 namespace u {
 
 /// Return the specified `str` is `str != 0`, and "" otherwise.
+// ensures: (str != 0 ==> __out == str) && (str == 0 ==> __out == "")
 inline
 const char *nonNullStr(const char *str)
 {
@@ -66,6 +67,7 @@ namespace balxml {
                                 // ------------
 
 // PRIVATE MANIPULATORS
+// ensures: (__out == 0) || (__out != 0)
 inline
 int Utf8ReaderWrapper::doOpen(const char *url, const char *encoding)
 {
@@ -265,6 +267,7 @@ int Utf8ReaderWrapper::advanceToNextNode()
 }
 
 // ACCESSORS
+// ensures: __out != 0
 bslma::Allocator *Utf8ReaderWrapper::allocator() const
 {
     return d_errorInfo.source().get_allocator().mechanism();

--- a/groups/bal/balxml/balxml_util.cpp
+++ b/groups/bal/balxml/balxml_util.cpp
@@ -145,6 +145,7 @@ namespace balxml {
                                 // -----------
 
 // CLASS METHODS
+// ensures: (__out == true ==> (targetNamespace != nullptr && (*targetNamespace).size() > 0)) && (__out == false ==> true)
 bool Util::extractNamespaceFromXsd(const bsl::string_view&  xsdSource,
                                    bsl::string             *targetNamespace)
 {

--- a/groups/bbl/bblb/bblb_schedulegenerationutil.cpp
+++ b/groups/bbl/bblb/bblb_schedulegenerationutil.cpp
@@ -66,6 +66,7 @@ void computeSerialMonthAndDay(int               *serialMonth,
 /// of the `month in `year'.  The behavior is undefined unless
 /// `1 <= year <= 9999`, `1 <= month <= 12`, and the resulting date is a
 /// valid `bdlt::Date`.
+// ensures: (__out.year() == year) && (__out.month() == month) && (__out.day() == __out.day())
 inline
 bdlt::Date getDayOfMonth(int year, int month, int day, int dayOfFeb)
 {
@@ -86,6 +87,7 @@ bdlt::Date getDayOfMonth(int year, int month, int day, int dayOfFeb)
 /// by the ratio of the specified `numerator` and the specified
 /// `denominator`, without the use of floating-point calculations.  The
 /// behavior is undefined unless `denominator > 0`.
+// ensures: (numerator >= 0 || numerator % denominator == 0) ==> (__out == numerator / denominator) && (numerator < 0 && numerator % denominator != 0) ==> (__out == numerator / denominator - 1)
 inline
 int rationalFloor(int numerator, int denominator)
 {
@@ -100,6 +102,7 @@ int rationalFloor(int numerator, int denominator)
 /// by the ratio of the specified `numerator` and the specified
 /// `denominator`, without the use of floating-point calculations.  The
 /// behavior is undefined unless `denominator > 0`.
+// ensures: (numerator > 0 && numerator % denominator != 0) ==> __out == (numerator / denominator + 1) && (numerator <= 0 || numerator % denominator == 0) ==> __out == (numerator / denominator)
 inline
 int rationalCeiling(int numerator, int denominator)
 {
@@ -120,6 +123,7 @@ int rationalCeiling(int numerator, int denominator)
 /// serial month.  The behavior is undefined unless
 /// `k_MIN_SERIAL_MONTH <= exampleSerialMonth <= k_MAX_SERIAL_MONTH`, and
 /// `earliestSerialMonth <= latestSerialMonth`.
+// ensures: (__out == e_VALID_RANGE ==> ((*startSerialMonth ↦ startSerialMonthCandidate) ⋆ (*endSerialMonth ↦ endSerialMonthCandidate) ⋆ (startSerialMonthCandidate >= earliestSerialMonth) ⋆ (endSerialMonthCandidate <= latestSerialMonth))) && (__out == e_OUT_OF_RANGE ==> (startSerialMonthCandidate > u::k_MAX_SERIAL_MONTH || endSerialMonthCandidate < u::k_MIN_SERIAL_MONTH))
 int computeMonthRange(int *startSerialMonth,
                       int *endSerialMonth,
                       int  earliestSerialMonth,
@@ -197,6 +201,7 @@ int computeMonthRange(int *startSerialMonth,
 /// `k_MIN_SERIAL_MONTH <= *endSerialMonth <= k_MAX_SERIAL_MONTH`,
 /// `k_MIN_SERIAL_MONTH <= earliestSerialMonth <= k_MAX_SERIAL_MONTH`,
 /// `1 <= startDay <= 31`, and `1 <= endDay <= 31`.
+// ensures: (__out == e_VALID_RANGE ==> ((*startSerialMonth ↦ startSerialMonthCandidate) ⋆ (*endSerialMonth ↦ endSerialMonthCandidate))) && (__out == e_OUT_OF_RANGE ==> true)
 int adjustMonthRange(int *startSerialMonth,
                      int *endSerialMonth,
                      int  startDay,

--- a/groups/bbl/bbldc/bbldc_basicactual360.cpp
+++ b/groups/bbl/bbldc/bbldc_basicactual360.cpp
@@ -14,6 +14,7 @@ namespace bbldc {
                           // ---------------------
 
 // CLASS METHODS
+// ensures: __out == (endDate - beginDate) / 360.0
 double BasicActual360::yearsDiff(const bdlt::Date& beginDate,
                                  const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicactual36525.cpp
+++ b/groups/bbl/bbldc/bbldc_basicactual36525.cpp
@@ -14,6 +14,7 @@ namespace bbldc {
                          // -----------------------
 
 // CLASS METHODS
+// ensures: __out == ((endDate - beginDate) / 365.25)
 double BasicActual36525::yearsDiff(const bdlt::Date& beginDate,
                                    const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicactual365fixed.cpp
+++ b/groups/bbl/bbldc/bbldc_basicactual365fixed.cpp
@@ -14,6 +14,7 @@ namespace bbldc {
                         // --------------------------
 
 // CLASS METHODS
+// ensures: __out == ((endDate - beginDate) / 365.0)
 double BasicActual365Fixed::yearsDiff(const bdlt::Date& beginDate,
                                       const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicdaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_basicdaycountutil.cpp
@@ -28,6 +28,7 @@ namespace bbldc {
                          // ------------------------
 
 // CLASS METHODS
+// ensures: __out == numDays
 int BasicDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                 const bdlt::Date&        endDate,
                                 DayCountConvention::Enum convention)

--- a/groups/bbl/bbldc/bbldc_basicpsa30360eom.cpp
+++ b/groups/bbl/bbldc/bbldc_basicpsa30360eom.cpp
@@ -19,6 +19,7 @@ namespace bbldc {
 /// specified `year` is the last day of February for that `year`, and
 /// `false` otherwise.  The behavior is undefined unless `year`, `month`,
 /// and `day` represent a valid `bdlt::Date` value.
+// ensures: (__out == true ==> (month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year))))) && (__out == false ==> !(month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year)))))
 inline
 static bool isLastDayOfFebruary(int year, int month, int day)
 {
@@ -30,6 +31,7 @@ static bool isLastDayOfFebruary(int year, int month, int day)
 }
 
 /// Return the maximum of the specified `lhs` and `rhs` values.
+// ensures: (__out == lhs ==> lhs >= rhs) && (__out == rhs ==> rhs >= lhs)
 inline
 static int max(int lhs, int rhs)
 {

--- a/groups/bbl/bbldc/bbldc_basicsia30360eom.cpp
+++ b/groups/bbl/bbldc/bbldc_basicsia30360eom.cpp
@@ -19,6 +19,7 @@ namespace bbldc {
 /// specified `year` is the last day of February for that `year`, and
 /// `false` otherwise.  The behavior is undefined unless `year`, `month`,
 /// and `day` represent a valid `bdlt::Date` value.
+// ensures: (__out == true ==> (month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year))))) && (__out == false ==> !(month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year)))))
 inline
 static bool isLastDayOfFebruary(int year, int month, int day)
 {

--- a/groups/bbl/bbldc/bbldc_calendardaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_calendardaycountutil.cpp
@@ -19,6 +19,7 @@ namespace bbldc {
                        // ---------------------------
 
 // CLASS METHODS
+// ensures: (convention == DayCountConvention::e_CALENDAR_BUS_252 ==> __out == bbldc::CalendarBus252::daysDiff(beginDate, endDate, calendar)) && (convention != DayCountConvention::e_CALENDAR_BUS_252 ==> __out == 0)
 int CalendarDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                    const bdlt::Date&        endDate,
                                    const bdlt::Calendar&    calendar,

--- a/groups/bbl/bbldc/bbldc_daycountconvention.cpp
+++ b/groups/bbl/bbldc/bbldc_daycountconvention.cpp
@@ -16,6 +16,7 @@ namespace bbldc {
                         // -------------------------
 
 // CLASS METHODS
+// ensures: __out == &stream && (__out ↦ _)
 bsl::ostream& DayCountConvention::print(
                                        bsl::ostream&            stream,
                                        DayCountConvention::Enum value,

--- a/groups/bbl/bbldc/bbldc_perioddaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_perioddaycountutil.cpp
@@ -77,6 +77,7 @@ double PeriodDayCountUtil::yearsDiffImp(
 }
 
 // CLASS METHODS
+// ensures: (convention == DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == bbldc::PeriodIcmaActualActual::daysDiff(beginDate, endDate)) && (convention != DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == 0)
 int PeriodDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                  const bdlt::Date&        endDate,
                                  DayCountConvention::Enum convention)

--- a/groups/bbl/bbldc/bbldc_periodicmaactualactual.cpp
+++ b/groups/bbl/bbldc/bbldc_periodicmaactualactual.cpp
@@ -48,6 +48,7 @@ namespace bbldc {
                       // -----------------------------
 
 // CLASS METHODS
+// ensures: (beginDate == endDate ==> __out == 0.0) && (beginDate != endDate ==> __out != 0.0)
 double PeriodIcmaActualActual::yearsDiff(const bdlt::Date&  beginDate,
                                          const bdlt::Date&  endDate,
                                          const bdlt::Date  *periodDateBegin,

--- a/groups/bbl/bbldc/bbldc_terminateddaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_terminateddaycountutil.cpp
@@ -18,6 +18,7 @@ namespace bbldc {
                       // -----------------------------
 
 // CLASS METHODS
+// ensures: (convention == DayCountConvention::e_ISDA_30_360_EOM ==> __out == bbldc::TerminatedIsda30360Eom::daysDiff(beginDate, endDate, terminationDate)) && (convention != DayCountConvention::e_ISDA_30_360_EOM ==> __out == 0)
 int TerminatedDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                      const bdlt::Date&        endDate,
                                      const bdlt::Date&        terminationDate,

--- a/groups/bdl/bdlat/bdlat_attributeinfo.cpp
+++ b/groups/bdl/bdlat/bdlat_attributeinfo.cpp
@@ -13,6 +13,7 @@ namespace BloombergLP {
                          // --------------------------
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& operator<<(bsl::ostream&              stream,
                          const bdlat_AttributeInfo& attributeInfo)
 {

--- a/groups/bdl/bdlat/bdlat_enumeratorinfo.cpp
+++ b/groups/bdl/bdlat/bdlat_enumeratorinfo.cpp
@@ -13,6 +13,7 @@ namespace BloombergLP {
                         // ---------------------------
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& operator<<(bsl::ostream&               stream,
                          const bdlat_EnumeratorInfo& enumeratorInfo)
 {

--- a/groups/bdl/bdlat/bdlat_selectioninfo.cpp
+++ b/groups/bdl/bdlat/bdlat_selectioninfo.cpp
@@ -13,6 +13,7 @@ namespace BloombergLP {
                          // --------------------------
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& operator<<(bsl::ostream&              stream,
                          const bdlat_SelectionInfo& selectionInfo)
 {

--- a/groups/bdl/bdlb/bdlb_bigendian.cpp
+++ b/groups/bdl/bdlb/bdlb_bigendian.cpp
@@ -27,6 +27,7 @@ namespace bdlb {
                          // --------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (!stream.bad())
 bsl::ostream& BigEndianInt16::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const
@@ -55,6 +56,7 @@ bsl::ostream& BigEndianInt16::print(bsl::ostream& stream,
                          // ---------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (!stream.bad()) && (level > 0 ==> bdlb::Print::indent(stream, level, spacesPerLevel)) && (stream ↦ _)
 bsl::ostream& BigEndianUint16::print(bsl::ostream& stream,
                                      int           level,
                                      int           spacesPerLevel) const
@@ -80,6 +82,7 @@ bsl::ostream& BigEndianUint16::print(bsl::ostream& stream,
                          // --------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (!stream.bad()) && (__out ↦ _)
 bsl::ostream& BigEndianInt32::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const
@@ -108,6 +111,7 @@ bsl::ostream& BigEndianInt32::print(bsl::ostream& stream,
                          // ---------------------
 
 // ACCESSORS
+// ensures: (__out == &stream) && (!stream.bad()) && (__out ↦ _)
 bsl::ostream& BigEndianUint32::print(bsl::ostream& stream,
                                      int           level,
                                      int           spacesPerLevel) const
@@ -133,6 +137,7 @@ bsl::ostream& BigEndianUint32::print(bsl::ostream& stream,
                          // --------------------
 
 // ACCESSORS
+// ensures: (__out == &stream) && (!stream.bad()) && (__out ↦ _)
 bsl::ostream& BigEndianInt64::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const
@@ -162,6 +167,7 @@ bsl::ostream& BigEndianInt64::print(bsl::ostream& stream,
                          // ---------------------
 
 // ACCESSORS
+// ensures: __out == &stream && (__out ↦ _)
 bsl::ostream& BigEndianUint64::print(bsl::ostream& stream,
                                      int           level,
                                      int           spacesPerLevel) const

--- a/groups/bdl/bdlb/bdlb_bitstringutil.cpp
+++ b/groups/bdl/bdlb/bdlb_bitstringutil.cpp
@@ -123,6 +123,7 @@ BSLMF_ASSERT(0 == (k_BITS_PER_UINT64 & (k_BITS_PER_UINT64 - 1))); // power of 2
 /// cast to is `unsigned int`, not `int`, since the `int` could wind up
 /// negative, in which case the `%` operation could return a negative
 /// result.
+// ensures: __out == static_cast<unsigned int>(value)
 static inline
 unsigned int u32(uint64_t value)
 {
@@ -232,6 +233,7 @@ BitPtrDiff::BitPtrDiff(IntPtr hi, unsigned lo)
 }
 
 // ACCESSOR
+// ensures: (__out.d_hi ↦ ~old_d_hi + (__out.d_lo & k_UNUSED_LO_MASK != 0)) ⋆ (__out.d_lo ↦ (k_USED_LO_MASK & ~old_d_lo) + 1 - (k_BITS_PER_UINT64 * (__out.d_lo & k_UNUSED_LO_MASK != 0)))
 inline
 BitPtrDiff BitPtrDiff::operator-() const
 {
@@ -260,6 +262,7 @@ BitPtrDiff BitPtrDiff::operator-() const
 
 /// Return `true` if the specified `lhs` is greater than the specified
 /// `rhs`, and `false` otherwise.
+// ensures: (__out == true ==> (lhs.d_hi > rhs.d_hi || (lhs.d_hi == rhs.d_hi && lhs.d_lo > rhs.d_lo))) && (__out == false ==> !(lhs.d_hi > rhs.d_hi || (lhs.d_hi == rhs.d_hi && lhs.d_lo > rhs.d_lo)))
 inline
 bool operator>(const BitPtrDiff& lhs, const BitPtrDiff& rhs)
 {
@@ -415,6 +418,7 @@ BitPtr::BitPtr(const uint64_t *ptr, size_t index)
 
 /// Return a `BitPtrDiff` representing the distance in bits between the
 /// specified `lhs` and `rhs`.
+// ensures: (__out.d_hi == lhs.d_hi - rhs.d_hi - (__out.d_lo < (lhs.d_lo - rhs.d_lo))) && (__out.d_lo == (lhs.d_lo - rhs.d_lo) + (__out.d_lo < (lhs.d_lo - rhs.d_lo) ? k_BITS_PER_UINT64 : 0))
 inline
 BitPtrDiff operator-(const BitPtr& lhs, const BitPtr& rhs)
 {
@@ -889,6 +893,7 @@ void Mover<OPER_DO_BITS, OPER_DO_ALIGNED_WORD>::move(
 /// `0 <= numBits < k_BITS_PER_UINT64`.  Note that this function performs
 /// the same calculation as `BitMaskUtil::lt64`, except that it doesn't
 /// waste time handling the case of `k_BITS_PER_UINT64 == numBits`.
+// ensures: (__out == ((1ULL << numBits) - 1)) && (0 <= numBits) && (numBits < 64)
 static inline
 uint64_t lt64Raw(int numBits)
 {
@@ -903,6 +908,7 @@ uint64_t lt64Raw(int numBits)
 /// `0 <= numBits < k_BITS_PER_UINT64`.  Note that this function performs
 /// the same calculation as `BitMaskUtil::ge64`, except that it doesn't
 /// waste time handling the case of `k_BITS_PER_UINT64 == numBits`.
+// ensures: (__out == (~0ULL << numBits)) && (0 <= numBits) && (numBits < 64)
 static inline
 uint64_t ge64Raw(int numBits)
 {
@@ -933,6 +939,7 @@ TYPE absRaw(TYPE x)
 /// `pos1 + numBits <= k_BITS_PER_UINT64`, and
 /// `pos2 + numBits <= k_BITS_PER_UINT64`.  Note that this function does not
 /// handle the case of `0 == numBits`.
+// ensures: (__out == true ==> (((word1 >> pos1) ^ (word2 >> pos2)) & BitMaskUtil::lt64(numBits)) != 0) && (__out == false ==> (((word1 >> pos1) ^ (word2 >> pos2)) & BitMaskUtil::lt64(numBits)) == 0)
 static inline
 bool bitsInWordsDiffer(uint64_t word1,
                        int      pos1,
@@ -1022,6 +1029,7 @@ void putSpaces(bsl::ostream& stream, int numSpaces)
 /// Output indentation to the specified `stream` that is appropriate
 /// according to BDE printing conventions for the specified `level` and
 /// the specified `spacesPerLevel`.
+// ensures: __out == stream
 static
 bsl::ostream& indent(bsl::ostream& stream,
                      int           level,
@@ -1037,6 +1045,7 @@ bsl::ostream& indent(bsl::ostream& stream,
 
 /// Output a newline and indentation to the specified `stream` appropriate
 /// for the specified `level` and the specified `spacesPerLevel`.
+// ensures: __out == stream
 static
 bsl::ostream& newlineAndIndent(bsl::ostream& stream,
                                int           level,

--- a/groups/bdl/bdlb/bdlb_doublecompareutil.cpp
+++ b/groups/bdl/bdlb/bdlb_doublecompareutil.cpp
@@ -15,6 +15,7 @@ const double DoubleCompareUtil::k_DEFAULT_RELATIVE_TOLERANCE = 1e-12;
 const double DoubleCompareUtil::k_DEFAULT_ABSOLUTE_TOLERANCE = 1e-24;
 
 /// Return the absolute value of the specified `input`.
+// ensures: __out == std::abs(input) && (input >= 0.0 ==> __out == input) && (input < 0.0 ==> __out == -input)
 static inline
 double fabsval(double input)
 {
@@ -26,6 +27,7 @@ double fabsval(double input)
                      // ------------------------------
 
 // CLASS METHODS
+// ensures: __out == BloombergLP::bdlb::DoubleCompareUtil::e_NON_COMPARABLE || __out == BloombergLP::bdlb::DoubleCompareUtil::e_EQUAL || __out == BloombergLP::bdlb::DoubleCompareUtil::e_LESS_THAN || __out == BloombergLP::bdlb::DoubleCompareUtil::e_GREATER_THAN
 DoubleCompareUtil::CompareResult
 DoubleCompareUtil::fuzzyCompare(double a,
                                 double b,

--- a/groups/bdl/bdlb/bdlb_float.cpp
+++ b/groups/bdl/bdlb/bdlb_float.cpp
@@ -58,6 +58,7 @@ namespace {
 /// Using `bsl::memcpy` is the only portable way to copy the contents of
 /// `number` into an integral type without aliasing and/or alignment
 /// problems.
+// ensures: __out == *reinterpret_cast<FloatRep_t*>(&number)
 inline
 FloatRep_t toRep(float number)
 {
@@ -67,6 +68,7 @@ FloatRep_t toRep(float number)
 }
 
 /// Implementation of `bdlb::Float::classify(float number)`.
+// ensures: (numberExp == 0 && (number & floatManMask) != 0 ==> __out == bdlb::Float::k_SUBNORMAL) && (numberExp == 0 && (number & floatManMask) == 0 ==> __out == bdlb::Float::k_ZERO) && (numberExp == floatExpMask && (number & floatManMask) != 0 ==> __out == bdlb::Float::k_NAN) && (numberExp == floatExpMask && (number & floatManMask) == 0 ==> __out == bdlb::Float::k_INFINITE) && (numberExp != 0 && numberExp != floatExpMask ==> __out == bdlb::Float::k_NORMAL)
 inline
 bdlb::Float::Classification classifyImp(FloatRep_t number)
 {
@@ -202,6 +204,7 @@ namespace {
 /// Using `bsl::memcpy` is the only portable way to copy the contents of
 /// `number` into an integral type without aliasing and/or alignment
 /// problems.
+// ensures: __out == *reinterpret_cast<DoubleRep_t*>(&number)
 inline
 DoubleRep_t toRep(double number)
 {
@@ -212,6 +215,7 @@ DoubleRep_t toRep(double number)
 }
 
 /// Implementation of `bdlb::Float::classify(double number)`.
+// ensures: (numberExp == 0 && (number & doubleManMask) != 0 ==> __out == bdlb::Float::k_SUBNORMAL) && (numberExp == 0 && (number & doubleManMask) == 0 ==> __out == bdlb::Float::k_ZERO) && (numberExp == doubleExpMask && (number & doubleManMask) != 0 ==> __out == bdlb::Float::k_NAN) && (numberExp == doubleExpMask && (number & doubleManMask) == 0 ==> __out == bdlb::Float::k_INFINITE) && (numberExp != 0 && numberExp != doubleExpMask ==> __out == bdlb::Float::k_NORMAL)
 inline
 bdlb::Float::Classification classifyImp(DoubleRep_t number)
 {

--- a/groups/bdl/bdlb/bdlb_guid.cpp
+++ b/groups/bdl/bdlb/bdlb_guid.cpp
@@ -57,6 +57,7 @@ void hex16sse(void *dst, const unsigned char *src)
 
 #else
 
+// ensures: (x >= 0 && x <= 15) ==> __out == "0123456789abcdef"[x]
 char hex1(unsigned x)
     // Return the equivalent hex ASCII character for the nibble specified in
     // 'x'.
@@ -142,6 +143,7 @@ bsl::ostream& Guid::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> bsl::memcmp(&lhs[0], &rhs[0], bdlb::Guid::k_GUID_NUM_BYTES) < 0) && (__out == false ==> bsl::memcmp(&lhs[0], &rhs[0], bdlb::Guid::k_GUID_NUM_BYTES) >= 0)
 bool bdlb::operator<(const bdlb::Guid& lhs, const bdlb::Guid& rhs)
 {
     return bsl::memcmp(&lhs[0], &rhs[0], bdlb::Guid::k_GUID_NUM_BYTES) < 0;

--- a/groups/bdl/bdlb/bdlb_numericparseutil.cpp
+++ b/groups/bdl/bdlb/bdlb_numericparseutil.cpp
@@ -83,6 +83,7 @@ typedef bsls::Types::Uint64 Uint64;
 /// Return a string reference to the characters of the specified
 /// `positiveNum` that do not contain the optionally present first `+`
 /// ASCII character.  The behavior is undefined if `positiveNum.empty()`.
+// ensures: (__out == positiveNum.substr(1) ==> positiveNum[0] == '+') && (__out == positiveNum ==> positiveNum[0] != '+')
 static
 inline
 bsl::string_view stripOptionalPlus(const bsl::string_view& positiveNum)
@@ -135,6 +136,7 @@ double reparseOutOfRange(const char              **restPtr,
 #else   // end - using 'double' 'from_chars' / begin - using 'strtod'
 
                               // Portability
+// ensures: (__out == true ==> bsl::isinf(number)) && (__out == false ==> !bsl::isinf(number))
 static
 bool isInf(double number)
     // Return 'true' if the specified 'number' is a positive or negative
@@ -161,6 +163,7 @@ bool isInf(double number)
 }
 
 #ifdef BDLB_NUMERICPARSEUTIL_STRTOD_PARSES_HEXFLOAT
+// ensures: (__out == true ==> (stdlibInput.substr(0, 2) == "0x" || stdlibInput.substr(0, 2) == "0X")) && (__out == false ==> (stdlibInput.substr(0, 2) != "0x" && stdlibInput.substr(0, 2) != "0X"))
 static
 bool hasHexPrefix(const bsl::string_view& stdlibInput)
     // Return 'true' if the first two characters of the specified 'stdlibInput'
@@ -185,6 +188,7 @@ namespace bdlb {
                         // struct NumericParseUtil
                         // -----------------------
 // CLASS METHODS
+// ensures: (__out >= 0 ==> (Ct::isDigit(character) && __out == character - '0') || (Ct::isAlpha(character) && __out == Ct::toLower(character) - ('a' - 10))) && (__out == -1 ==> !(Ct::isDigit(character) || Ct::isAlpha(character)) || (Ct::isDigit(character) && character - '0' >= base) || (Ct::isAlpha(character) && Ct::toLower(character) - ('a' - 10) >= base))
 int NumericParseUtil::characterToDigit(char character, int base)
 {
     BSLS_ASSERT_SAFE(2 <= base);

--- a/groups/bdl/bdlb/bdlb_print.cpp
+++ b/groups/bdl/bdlb/bdlb_print.cpp
@@ -362,6 +362,7 @@ namespace bdlb {
                              // ------------
 
 // CLASS METHODS
+// ensures: __out == stream
 bsl::ostream& Print::indent(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel)

--- a/groups/bdl/bdlb/bdlb_randomdevice.cpp
+++ b/groups/bdl/bdlb/bdlb_randomdevice.cpp
@@ -82,6 +82,7 @@ namespace bdlb {
                         // ------------------------
 
 // CLASS METHODS
+// ensures: (numBytes == 0 ==> __out == 0) && (numBytes != 0 ==> (__out == 0 ⋆ SEPFORALL(0, numBytes, i, (buffer + i ↦ _))))
 int RandomDevice::getRandomBytes(unsigned char *buffer, size_t numBytes)
 {
     if (0 == numBytes) {

--- a/groups/bdl/bdlb/bdlb_string.cpp
+++ b/groups/bdl/bdlb/bdlb_string.cpp
@@ -15,6 +15,7 @@ namespace bdlb {
                                // -------------
 
 // CLASS METHODS
+// ensures: (__out == true ==> SEPFORALL(0, strlen(lhsString), i, (bdlb::CharType::toLower(lhsString[i]) == bdlb::CharType::toLower(rhsString[i])))) && (__out == false ==> SEPEXISTS(0, strlen(lhsString), i, (bdlb::CharType::toLower(lhsString[i]) != bdlb::CharType::toLower(rhsString[i]))) || (strlen(lhsString) != strlen(rhsString)))
 bool String::areEqualCaseless(const char *lhsString,
                               const char *rhsString)
 {

--- a/groups/bdl/bdlb/bdlb_stringrefutil.cpp
+++ b/groups/bdl/bdlb/bdlb_stringrefutil.cpp
@@ -13,6 +13,7 @@ namespace bdlb {
 /// case character, and return `ch` otherwise; the sequence of characters
 /// `[A .. Z]` is mapped to `[a .. z]`.  The behavior is undefined unless
 /// characters are ASCII encoded.
+// ensures: (('A' <= ch && ch <= 'Z') ==> (__out == (ch | 0x20))) && (!(('A' <= ch && ch <= 'Z')) ==> (__out == ch))
 static inline int u_upperToLower(int ch)
 {
     return 'A' <= ch && ch <= 'Z'
@@ -24,6 +25,7 @@ static inline int u_upperToLower(int ch)
 /// case character, and return `ch` otherwise; the sequence of characters
 /// `[a .. z]` is mapped to `[A .. Z]`.  The behavior is undefined unless
 /// characters are ASCII encoded.
+// ensures: (('a' <= ch && ch <= 'z') ==> (__out == (ch & ~0x20))) && (!(('a' <= ch && ch <= 'z')) ==> (__out == ch))
 static inline int u_lowerToUpper(int ch)
 {
     return 'a' <= ch && ch <= 'z'
@@ -33,6 +35,7 @@ static inline int u_lowerToUpper(int ch)
 
 /// Return `true` is the specified `ch` is one of the ASCII whitespace
 /// characters in the "C" and "POSIX" locales, and `false` otherwise.
+// ensures: (__out == true ==> (ch == 32 || (ch >= 9 && ch <= 13))) && (__out == false ==> (ch != 32 && (ch < 9 || ch > 13)))
 static inline bool u_isWhitespace(unsigned char ch)
 {
     if (' ' == ch) {

--- a/groups/bdl/bdlb/bdlb_stringviewutil.cpp
+++ b/groups/bdl/bdlb/bdlb_stringviewutil.cpp
@@ -11,6 +11,7 @@ namespace bdlb {
 
 /// Return `true` is the specified `ch` is one of the ASCII whitespace
 /// characters in the "C" and "POSIX" locales, and `false` otherwise.
+// ensures: (__out == true ==> (ch == 32 || (ch >= 9 && ch <= 13))) && (__out == false ==> (ch != 32 && (ch < 9 || ch > 13)))
 static inline bool u_isWhitespace(unsigned char ch)
 {
     if (' ' == ch) {

--- a/groups/bdl/bdlb/bdlb_tokenizer.cpp
+++ b/groups/bdl/bdlb/bdlb_tokenizer.cpp
@@ -152,6 +152,7 @@ TokenizerIterator::TokenizerIterator(const TokenizerIterator& origin)
 }
 
 // MANIPULATORS
+// ensures: (__out == *this) && (this != &rhs ==> (d_sharedData_p == rhs.d_sharedData_p ⋆ d_cursor_p == rhs.d_cursor_p ⋆ d_token_p == rhs.d_token_p ⋆ d_postDelim_p == rhs.d_postDelim_p ⋆ d_end_p == rhs.d_end_p ⋆ d_endFlag == rhs.d_endFlag))
 TokenizerIterator& TokenizerIterator::operator=(const TokenizerIterator& rhs)
 {
     if (this != &rhs)
@@ -314,6 +315,7 @@ Tokenizer::~Tokenizer()
 }
 
 // MANIPULATORS
+// ensures: &__out == this
 Tokenizer& Tokenizer::operator++()
 {
     // Operator++ called on invalid tokenizer

--- a/groups/bdl/bdlbb/bdlbb_blob.cpp
+++ b/groups/bdl/bdlbb/bdlbb_blob.cpp
@@ -37,6 +37,7 @@ namespace bdlbb {
                               // ================
 
 // MANIPULATORS
+// ensures: (__out.d_buffer ↦ rhs.d_buffer) ⋆ (__out.d_size ↦ rhs.d_size)
 BlobBuffer& BlobBuffer::operator=(const BlobBuffer& rhs)
 {
     d_buffer = rhs.d_buffer;
@@ -97,6 +98,7 @@ BlobBuffer BlobBuffer::trim(int toSize)
 }
 
 // ACCESSORS
+// ensures: __out == stream
 bsl::ostream& BlobBuffer::print(bsl::ostream& stream, int, int) const
 {
     bdlb::Print::hexDump(stream, d_buffer.get(), d_size);
@@ -105,6 +107,7 @@ bsl::ostream& BlobBuffer::print(bsl::ostream& stream, int, int) const
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& bdlbb::operator<<(bsl::ostream& stream, const BlobBuffer& buffer)
 {
     return buffer.print(stream, 0, -1);
@@ -134,6 +137,7 @@ BlobBufferFactory::~BlobBufferFactory()
                                  // ==========
 
 // PRIVATE ACCESSORS
+// ensures: __out == 0
 int Blob::assertInvariants() const
 {
     BSLS_ASSERT(0 <= d_totalSize);
@@ -761,6 +765,7 @@ void Blob::moveAndAppendDataBuffers(Blob *srcBlob)
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.d_buffers == rhs.d_buffers && lhs.d_totalSize == rhs.d_totalSize && lhs.d_dataLength == rhs.d_dataLength && lhs.d_dataIndex == rhs.d_dataIndex && lhs.d_preDataIndexLength == rhs.d_preDataIndexLength)) && (__out == false ==> !(lhs.d_buffers == rhs.d_buffers && lhs.d_totalSize == rhs.d_totalSize && lhs.d_dataLength == rhs.d_dataLength && lhs.d_dataIndex == rhs.d_dataIndex && lhs.d_preDataIndexLength == rhs.d_preDataIndexLength))
 bool bdlbb::operator==(const Blob& lhs, const Blob& rhs)
 {
     return lhs.d_buffers == rhs.d_buffers &&

--- a/groups/bdl/bdlbb/bdlbb_blobstreambuf.cpp
+++ b/groups/bdl/bdlbb/bdlbb_blobstreambuf.cpp
@@ -100,6 +100,7 @@ void InBlobStreamBuf::setGetPosition(bsl::size_t position)
 }
 
 // PRIVATE ACCESSORS
+// ensures: __out == 0
 int InBlobStreamBuf::checkInvariant() const
 {
     bsl::size_t numBuffers = d_blob_p->numBuffers();
@@ -125,6 +126,7 @@ int InBlobStreamBuf::checkInvariant() const
 }
 
 // PROTECTED MANIPULATORS
+// ensures: __out == traits_type::eof()
 InBlobStreamBuf::int_type InBlobStreamBuf::overflow(InBlobStreamBuf::int_type)
 {
     return traits_type::eof();
@@ -405,6 +407,7 @@ void OutBlobStreamBuf::setPutPosition(bsl::size_t position)
 }
 
 // PRIVATE ACCESSORS
+// ensures: __out == 0
 int OutBlobStreamBuf::checkInvariant() const
 {
     bsl::size_t numBuffers = d_blob_p->numBuffers();
@@ -431,6 +434,7 @@ int OutBlobStreamBuf::checkInvariant() const
 }
 
 // PROTECTED MANIPULATORS
+// ensures: (__out == c) && (c != EOF) || (__out == traits_type::not_eof(c) && c == EOF)
 OutBlobStreamBuf::int_type OutBlobStreamBuf::overflow(
                                                   OutBlobStreamBuf::int_type c)
 {

--- a/groups/bdl/bdlbb/bdlbb_blobutil.cpp
+++ b/groups/bdl/bdlbb/bdlbb_blobutil.cpp
@@ -60,6 +60,7 @@ void copyFromPlace(char                *dstBuffer,
 /// `stream`.  The behavior is undefined unless `0 <= bufferIndex`,
 /// `0 <= numBytes`, and the incrementing `bufferIndex` does not reach the
 /// number of data buffers.
+// ensures: (__out == &stream) && (__out != 0)
 bsl::ostream& asciiDumpFromBufferStart(bsl::ostream&      stream,
                                        const bdlbb::Blob& source,
                                        int                bufferIndex,

--- a/groups/bdl/bdlbb/bdlbb_simpleblobbufferfactory.cpp
+++ b/groups/bdl/bdlbb/bdlbb_simpleblobbufferfactory.cpp
@@ -45,6 +45,7 @@ void SimpleBlobBufferFactory::setBufferSize(int bufferSize)
 }
 
 // ACCESSORS
+// ensures: __out == d_size
 int SimpleBlobBufferFactory::bufferSize() const
 {
     return d_size;

--- a/groups/bdl/bdlc/bdlc_bitarray.cpp
+++ b/groups/bdl/bdlc/bdlc_bitarray.cpp
@@ -28,6 +28,7 @@ namespace bdlc {
 /// behavior is undefined unless `0 <= numBits < k_BITS_PER_UINT64`.  Note
 /// that this is a faster version of `bdlb::BitMaskUtil::lt64` with a
 /// narrower contract.
+// ensures: __out == ((static_cast<uint64_t>(1) << numBits) - 1)
 static inline
 uint64_t rawLt64(int numBits)
 {

--- a/groups/bdl/bdlc/bdlc_hashtable.cpp
+++ b/groups/bdl/bdlc/bdlc_hashtable.cpp
@@ -287,6 +287,7 @@ const int           HashTable_ImpUtil::NUM_PRIME_NUMBERS
                                                        = NUM_PRIME_NUMBERS_IMP;
 
 // CLASS METHODS
+// ensures: __out == *bsl::lower_bound(PRIME_NUMBERS, PRIME_NUMBERS + NUM_PRIME_NUMBERS, std::abs(hint)) || (__out == *(bsl::lower_bound(PRIME_NUMBERS, PRIME_NUMBERS + NUM_PRIME_NUMBERS, std::abs(hint)) - 1))
 unsigned int HashTable_ImpUtil::hashSize(bsls::Types::Int64 hint)
 {
     BSLS_ASSERT(0 != hint);

--- a/groups/bdl/bdlc/bdlc_indexclerk.cpp
+++ b/groups/bdl/bdlc/bdlc_indexclerk.cpp
@@ -31,6 +31,7 @@ namespace bdlc {
                               // ----------------
 
 // PRIVATE ACCESSORS
+// ensures: (__out == true) == (!(indicesInvalid || (indicesNotUnique & 0x2)))
 bool
 IndexClerk::areInvariantsPreserved(const bsl::vector<int>& unusedStack,
                                    int                     nextNewIndex)
@@ -60,6 +61,7 @@ IndexClerk::areInvariantsPreserved(const bsl::vector<int>& unusedStack,
 }
 
 // ACCESSORS
+// ensures: (__out == false ==> EXISTS(0, d_unusedStack.size(), i, d_unusedStack[i] == index)) && (__out == true ==> FORALL(0, d_unusedStack.size(), i, d_unusedStack[i] != index))
 bool IndexClerk::isInUse(int index) const
 {
     BSLS_ASSERT((unsigned int) index < (unsigned int)d_nextNewIndex);

--- a/groups/bdl/bdlcc/bdlcc_fixedqueueindexmanager.cpp
+++ b/groups/bdl/bdlcc/bdlcc_fixedqueueindexmanager.cpp
@@ -227,6 +227,7 @@ static const unsigned int k_NUM_REPRESENTABLE_COMBINED_INDICES =
 /// Return an encoded state value comprising the specified `generation` and
 /// the specified `indexState`.  Note that the resulting encoded value is
 /// appropriate for storage in the `d_states` array.
+// ensures: __out == ((generation << k_GENERATION_COUNT_SHIFT) | indexState)
 inline
 static unsigned int encodeElementState(unsigned int generation,
                                        ElementState indexState)
@@ -238,6 +239,7 @@ static unsigned int encodeElementState(unsigned int generation,
 /// behavior is undefined unless `value` was encoded by
 /// `encodeElementState`.  Note that `encodedState` is typically obtained
 /// from the `d_states` array.
+// ensures: __out == (encodedState >> k_GENERATION_COUNT_SHIFT)
 inline
 static unsigned int decodeGenerationFromElementState(unsigned int encodedState)
 {
@@ -248,6 +250,7 @@ static unsigned int decodeGenerationFromElementState(unsigned int encodedState)
 /// is undefined unless `encodedState` was encoded by `encodeElementState`.
 /// Note that `encodedState` is typically obtained from the `d_states`
 /// array.
+// ensures: __out == ElementState(encodedState & k_ELEMENT_STATE_MASK)
 inline
 static ElementState decodeStateFromElementState(unsigned int encodedState)
 {
@@ -261,6 +264,7 @@ static ElementState decodeStateFromElementState(unsigned int encodedState)
 
 /// Return `true` if the specified `encodedPushIndex` has the disabled flag
 /// set, and 'false otherwise.
+// ensures: (__out == true ==> (encodedPushIndex & k_DISABLED_STATE_MASK)) && (__out == false ==> !(encodedPushIndex & k_DISABLED_STATE_MASK))
 inline
 static bool isDisabledFlagSet(unsigned int encodedPushIndex)
 {
@@ -269,6 +273,7 @@ static bool isDisabledFlagSet(unsigned int encodedPushIndex)
 
 /// Return the push-index of the specified `encodedPushIndex`, discarding
 /// the disabled flag.
+// ensures: __out == (encodedPushIndex & ~k_DISABLED_STATE_MASK)
 inline
 static unsigned int discardDisabledFlag(unsigned int encodedPushIndex)
 {
@@ -780,6 +785,7 @@ void FixedQueueIndexManager::abortPushIndexReservation(unsigned int generation,
 }
 
 // ACCESSORS
+// ensures: (__out == 0) || (__out > 0 ==> (__out <= d_capacity))
 bsl::size_t FixedQueueIndexManager::length() const
 {
     // Note that 'FixedQueue::pushBack' and 'FixedQueue::popFront' rely on the

--- a/groups/bdl/bdld/bdld_datum.cpp
+++ b/groups/bdl/bdld/bdld_datum.cpp
@@ -1437,6 +1437,7 @@ bsl::ostream& Datum::print(bsl::ostream& stream,
                          // -------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (__out.good() || __out.bad())
 bsl::ostream& DatumArrayRef::print(bsl::ostream& stream,
                                    int           level,
                                    int           spacesPerLevel) const
@@ -1462,6 +1463,7 @@ bsl::ostream& DatumArrayRef::print(bsl::ostream& stream,
                           // ----------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (__out.bad() ==> stream.bad()) && (__out.good() ==> stream.good()) && (__out != stream ==> (__out ↦ _ ⋆ stream ↦ _))
 bsl::ostream& DatumIntMapEntry::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const
@@ -1487,6 +1489,7 @@ bsl::ostream& DatumIntMapEntry::print(bsl::ostream& stream,
                             // -------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (stream.bad() ==> __out.bad()) && (stream.good() ==> __out.good()) && (__out->stream_state ↦ stream->stream_state ⋆ __out->buffer ↦ stream->buffer) && (__out->buffer ↦ bsl::flush)
 bsl::ostream& DatumMapEntry::print(bsl::ostream& stream,
                                    int           level,
                                    int           spacesPerLevel) const
@@ -1508,6 +1511,7 @@ bsl::ostream& DatumMapEntry::print(bsl::ostream& stream,
                           // class DatumMapRef
                           // -----------------
 // ACCESSORS
+// ensures: (__out == 0 ==> !findElementBinary(key, *this) && !findElementLinear(key, *this)) && (__out != 0 ==> true)
 const Datum *DatumIntMapRef::find(int key) const
 {
     return d_sorted ? findElementBinary(key, *this) :

--- a/groups/bdl/bdld/bdld_datumarraybuilder.cpp
+++ b/groups/bdl/bdld/bdld_datumarraybuilder.cpp
@@ -22,6 +22,7 @@ typedef DatumArrayBuilder::allocator_type allocator_type;
 
 /// Calculate the new capacity needed to accommodate data having the
 /// specified `length` for the datum array having the specified `capacity`.
+// ensures: __out >= length
 static DatumArrayBuilder::SizeType getNewCapacity(
                                           DatumArrayBuilder::SizeType capacity,
                                           DatumArrayBuilder::SizeType length)

--- a/groups/bdl/bdld/bdld_datumbinaryref.cpp
+++ b/groups/bdl/bdld/bdld_datumbinaryref.cpp
@@ -16,6 +16,7 @@ namespace bdld {
                         // --------------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (__out.good() || __out.bad())
 bsl::ostream& DatumBinaryRef::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const

--- a/groups/bdl/bdld/bdld_datumerror.cpp
+++ b/groups/bdl/bdld/bdld_datumerror.cpp
@@ -16,6 +16,7 @@ namespace bdld {
                         // ----------------
 
 // ACCESSORS
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& DatumError::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bdl/bdld/bdld_datumintmapbuilder.cpp
+++ b/groups/bdl/bdld/bdld_datumintmapbuilder.cpp
@@ -25,6 +25,7 @@ typedef DatumIntMapBuilder::allocator_type allocator_type;
 
 /// Calculate the new capacity needed to accommodate data having the
 /// specified `size` for the datum int-map having the specified `capacity`.
+// ensures: __out >= size && (capacity != 0 ==> __out >= capacity) && FORALL(0, __out, i, i < size ==> i < __out)
 static DatumIntMapBuilder::SizeType getNewCapacity(
                                          DatumIntMapBuilder::SizeType capacity,
                                          DatumIntMapBuilder::SizeType size)
@@ -75,6 +76,7 @@ static bool compareGreater(const DatumIntMapEntry& lhs,
 
 /// Return `true` if key in the specified `lhs` is less than key in the
 /// specified `rhs` and `false` otherwise.
+// ensures: (__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())
 static bool compareLess(const DatumIntMapEntry& lhs,
                         const DatumIntMapEntry& rhs)
 {

--- a/groups/bdl/bdld/bdld_datummaker.cpp
+++ b/groups/bdl/bdld/bdld_datummaker.cpp
@@ -29,6 +29,7 @@ namespace bdld {
                               // ----------------
 
 // ACCESSORS
+// ensures: (__out == bdld::Datum::adoptMap(map)) && SEPFORALL(0, size, i, (map.data() + i ↦ elements[i])) && (*map.size() == size) && (*map.sorted() == sorted)
 bdld::Datum DatumMaker::operator()(const bdld::DatumMapEntry *elements,
                                    int                        size,
                                    bool                       sorted) const

--- a/groups/bdl/bdld/bdld_datummapbuilder.cpp
+++ b/groups/bdl/bdld/bdld_datummapbuilder.cpp
@@ -26,6 +26,7 @@ typedef DatumMapBuilder::allocator_type allocator_type;
 
 /// Calculate the new capacity needed to accommodate data having the
 /// specified `size` for the datum map having the specified `capacity`.
+// ensures: __out >= size && (capacity != 0 ==> __out >= capacity) && FORALL(0, __out, i, i < size ==> i < __out)
 static DatumMapBuilder::SizeType getNewCapacity(
                                             DatumMapBuilder::SizeType capacity,
                                             DatumMapBuilder::SizeType size)

--- a/groups/bdl/bdld/bdld_datummapowningkeysbuilder.cpp
+++ b/groups/bdl/bdld/bdld_datummapowningkeysbuilder.cpp
@@ -25,6 +25,7 @@ namespace {
 /// Calculate the new capacity needed to accommodate data/keys having the
 /// specified `size` for the datum-key-owning map having the specified
 /// `capacity` as its capacity/`keys-capacity`.
+// ensures: __out >= size && __out != 0
 static DatumMapOwningKeysBuilder::SizeType getNewCapacity(
                                   DatumMapOwningKeysBuilder::SizeType capacity,
                                   DatumMapOwningKeysBuilder::SizeType size)
@@ -80,6 +81,7 @@ static bool compareGreater(const DatumMapEntry& lhs, const DatumMapEntry& rhs)
 
 /// Return `true` if key in the specified `lhs` is less than key in the
 /// specified `rhs` and `false` otherwise.
+// ensures: (__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())
 static bool compareLess(const DatumMapEntry& lhs, const DatumMapEntry& rhs)
 {
     return lhs.key() < rhs.key();

--- a/groups/bdl/bdld/bdld_datumudt.cpp
+++ b/groups/bdl/bdld/bdld_datumudt.cpp
@@ -16,6 +16,7 @@ namespace bdld {
                         // --------------
 
 // ACCESSORS
+// ensures: (__out == &stream) && (__out != nullptr)
 bsl::ostream& DatumUdt::print(bsl::ostream& stream,
                               int           level,
                               int           spacesPerLevel) const

--- a/groups/bdl/bdlde/bdlde_base64alphabet.cpp
+++ b/groups/bdl/bdlde/bdlde_base64alphabet.cpp
@@ -16,6 +16,7 @@ namespace bdlde {
                           // ---------------------
 
 // CLASS METHODS
+// ensures: (__out == &stream) && (!stream.bad()) && (__out ↦ _)
 bsl::ostream& Base64Alphabet::print(bsl::ostream&        stream,
                                     Base64Alphabet::Enum value,
                                     int                  level,
@@ -48,6 +49,7 @@ const char *Base64Alphabet::toAscii(Base64Alphabet::Enum value)
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == &stream && __out != nullptr
 bsl::ostream& bdlde::operator<<(bsl::ostream&               stream,
                                 bdlde::Base64Alphabet::Enum value)
 {

--- a/groups/bdl/bdlde/bdlde_base64decoderoptions.cpp
+++ b/groups/bdl/bdlde/bdlde_base64decoderoptions.cpp
@@ -16,6 +16,7 @@ namespace bdlde {
                             // --------------------
 
 // ACCESSORS
+// ensures: __out == stream ⋆ (stream ↦ _)
 bsl::ostream& Base64DecoderOptions::print(bsl::ostream& stream,
                                           int           level,
                                           int           spacesPerLevel) const
@@ -37,6 +38,7 @@ bsl::ostream& Base64DecoderOptions::print(bsl::ostream& stream,
 // inline in anticipation of their being rarely used.
 
 // FREE FUNCTIONS
+// ensures: (__out == true) ==> (lhs.ignoreMode() == rhs.ignoreMode() && lhs.alphabet() == rhs.alphabet() && lhs.isPadded() == rhs.isPadded()) && (__out == false) ==> !(lhs.ignoreMode() == rhs.ignoreMode() && lhs.alphabet() == rhs.alphabet() && lhs.isPadded() == rhs.isPadded())
 bool bdlde::operator==(const bdlde::Base64DecoderOptions& lhs,
                        const bdlde::Base64DecoderOptions& rhs)
 {

--- a/groups/bdl/bdlde/bdlde_base64encoderoptions.cpp
+++ b/groups/bdl/bdlde/bdlde_base64encoderoptions.cpp
@@ -16,6 +16,7 @@ namespace bdlde {
                             // --------------------
 
 // ACCESSORS
+// ensures: __out == &stream && (__out ↦ _)
 bsl::ostream& Base64EncoderOptions::print(bsl::ostream& stream,
                                           int           level,
                                           int           spacesPerLevel) const
@@ -37,6 +38,7 @@ bsl::ostream& Base64EncoderOptions::print(bsl::ostream& stream,
 // inline in anticipation of their being rarely used.
 
 // FREE FUNCTIONS
+// ensures: (__out == true ==> (lhs.alphabet() == rhs.alphabet() && lhs.maxLineLength() == rhs.maxLineLength() && lhs.isPadded() == rhs.isPadded())) && (__out == false ==> (lhs.alphabet() != rhs.alphabet() || lhs.maxLineLength() != rhs.maxLineLength() || lhs.isPadded() != rhs.isPadded()))
 bool bdlde::operator==(const bdlde::Base64EncoderOptions& lhs,
                        const bdlde::Base64EncoderOptions& rhs)
 {

--- a/groups/bdl/bdlde/bdlde_base64ignoremode.cpp
+++ b/groups/bdl/bdlde/bdlde_base64ignoremode.cpp
@@ -16,6 +16,7 @@ namespace bdlde {
                           // -----------------------
 
 // CLASS METHODS
+// ensures: (__out == stream) && (__out.bad() == false) && (__out.rdbuf() ↦ _)
 bsl::ostream& Base64IgnoreMode::print(bsl::ostream&          stream,
                                       Base64IgnoreMode::Enum value,
                                       int                    level,
@@ -49,6 +50,7 @@ const char *Base64IgnoreMode::toAscii(Base64IgnoreMode::Enum value)
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& bdlde::operator<<(bsl::ostream&                 stream,
                                 bdlde::Base64IgnoreMode::Enum value)
 {

--- a/groups/bdl/bdlde/bdlde_byteorder.cpp
+++ b/groups/bdl/bdlde/bdlde_byteorder.cpp
@@ -15,6 +15,7 @@ namespace bdlde {
                               // ----------------
 
 // CLASS METHODS
+// ensures: (__out == stream) && (__out.bad() == false) && (__out.rdbuf() ↦ _)
 bsl::ostream& ByteOrder::print(bsl::ostream&   stream,
                                ByteOrder::Enum value,
                                int             level,

--- a/groups/bdl/bdlde/bdlde_charconvertstatus.cpp
+++ b/groups/bdl/bdlde/bdlde_charconvertstatus.cpp
@@ -16,6 +16,7 @@ namespace bdlde {
                           // ------------------------
 
 // CLASS METHODS
+// ensures: (__out == stream) && (__out.bad() == false) && (__out.good() == true) && (__out.str().find(CharConvertStatus::toAscii(value)) != std::string::npos)
 bsl::ostream& CharConvertStatus::print(bsl::ostream&           stream,
                                        CharConvertStatus::Enum value,
                                        int                     level,

--- a/groups/bdl/bdlde/bdlde_charconvertutf32.cpp
+++ b/groups/bdl/bdlde/bdlde_charconvertutf32.cpp
@@ -222,6 +222,7 @@ void Capacity::operator-=(int delta)
 
 /// Return `true` if `d_capacity` is less than the specified `rhs`, and
 /// `false` otherwise.
+// ensures: (__out == true ==> d_capacity < rhs) && (__out == false ==> d_capacity >= rhs)
 inline
 bool Capacity::operator<( bsl::size_t rhs) const
 {
@@ -230,6 +231,7 @@ bool Capacity::operator<( bsl::size_t rhs) const
 
 /// Return `true` if `d_capacity` is greater than or equal to the specified
 /// `rhs`, and `false` otherwise.
+// ensures: (__out == true ==> d_capacity >= rhs) && (__out == false ==> d_capacity < rhs)
 inline
 bool Capacity::operator>=(bsl::size_t rhs) const
 {
@@ -296,6 +298,7 @@ void NoopCapacity::operator-=(int)
 // ACCESSORS
 
 /// Return `false`.
+// ensures: __out == false
 inline
 bool NoopCapacity::operator<( bsl::size_t) const
 {
@@ -303,6 +306,7 @@ bool NoopCapacity::operator<( bsl::size_t) const
 }
 
 /// Return `true`.
+// ensures: __out == true
 inline
 bool NoopCapacity::operator>=(bsl::size_t) const
 {
@@ -403,6 +407,7 @@ Utf8PtrBasedEnd::Utf8PtrBasedEnd(const char *end)
 {}
 
 // ACCESSORS
+// ensures: (__out == false ==> position < d_end) && (__out == true ==> position >= d_end)
 inline
 bool Utf8PtrBasedEnd::isFinished(const OctetType *position) const
 {
@@ -498,6 +503,7 @@ Utf8ZeroBasedEnd::Utf8ZeroBasedEnd()
 }
 
 // ACCESSORS
+// ensures: __out == (*position == 0)
 inline
 bool Utf8ZeroBasedEnd::isFinished(const OctetType *position) const
 {
@@ -580,6 +586,7 @@ Utf32PtrBasedEnd::Utf32PtrBasedEnd(const unsigned int *end)
 {}
 
 // ACCESSORS
+// ensures: (__out == false ==> position < d_end_p) && (__out == true ==> position >= d_end_p)
 inline
 bool Utf32PtrBasedEnd::isFinished(const unsigned int *position) const
 {
@@ -620,6 +627,7 @@ Utf32ZeroBasedEnd::Utf32ZeroBasedEnd()
 }
 
 // ACCESSORS
+// ensures: (__out == true ==> *position == 0) && (__out == false ==> *position != 0)
 inline
 bool Utf32ZeroBasedEnd::isFinished(const unsigned int *position) const
 {
@@ -632,6 +640,7 @@ bool Utf32ZeroBasedEnd::isFinished(const unsigned int *position) const
 /// `static_cast` does not work here, and the idea is to be sure in these
 /// casts that one is never accidentally casting between pointers to `char`
 /// or `OctetType` and pointers to `unsigned int`.
+// ensures: __out == reinterpret_cast<const OctetType*>(ptr)
 static inline
 const OctetType *constOctetCast(const char *ptr)
 {
@@ -643,6 +652,7 @@ const OctetType *constOctetCast(const char *ptr)
 /// `static_cast` does not work here, and the idea is to be sure in these
 /// casts that one is never accidentally casting between pointers to `char`
 /// or `OctetType` and pointers to `unsigned int`.
+// ensures: __out == reinterpret_cast<OctetType*>(ptr)
 static inline
 OctetType *octetCast(char *ptr)
 {
@@ -651,6 +661,7 @@ OctetType *octetCast(char *ptr)
 }
 
 /// Return `true` if the specified `oct` is a single-octet UTF-8 sequence.
+// ensures: (__out == true ==> !(oct & k_ONE_OCTET_MASK)) && (__out == false ==> (oct & k_ONE_OCTET_MASK) != 0)
 static inline
 bool isSingleOctet(OctetType oct)
 {
@@ -659,6 +670,7 @@ bool isSingleOctet(OctetType oct)
 
 /// Return `true` if the specified `oct` is a continuation octet and `false`
 /// otherwise.
+// ensures: (__out == true ==> ((oct & k_CONTINUE_MASK) == k_CONTINUE_TAG)) && (__out == false ==> ((oct & k_CONTINUE_MASK) != k_CONTINUE_TAG))
 static inline
 bool isContinuation(OctetType oct)
 {
@@ -667,6 +679,7 @@ bool isContinuation(OctetType oct)
 
 /// Return `true` if the specified `oct` is the first octet of a two-octet
 /// UTF-8 sequence and `false` otherwise.
+// ensures: (__out == true ==> (oct & k_TWO_OCTET_MASK) == k_TWO_OCTET_TAG) && (__out == false ==> (oct & k_TWO_OCTET_MASK) != k_TWO_OCTET_TAG)
 static inline
 bool isTwoOctetHeader(OctetType oct)
 {
@@ -675,6 +688,7 @@ bool isTwoOctetHeader(OctetType oct)
 
 /// Return `true` if the specified `oct` is the first octet of a three-octet
 /// UTF-8 sequence and `false` otherwise.
+// ensures: (__out == true ==> ((oct & k_THREE_OCTET_MASK) == k_THREE_OCTET_TAG)) && (__out == false ==> ((oct & k_THREE_OCTET_MASK) != k_THREE_OCTET_TAG))
 static inline
 bool isThreeOctetHeader(OctetType oct)
 {
@@ -683,6 +697,7 @@ bool isThreeOctetHeader(OctetType oct)
 
 /// Return `true` if the specified `oct` is the first octet of a four-octet
 /// UTF-8 sequence and `false` otherwise.
+// ensures: (__out == true ==> ((oct & k_FOUR_OCTET_MASK) == k_FOUR_OCTET_TAG)) && (__out == false ==> ((oct & k_FOUR_OCTET_MASK) != k_FOUR_OCTET_TAG))
 static inline
 bool isFourOctetHeader(OctetType oct)
 {
@@ -722,6 +737,7 @@ unsigned int decodeFourOctets(const OctetType *octBuf)
 /// Return the number of continuation octets beginning at the specified
 /// `octBuf`, up to but not greater than the specified `n`.  Note that a
 /// null octet is not a continuation and is taken to end the scan.
+// ensures: __out == 0 || (SEPFORALL(0, __out, i, (octBuf + i ↦ _) && isContinuation(octBuf[i])) ⋆ SEPFORALL(__out, n, i, (octBuf + i ↦ _)) && !isContinuation(octBuf[__out]) || __out == n)
 static inline
 bsl::size_t lookaheadContinuations(const OctetType * const octBuf, int n)
 {
@@ -735,6 +751,7 @@ bsl::size_t lookaheadContinuations(const OctetType * const octBuf, int n)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in a
 /// single UTF-8 octet and `false` otherwise.
+// ensures: (uc <= 0xFF) ==> __out == true && (uc > 0xFF) ==> __out == false
 static inline
 bool fitsInSingleOctet(unsigned int uc)
 {
@@ -743,6 +760,7 @@ bool fitsInSingleOctet(unsigned int uc)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in two
 /// UTF-8 octets or less and `false` otherwise.
+// ensures: (__out == true ==> (uc & (~0 << (k_TWO_OCT_CONT_WID + k_CONTINUE_CONT_WID))) == 0) && (__out == false ==> (uc & (~0 << (k_TWO_OCT_CONT_WID + k_CONTINUE_CONT_WID))) != 0)
 static inline
 bool fitsInTwoOctets(unsigned int uc)
 {
@@ -752,6 +770,7 @@ bool fitsInTwoOctets(unsigned int uc)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in three
 /// UTF-8 octets or less and `false` otherwise.
+// ensures: (__out == true) || (__out == false)
 static inline
 bool fitsInThreeOctets(unsigned int uc)
 {
@@ -761,6 +780,7 @@ bool fitsInThreeOctets(unsigned int uc)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in four
 /// UTF-8 octets or less and `false` otherwise.
+// ensures: (__out == true) || (__out == false)
 static inline
 bool fitsInFourOctets(unsigned int uc)
 {
@@ -807,6 +827,7 @@ void encodeFourOctets(OctetType *octBuf, unsigned int isoBuf)
 /// Return `true` if the specified Unicode value `uc` is a value reserved
 /// for the encoding of double-word planes in UTF-16 (such values are
 /// illegal in ANY Unicode format) and `false` otherwise.
+// ensures: (__out == true ==> (uc >= 0xd800 && uc < 0xe000)) && (__out == false ==> !(uc >= 0xd800 && uc < 0xe000))
 static inline
 bool isIllegal16BitValue(unsigned int uc)
 {
@@ -815,6 +836,7 @@ bool isIllegal16BitValue(unsigned int uc)
 
 /// Return `true` if the specified 32-bit value `uc` is too high to be
 /// represented in Unicode and `false` otherwise.
+// ensures: (__out == true ==> uc > 0x10ffff) && (__out == false ==> uc <= 0x10ffff)
 static inline
 bool isIllegalFourOctetValue(unsigned int uc)
 {
@@ -836,6 +858,7 @@ bool isLegalUtf32ErrorWord(unsigned int uc)
 /// incomplete sequence is skipped as a single char, and that any first byte
 /// that is neither a single byte nor a header of a valid UTF-8 sequence is
 /// interpreted as a 5-byte header.
+// ensures: __out >= input
 static inline
 const OctetType *skipUtf8CodePoint(const OctetType *input)
 {

--- a/groups/bdl/bdlde/bdlde_crc32.cpp
+++ b/groups/bdl/bdlde/bdlde_crc32.cpp
@@ -189,6 +189,7 @@ void Crc32::update(const void *data, bsl::size_t length)
 }
 
 // ACCESSORS
+// ensures: __out == stream
 bsl::ostream& Crc32::print(bsl::ostream& stream) const
 {
     const char *hex = "0123456789abcdef";

--- a/groups/bdl/bdlde/bdlde_crc32c.cpp
+++ b/groups/bdl/bdlde/bdlde_crc32c.cpp
@@ -716,6 +716,7 @@ class Crc32cCalculator {
 /// over the specified `length` number of bytes, using the specified `crc`
 /// value as the starting point for the calculation.  Note that the `data`
 /// is permitted to be null if the `length` is 0.
+// ensures: (length == 0 || (data != nullptr && SEPFORALL(0, length, i, (data + i ↦ _)))) ==> __out == crc
 inline
 unsigned int calculateCrc32c(const unsigned char *data,
                              bsl::size_t          length,
@@ -769,6 +770,7 @@ unsigned int sparcHardware(const unsigned char *data,
 /// over the specified `length` number of bytes, using the specified `crc`
 /// value as the starting point for the calculation.  Note that the `data`
 /// is permitted to be null if the `length` is 0.
+// ensures: __out == ~crc
 unsigned int crc32cSoftware(const unsigned char *data,
                             bsl::size_t          length,
                             unsigned int         crc)

--- a/groups/bdl/bdlde/bdlde_crc64.cpp
+++ b/groups/bdl/bdlde/bdlde_crc64.cpp
@@ -329,6 +329,7 @@ void Crc64::update(const void *data, bsl::size_t length)
 }
 
 // ACCESSORS
+// ensures: __out == &stream ⋆ stream ↦ _
 bsl::ostream& Crc64::print(bsl::ostream& stream) const
 {
     static const char hex[] = "0123456789abcdef";

--- a/groups/bdl/bdlde/bdlde_hexdecoder.cpp
+++ b/groups/bdl/bdlde/bdlde_hexdecoder.cpp
@@ -164,6 +164,7 @@ HexDecoder::HexDecoder()
 }
 
 // MANIPULATORS
+// ensures: (__out == -1 ==> (d_state == e_ERROR_STATE)) && (__out == 0 ==> (d_state == e_DONE_STATE))
 int HexDecoder::endConvert()
 {
     if (e_ERROR_STATE == d_state) {

--- a/groups/bdl/bdlde/bdlde_md5.cpp
+++ b/groups/bdl/bdlde/bdlde_md5.cpp
@@ -403,6 +403,7 @@ static void append(unsigned int *state, const unsigned char *data)
 
 /// Return the number of bytes in use in the buffer for the total specified
 /// `length`.
+// ensures: (__out >= 0) && (__out < 64)
 inline
 static int getLengthInUse(bsls::Types::Int64 length)
 {
@@ -646,6 +647,7 @@ bsl::ostream& Md5::print(bsl::ostream& stream) const
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.d_length == rhs.d_length && SEPFORALL(0, getLengthInUse(lhs.d_length), i, (lhs.d_buffer[i] == rhs.d_buffer[i])))) && (__out == false ==> (lhs.d_length != rhs.d_length || SEPEXISTS(0, getLengthInUse(lhs.d_length), i, (lhs.d_buffer[i] != rhs.d_buffer[i]))))
 bool bdlde::operator==(const Md5& lhs, const Md5& rhs)
 {
     if (lhs.d_length != rhs.d_length

--- a/groups/bdl/bdlde/bdlde_quotedprintabledecoder.cpp
+++ b/groups/bdl/bdlde/bdlde_quotedprintabledecoder.cpp
@@ -210,6 +210,7 @@ QuotedPrintableDecoder::~QuotedPrintableDecoder()
 }
 
 // MANIPULATORS
+// ensures: (__out == -1 || __out == 0) && (__out == -1 ==> (d_state == e_ERROR_STATE || d_state == e_DONE_STATE)) && (__out == 0 ==> (d_state == e_INPUT_STATE || d_state == e_SAW_WS_STATE || d_state == e_SAW_EQUAL_STATE || d_state == e_NEED_HEX_STATE || d_state == e_NEED_SOFT_LF_STATE || d_state == e_NEED_HARD_LF_STATE))
 int QuotedPrintableDecoder::convert(char       *out,
                                     int        *numOut,
                                     int        *numIn,

--- a/groups/bdl/bdlde/bdlde_quotedprintableencoder.cpp
+++ b/groups/bdl/bdlde/bdlde_quotedprintableencoder.cpp
@@ -252,6 +252,7 @@ QuotedPrintableEncoder::~QuotedPrintableEncoder()
 }
 
 // MANIPULATORS
+// ensures: (__out == -1) ==> ((d_state == e_ERROR_STATE) || (d_state == e_DONE_STATE)) && (*numOut == 0) && (*numIn == 0)
 int QuotedPrintableEncoder::convert(char       *out,
                                     int        *numOut,
                                     int        *numIn,

--- a/groups/bdl/bdlde/bdlde_sha1.cpp
+++ b/groups/bdl/bdlde/bdlde_sha1.cpp
@@ -51,6 +51,7 @@ const Sha1Word k_SHA1_CONSTANTS[80] = {
 /// Return the result of a bitwise rotation on the specified `value` by the
 /// specified `shift` number of bits.  The behavior is undefined unless
 /// `shift` is positive and strictly less than 32.
+// ensures: __out == ((value << shift) | (value >> ((sizeof(value) * CHAR_BIT) - shift)))
 static Sha1Word rotateLeft(Sha1Word value, int shift)
 {
     return (value << shift) | (value >> ((sizeof(value) * CHAR_BIT) - shift));
@@ -60,6 +61,7 @@ static Sha1Word rotateLeft(Sha1Word value, int shift)
 /// the corresponding bit from the specified `x`, otherwise uses the
 /// corresponding bit from the specified `y`.  This function is named `Ch`
 /// in FIPS 180-4.
+// ensures: __out == ((condition & (x ^ y)) ^ y)
 static Sha1Word bitwiseConditional(Sha1Word condition, Sha1Word x, Sha1Word y)
 {
     // The following implementation, taken from bdlde_sha2.cpp, only uses 3
@@ -73,6 +75,7 @@ static Sha1Word bitwiseConditional(Sha1Word condition, Sha1Word x, Sha1Word y)
 /// Return a value that has each bit set if and only if the corresponding
 /// bit is set in at least two out of three of the specified `x`, `y`, and
 /// `z`.  This function is named `Maj` in FIPS 180-4.
+// ensures: __out == ((x & y) | ((x | y) & z))
 static Sha1Word bitwiseMajority(Sha1Word x, Sha1Word y, Sha1Word z)
 {
     return (x & y) | ((x | y) & z);
@@ -82,6 +85,7 @@ static Sha1Word bitwiseMajority(Sha1Word x, Sha1Word y, Sha1Word z)
 /// specified `x`, `y`, and `z` as arguments, as defined in section 4.1.1 of
 /// FIPS 180-4.  The behavior is undefined unless `index` is nonnegative and
 /// less than or equal to 79.
+// ensures: (index <= 19 ==> __out == bitwiseConditional(x, y, z)) && (index >= 40 && index <= 59 ==> __out == bitwiseMajority(x, y, z)) && ((index > 19 && index < 40) || (index > 59) ==> __out == (x ^ y ^ z))
 static Sha1Word f(Sha1Word x, Sha1Word y, Sha1Word z, int index)
 {
     if (index <= 19) {
@@ -360,6 +364,7 @@ bsl::ostream& Sha1::print(bsl::ostream& stream) const
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && bsl::equal(lhs.d_buffer, lhs.d_buffer + lhs.d_bufferSize, rhs.d_buffer) && bsl::equal(bsl::begin(lhs.d_state), bsl::end(lhs.d_state), bsl::begin(rhs.d_state)))) && (__out == false ==> !(lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && bsl::equal(lhs.d_buffer, lhs.d_buffer + lhs.d_bufferSize, rhs.d_buffer) && bsl::equal(bsl::begin(lhs.d_state), bsl::end(lhs.d_state), bsl::begin(rhs.d_state))))
 bool bdlde::operator==(const Sha1& lhs, const Sha1& rhs)
 {
     return lhs.d_totalSize == rhs.d_totalSize &&

--- a/groups/bdl/bdlde/bdlde_sha2.cpp
+++ b/groups/bdl/bdlde/bdlde_sha2.cpp
@@ -40,6 +40,7 @@ INTEGER bitwiseMajority(INTEGER x, INTEGER y, INTEGER z)
 
 /// First mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 2) ^ rotateRight(value, 13) ^ rotateRight(value, 22))
 bsl::uint32_t f1(bsl::uint32_t value)
 {
     return rotateRight(value,  2)
@@ -49,6 +50,7 @@ bsl::uint32_t f1(bsl::uint32_t value)
 
 /// First mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 28) ^ rotateRight(value, 34) ^ rotateRight(value, 39))
 bsl::uint64_t f1(bsl::uint64_t value)
 {
     return rotateRight(value, 28)
@@ -58,6 +60,7 @@ bsl::uint64_t f1(bsl::uint64_t value)
 
 /// Second mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 6) ^ rotateRight(value, 11) ^ rotateRight(value, 25))
 bsl::uint32_t f2(bsl::uint32_t value)
 {
     return rotateRight(value,  6)
@@ -67,6 +70,7 @@ bsl::uint32_t f2(bsl::uint32_t value)
 
 /// Second mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 14) ^ rotateRight(value, 18) ^ rotateRight(value, 41))
 bsl::uint64_t f2(bsl::uint64_t value)
 {
     return rotateRight(value, 14)
@@ -76,6 +80,7 @@ bsl::uint64_t f2(bsl::uint64_t value)
 
 /// Third mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 7) ^ rotateRight(value, 18) ^ (value >> 3))
 bsl::uint32_t f3(bsl::uint32_t value)
 {
     return rotateRight(value,  7) ^ rotateRight(value, 18) ^ (value >>  3);
@@ -83,6 +88,7 @@ bsl::uint32_t f3(bsl::uint32_t value)
 
 /// Third mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 1) ^ rotateRight(value, 8) ^ (value >> 7))
 bsl::uint64_t f3(bsl::uint64_t value)
 {
     return rotateRight(value,  1) ^ rotateRight(value,  8) ^ (value >>  7);
@@ -90,6 +96,7 @@ bsl::uint64_t f3(bsl::uint64_t value)
 
 /// Fourth mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 17) ^ rotateRight(value, 19) ^ (value >> 10))
 bsl::uint32_t f4(bsl::uint32_t value)
 {
     return rotateRight(value, 17) ^ rotateRight(value, 19) ^ (value >> 10);
@@ -97,6 +104,7 @@ bsl::uint32_t f4(bsl::uint32_t value)
 
 /// Fourth mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// ensures: __out == (rotateRight(value, 19) ^ rotateRight(value, 61) ^ (value >> 6))
 bsl::uint64_t f4(bsl::uint64_t value)
 {
     return rotateRight(value, 19) ^ rotateRight(value, 61) ^ (value >>  6);
@@ -653,6 +661,7 @@ bsl::ostream& Sha512::print(bsl::ostream& stream) const
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.d_totalSize == rhs.d_totalSize ⋆ lhs.d_bufferSize == rhs.d_bufferSize ⋆ SEPFORALL(0, lhs.d_bufferSize, i, (lhs.d_buffer + i ↦ rhs.d_buffer[i])) ⋆ SEPFORALL(0, 8, i, (lhs.d_state + i ↦ rhs.d_state[i])))) && (__out == false ==> !(lhs.d_totalSize == rhs.d_totalSize ⋆ lhs.d_bufferSize == rhs.d_bufferSize ⋆ SEPFORALL(0, lhs.d_bufferSize, i, (lhs.d_buffer + i ↦ rhs.d_buffer[i])) ⋆ SEPFORALL(0, 8, i, (lhs.d_state + i ↦ rhs.d_state[i]))))
 bool bdlde::operator==(const Sha224& lhs, const Sha224& rhs)
 {
     return lhs.d_totalSize  == rhs.d_totalSize

--- a/groups/bdl/bdlde/bdlde_utf8checkinginstreambufwrapper.cpp
+++ b/groups/bdl/bdlde/bdlde_utf8checkinginstreambufwrapper.cpp
@@ -29,6 +29,7 @@ namespace bdlde {
                      // ------------------------------------
 
 // PRIVATE MANIPULATOR
+// ensures: (__out == pos_type(-1)) && (d_offset == 0) && (d_errorStatus == k_SEEK_FAIL) && (d_bufEndStatus == 0) && (d_putBackMode == false)
 inline
 bsl::streambuf::pos_type Utf8CheckingInStreamBufWrapper::setSeekFailure(
                                                   bsl::ios_base::openmode mode)
@@ -54,6 +55,7 @@ bsl::streambuf::pos_type Utf8CheckingInStreamBufWrapper::setSeekFailure(
 
                             // implementation functions
 
+// ensures: __out == traits_type::eof()
 bsl::streambuf::int_type
 Utf8CheckingInStreamBufWrapper::overflow(int_type)
     // This method is normally associated with output and is stubbed out in
@@ -340,6 +342,7 @@ bsl::streamsize Utf8CheckingInStreamBufWrapper::xsputn(const char      *,
 }
 
 // PUBLIC CLASS METHOD
+// ensures: (errorStatus == 0 ==> __out == "NO_ERROR") && (errorStatus == k_SEEK_FAIL ==> __out == "SEEK_FAIL") && (errorStatus != 0 && errorStatus != k_SEEK_FAIL ==> __out == Utf8Util::toAscii(errorStatus))
 const char *Utf8CheckingInStreamBufWrapper::toAscii(int errorStatus)
 {
     if (0 == errorStatus) {

--- a/groups/bdl/bdlde/bdlde_utf8util.cpp
+++ b/groups/bdl/bdlde/bdlde_utf8util.cpp
@@ -91,6 +91,7 @@ bool BSLA_UNUSED isValidUtf8CodePoint(const char *sequence)
 /// Return the length of the UTF-8 code point for which the specified
 /// `character` is the first `char`.  The behavior is undefined unless
 /// `character` is the first `char` of a UTF-8 code point.
+// ensures: (__out == 1 || __out == 2 || __out == 3 || __out == 4)
 int utf8Size(char character)
 {
     if ((character & k_ONEBYTEHEAD_TEST) == k_ONEBYTEHEAD_RES) {
@@ -165,6 +166,7 @@ int appendUtf8CodePointImpl(ITERATOR output, unsigned int codePoint)
 
 /// Return `true` if the specified `value` is NOT a UTF-8 continuation byte,
 /// and `false` otherwise.
+// ensures: (__out == true ==> (0x80 != (value & 0xc0))) && (__out == false ==> (0x80 == (value & 0xc0)))
 inline
 bool isNotContinuation(char value)
 {
@@ -173,6 +175,7 @@ bool isNotContinuation(char value)
 
 /// Return `true` if the specified `value` is a surrogate value, and `false`
 /// otherwise.
+// ensures: (__out == true ==> ((k_SURROGATE_MASK & value) == k_MIN_SURROGATE)) && (__out == false ==> ((k_SURROGATE_MASK & value) != k_MIN_SURROGATE))
 inline
 bool isSurrogateValue(int value)
 {
@@ -185,6 +188,7 @@ bool isSurrogateValue(int value)
 /// 2-byte UTF-8 sequence referred to by the specified `pc`.  The behavior
 /// is undefined unless the 2 bytes starting at `pc` contain a UTF-8
 /// sequence describing a single valid code point.
+// ensures: (pc ↦ _) ⋆ (pc + 1 ↦ _)
 inline
 int get2ByteValue(const char *pc)
 {
@@ -195,6 +199,7 @@ int get2ByteValue(const char *pc)
 /// 3-byte UTF-8 sequence referred to by the specified `pc`.  The behavior
 /// is undefined unless the 3 bytes starting at `pc` contain a UTF-8
 /// sequence describing a single valid code point.
+// ensures: __out == ((*pc & 0xf) << 12) | ((pc[1] & k_CONT_VALUE_MASK) << 6) | (pc[2] & k_CONT_VALUE_MASK)
 inline
 int get3ByteValue(const char *pc)
 {
@@ -206,6 +211,7 @@ int get3ByteValue(const char *pc)
 /// 4-byte UTF-8 sequence referred to by the specified `pc`.  The behavior
 /// is undefined unless the 4 bytes starting at `pc` contain a UTF-8
 /// sequence describing a single valid code point.
+// ensures: (pc ↦ _ ⋆ (pc + 1) ↦ _ ⋆ (pc + 2) ↦ _ ⋆ (pc + 3) ↦ _)
 inline
 int get4ByteValue(const char *pc)
 {
@@ -299,6 +305,7 @@ Utf8Util::size_type replaceErrors(STRING_TYPE      *output,
 /// `string` is necessarily null-terminated, so it cannot contain embedded
 /// null bytes.  Note that `string` may contain less than
 /// `bsl::strlen(string)` Unicode code points.
+// ensures: (__out >= 0) || (__out < 0 ==> (*invalidString != nullptr))
 int validateAndCountCodePoints(const char **invalidString, const char *string)
 {
     // The following assertions are redundant with those in the CLASS METHODS.
@@ -438,6 +445,7 @@ int validateAndCountCodePoints(const char **invalidString, const char *string)
 /// embedded null bytes.  The behavior is undefined unless
 /// `0 <= IntPtr(length)`.  Note that `string` may contain less than
 /// `length` Unicode code points.
+// ensures: (__out >= 0) || (__out < 0 ==> (*invalidString != nullptr))
 int validateAndCountCodePoints(const char             **invalidString,
                                const char              *string,
                                bsls::Types::size_type   length)
@@ -679,6 +687,7 @@ namespace bdlde {
                           // -----------------------
 
 // CLASS METHODS
+// ensures: __out > 0 && __out <= input.length()
 Utf8Util_ImpUtil::size_type
 Utf8Util_ImpUtil::advancePastValidOrInvalidCodePoint(
                                                  const bsl::string_view& input)

--- a/groups/bdl/bdldfp/bdldfp_decimal.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimal.cpp
@@ -293,6 +293,7 @@ doGetCommon(ITER_TYPE                    begin,
 }
 
 /// Return `true` if the specified `x` is negative and `false` otherwise.
+// ensures: (__out == true ==> (x.value().d_raw & k_SIGN_MASK != 0)) && (__out == false ==> (x.value().d_raw & k_SIGN_MASK == 0))
 inline
 bool isNegative(const Decimal32& x)
 {
@@ -337,6 +338,7 @@ namespace bdldfp {
                             // --------------------
 
 // ACCESSORS
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream& Decimal_Type64::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const

--- a/groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp
@@ -53,6 +53,7 @@ void memrev(void *buffer, size_t count)
 /// Reverse the first specified `count` bytes from the specified `buffer`,
 /// if the host endian is different from network endian, and return the
 /// address computed from `static_cast<unsigned char *>(buffer) + count`.
+// ensures: __out == static_cast<unsigned char*>(buffer) + count
 inline
 unsigned char *memReverseIfNeeded(void *buffer, size_t count)
 {
@@ -258,6 +259,7 @@ bool restoreSingularDecimalFromBinary(DECIMAL_TYPE *decimal,
 /// Return the specified `low` if the specified `value` is less than 1, the
 /// specified `high` if `value` is greater than `high`, and `value`
 /// otherwise.
+// ensures: (value < 1 ==> __out == low) && (value > high ==> __out == high) && (value >= 1 && value <= high ==> __out == value)
 inline
 int bound(int value, int low, int high)
 {

--- a/groups/bdl/bdldfp/bdldfp_decimalimputil.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalimputil.cpp
@@ -95,6 +95,7 @@ T divmod10(T* v)
 
 /// Load the resultant value of dividing the specified value `v` by 10 into
 /// `v`.  Return the remainder of the division.
+// ensures: __out >= 0 && __out < 10
 bsls::Types::Uint64 divmod10(Uint128* v)
 {
     // Set a = v.high(), b = v.low().
@@ -595,6 +596,7 @@ struct Properties64
 /// underlying implementation.  Note that `classification` is of an
 /// implementation defined type, and corresponds to specific underlying
 /// library constants.
+// ensures: (__out == FP_NAN) || (__out == FP_INFINITE) || (__out == FP_ZERO) || (__out == FP_NORMAL) || (__out == FP_SUBNORMAL) || (__out == -1)
 static int canonicalizeDecimalValueClassification(int classification)
 {
     enum class_types cl = static_cast<class_types>(classification);

--- a/groups/bdl/bdljsn/bdljsn_error.cpp
+++ b/groups/bdl/bdljsn/bdljsn_error.cpp
@@ -43,6 +43,7 @@ bsl::ostream& Error::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& bdljsn::operator<<(bsl::ostream& stream,
                                  const Error&  object)
 {

--- a/groups/bdl/bdljsn/bdljsn_jsontestsuiteutil.cpp
+++ b/groups/bdl/bdljsn/bdljsn_jsontestsuiteutil.cpp
@@ -28,6 +28,7 @@ namespace u {
 
 /// Return the address of a null-terminated string containing the input of
 /// the `n_structure_100000_opening_arrays.json` test point.
+// ensures: __out != 0 && SEPFORALL(0, 100000, i, (__out + i ↦ '['))
 static const char *getLeftBrackets100000()
 {
     static bsl::string leftBrackets100000(bslma::Default::globalAllocator());
@@ -46,6 +47,7 @@ static const bsl::size_t lenLeftBrackets100000 = 100000;
 
 /// Return the address of a null-terminated string containing the input of
 /// the `n_structure_open_array_object.json` test point.
+// ensures: __out != 0
 static const char *getOpenArrayObject50000()
 {
     static char              openArrayObjectSubsequence[] = "[{\"\":";
@@ -1102,6 +1104,7 @@ const bsl::size_t JsonTestSuiteUtil::s_numData = sizeof  s_data
 #undef JSON
 
 // ACCESSORS
+// ensures: __out != 0 && (__out == &s_data[index])
 const JsonTestSuiteUtil::Datum *JsonTestSuiteUtil::data(bsl::size_t index)
 {
     BSLS_ASSERT(index < s_numData);

--- a/groups/bdl/bdljsn/bdljsn_jsontype.cpp
+++ b/groups/bdl/bdljsn/bdljsn_jsontype.cpp
@@ -16,6 +16,7 @@ namespace bdljsn {
                                // --------------
 
 // CLASS METHODS
+// ensures: __out == &stream && (__out ↦ _)
 bsl::ostream& JsonType::print(bsl::ostream&  stream,
                               JsonType::Enum value,
                               int            level,

--- a/groups/bdl/bdljsn/bdljsn_jsonutil.cpp
+++ b/groups/bdl/bdljsn/bdljsn_jsonutil.cpp
@@ -51,6 +51,7 @@ int read(Json *result, Error *error, Tokenizer *tokenizer, int maxNestedDepth);
     // exceeding the specified 'maxNestedDepth'.  Return 0 on success, and a
     // non-0 value populating the specified 'error' accordingly on failure.
 
+// ensures: (__out == 0 ==> (result != 0)) && (__out != 0 ==> (error != 0 && (error->message() ↦ _)))
 int readObject(JsonObject *result,
                Error      *error,
                Tokenizer  *tokenizer,
@@ -112,6 +113,7 @@ int readObject(JsonObject *result,
     return 0;
 }
 
+// ensures: (__out == 0) || (__out != 0 && error != nullptr)
 int readArray(JsonArray *result,
               Error     *error,
               Tokenizer *tokenizer,
@@ -152,6 +154,7 @@ int readArray(JsonArray *result,
 
 // BDE_VERIFY pragma: push
 // BDE_VERIFY pragma: -FABC01
+// ensures: __out == 0 || __out == -1
 int readScalar(Json *result, Error *error, Tokenizer *tokenizer)
     // Read into the specified 'result' from the specified 'tokenizer', not
     // exceeding the specified 'maxNestedDepth'.  Return 0 on success, and a
@@ -313,7 +316,8 @@ class JsonObjectUnsortedMemberIterator {
     }
 
     // MANIPULATORS
-    bool next()
+    // ensures: (__out == true ==> d_it != d_end) && (__out == false ==> d_it == d_end)
+bool next()
         // Advance to the next member in the object.  Return 'true' if the new
         // position is valid.
     {
@@ -322,19 +326,22 @@ class JsonObjectUnsortedMemberIterator {
     }
 
     // ACCESSORS
-    bool isFirst() const
+    // ensures: (__out == true ==> (d_it == d_begin)) && (__out == false ==> (d_it != d_begin))
+bool isFirst() const
         // Return 'true' if this object is in its initial state.
     {
         return d_it == d_begin;
     }
 
-    bool isValid() const
+    // ensures: (__out == true ==> d_it != d_end) && (__out == false ==> d_it == d_end)
+bool isValid() const
         // Return 'true' if the current position of this iterator is valid.
     {
         return d_it != d_end;
     }
 
-    const bsl::pair<const bsl::string, Json>& member() const
+    // ensures: __out == *d_it
+const bsl::pair<const bsl::string, Json>& member() const
         // Return the current member.
     {
         return *d_it;
@@ -344,7 +351,8 @@ class JsonObjectUnsortedMemberIterator {
 struct ObjectMemberLess {
     // This struct provides a comparator allowing object entries to be compared
     // lexicographically based on their 'bsl::string' keys.
-    bool operator()(const JsonObject::ConstIterator& lhs,
+    // ensures: (__out == true ==> (lhs->first < rhs->first)) && (__out == false ==> !(lhs->first < rhs->first))
+bool operator()(const JsonObject::ConstIterator& lhs,
                     const JsonObject::ConstIterator& rhs)
         // Return true if the key of the specified 'lhs' is lexicographically
         // less than the key of the specified 'rhs'.
@@ -393,7 +401,8 @@ class JsonObjectSortedMemberIterator {
     }
 
     // MANIPULATORS
-    bool next()
+    // ensures: (__out == true ==> d_it == d_sortedMembers.end()) && (__out == false ==> d_it != d_sortedMembers.end())
+bool next()
         // Advance to the next member in the object.  Return 'true' if the new
         // position is valid.
     {
@@ -402,13 +411,15 @@ class JsonObjectSortedMemberIterator {
     }
 
     // ACCESSORS
-    bool isFirst() const
+    // ensures: (__out == true ==> d_it == d_sortedMembers.begin()) && (__out == false ==> d_it != d_sortedMembers.begin())
+bool isFirst() const
         // Return 'true' if this object is in its initial state.
     {
         return d_it == d_sortedMembers.begin();
     }
 
-    bool isValid() const
+    // ensures: (__out == true ==> d_it != d_sortedMembers.end()) && (__out == false ==> d_it == d_sortedMembers.end())
+bool isValid() const
         // Return 'true' if the current position of this iterator is valid.
     {
         return d_it != d_sortedMembers.end();
@@ -695,6 +706,7 @@ void writeDispatchFormatting(bsl::ostream&       output,
                               // ---------------
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> (result->allocator() != nullptr)) && (__out != 0 ==> (errorDescription->message() != ""))
 int JsonUtil::read(Json               *result,
                    Error              *errorDescription,
                    bsl::streambuf     *input,

--- a/groups/bdl/bdljsn/bdljsn_location.cpp
+++ b/groups/bdl/bdljsn/bdljsn_location.cpp
@@ -33,6 +33,7 @@ bsl::ostream& Location::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == &stream) && (__out->str() == old___out->str() + std::to_string(object.offset()))
 bsl::ostream& bdljsn::operator<<(bsl::ostream&           stream,
                                  const bdljsn::Location& object)
 {

--- a/groups/bdl/bdljsn/bdljsn_numberutil.cpp
+++ b/groups/bdl/bdljsn/bdljsn_numberutil.cpp
@@ -59,6 +59,7 @@ static const bsls::Types::Uint64 POWER_OF_TEN_LOOKUP[] = {
 /// valid unsigned integer.  If this function returns `false`, `*iter` is
 /// left in a valid but unspecified state (i.e., it may or may not have been
 /// advanced).
+// ensures: (__out == true ==> (*iter == end || !bdlb::CharType::isDigit(**iter)) && SEPFORALL(old_iter, *iter, i, (i ↦ _) && bdlb::CharType::isDigit(*i))) && (__out == false ==> SEPEXISTS(old_iter, *iter, i, (i ↦ _) && !bdlb::CharType::isDigit(*i)))
 static bool skipIfIsValidUint(bsl::string_view::const_iterator *iter,
                               bsl::string_view::const_iterator  end)
 {
@@ -164,6 +165,7 @@ bsl::ostream& operator<<(bsl::ostream& stream, const DecomposedNumber& n)
 /// for equality), and primarily serves to ignore a `+` character if it
 /// appears in the Exp.  E.g., "1e100000000000000000000" and
 /// "1e+100000000000000000000" would compare equal.
+// ensures: (__out == true ==> (lhs.d_isExpNegative == rhs.d_isExpNegative && lhs.d_significantDigits == rhs.d_significantDigits && lhs.d_exponent == rhs.d_exponent)) && (__out == false ==> (lhs.d_isExpNegative != rhs.d_isExpNegative || lhs.d_significantDigits != rhs.d_significantDigits || lhs.d_exponent != rhs.d_exponent))
 static bool compareNumberTextFallback(const DecomposedNumber& lhs,
                                       const DecomposedNumber& rhs)
 {
@@ -182,6 +184,7 @@ static bool compareNumberTextFallback(const DecomposedNumber& lhs,
 /// iterator, and prior to the specified `end` character.  Return `end` if
 /// all of the characters are digits.  Note that `find_if_not` is a C++20
 /// algorithm.
+// ensures: (__out == end) || (!bdlb::CharType::isDigit(*__out))
 static bsl::string_view::const_iterator findFirstNonDigit(
                                         bsl::string_view::const_iterator begin,
                                         bsl::string_view::const_iterator end)

--- a/groups/bdl/bdljsn/bdljsn_readoptions.cpp
+++ b/groups/bdl/bdljsn/bdljsn_readoptions.cpp
@@ -25,6 +25,7 @@ ReadOptions::ReadOptions()
 }
 
 // MANIPULATORS
+// ensures: __out.d_allowTrailingText ↦ s_DEFAULT_INITIALIZER_ALLOW_TRAILING_TEXT ⋆ __out.d_maxNestedDepth ↦ s_DEFAULT_INITIALIZER_MAX_NESTED_DEPTH
 ReadOptions& ReadOptions::reset()
 {
     d_allowTrailingText = s_DEFAULT_INITIALIZER_ALLOW_TRAILING_TEXT;

--- a/groups/bdl/bdljsn/bdljsn_tokenizer.cpp
+++ b/groups/bdl/bdljsn/bdljsn_tokenizer.cpp
@@ -76,6 +76,7 @@ namespace bdljsn {
                               // ---------------
 
 // PRIVATE MANIPULATORS
+// ensures: (__out == 0 ==> __out != -1) && (__out == -1 ==> __out != 0)
 int Tokenizer::expandBufferForLargeValue()
 {
     const bsl::string::size_type currLength = d_stringBuffer.length();
@@ -331,6 +332,7 @@ int Tokenizer::skipWhitespace()
 }
 
 // MANIPULATORS
+// ensures: (__out == 0) || (__out == -1)
 int Tokenizer::advanceToNextToken()
 {
     BSLS_ASSERT(d_streambuf_p);
@@ -719,6 +721,7 @@ int Tokenizer::resetStreamBufGetPointer()
 }
 
 // ACCESSORS
+// ensures: (__out == 0 ==> (*data ↦ bsl::string_view(d_stringBuffer).substr(d_valueBegin, d_valueEnd - d_valueBegin))) && (__out == -1 ==> (*data ↦ _))
 int Tokenizer::value(bsl::string_view *data) const
 {
     if ((e_ELEMENT_NAME == d_tokenType || e_ELEMENT_VALUE == d_tokenType) &&

--- a/groups/bdl/bdljsn/bdljsn_writeoptions.cpp
+++ b/groups/bdl/bdljsn/bdljsn_writeoptions.cpp
@@ -33,6 +33,7 @@ WriteOptions::WriteOptions()
 }
 
 // MANIPULATORS
+// ensures: d_initialIndentLevel ↦ s_DEFAULT_INITIALIZER_INITIAL_INDENT_LEVEL ⋆ d_sortMembers ↦ s_DEFAULT_INITIALIZER_SORT_MEMBERS ⋆ d_escapeForwardSlash ↦ s_DEFAULT_INITIALIZER_ESCAPE_FORWARD_SLASH ⋆ d_spacesPerLevel ↦ s_DEFAULT_INITIALIZER_SPACES_PER_LEVEL ⋆ d_style ↦ s_DEFAULT_INITIALIZER_STYLE
 WriteOptions& WriteOptions::reset()
 {
     d_initialIndentLevel = s_DEFAULT_INITIALIZER_INITIAL_INDENT_LEVEL;

--- a/groups/bdl/bdljsn/bdljsn_writestyle.cpp
+++ b/groups/bdl/bdljsn/bdljsn_writestyle.cpp
@@ -17,6 +17,7 @@ namespace bdljsn {
                              // -----------------
 
 // CLASS METHODS
+// ensures: __out == stream ⋆ stream ↦ _
 bsl::ostream& WriteStyle::print(bsl::ostream&    stream,
                                 WriteStyle::Enum value,
                                 int              level,

--- a/groups/bdl/bdlma/bdlma_aligningallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_aligningallocator.cpp
@@ -49,6 +49,7 @@ AligningAllocator::AligningAllocator(bsls::Types::size_type  alignment,
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 && (reinterpret_cast<bsls::Types::size_type>(__out) & d_mask) == 0))
 void *AligningAllocator::allocate(bsls::Types::size_type size)
 {
     void *ret;

--- a/groups/bdl/bdlma/bdlma_blocklist.cpp
+++ b/groups/bdl/bdlma/bdlma_blocklist.cpp
@@ -20,6 +20,7 @@ namespace bdlma {
 /// supplied allocator returning naturally-aligned memory, the size of the
 /// overall allocation will be rounded up to an integral multiple of
 /// `bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT`.
+// ensures: __out == ((size + sizeOfBlock - 1) & ~(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))
 inline
 static bsls::Types::size_type alignedAllocationSize(
                                             bsls::Types::size_type size,
@@ -48,6 +49,7 @@ BlockList::~BlockList()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *BlockList::allocate(bsls::Types::size_type size)
 {
     if (0 == size) {

--- a/groups/bdl/bdlma/bdlma_bufferimputil.cpp
+++ b/groups/bdl/bdlma/bdlma_bufferimputil.cpp
@@ -15,6 +15,7 @@ namespace bdlma {
                            // --------------------
 
 // CLASS METHODS
+// ensures: (__out != 0) && (old_cursor <= *cursor) && (*cursor <= bufferSize) && (SEPFORALL(0, *cursor, i, (buffer + i ↦ _)) ⋆ SEPFORALL(*cursor, bufferSize, i, (buffer + i ↦ _)))
 void *BufferImpUtil::allocateFromBuffer(bsls::Types::IntPtr       *cursor,
                                         char                      *buffer,
                                         bsls::Types::size_type     bufferSize,

--- a/groups/bdl/bdlma/bdlma_buffermanager.cpp
+++ b/groups/bdl/bdlma/bdlma_buffermanager.cpp
@@ -14,6 +14,7 @@ namespace bdlma {
                            // -------------------
 
 // MANIPULATORS
+// ensures: __out == size || __out > size
 bsls::Types::size_type BufferManager::expand(void                   *address,
                                              bsls::Types::size_type  size)
 {

--- a/groups/bdl/bdlma/bdlma_concurrentallocatoradapter.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentallocatoradapter.cpp
@@ -19,6 +19,7 @@ ConcurrentAllocatorAdapter::~ConcurrentAllocatorAdapter()
 }
 
 // MANIPULATORS
+// ensures: __out != 0 ==> (__out ↦ _)
 void *ConcurrentAllocatorAdapter::allocate(bsls::Types::size_type numBytes)
 {
     bslmt::LockGuard<bslmt::Mutex> guard(d_mutex_p);

--- a/groups/bdl/bdlma/bdlma_concurrentfixedpool.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentfixedpool.cpp
@@ -55,6 +55,7 @@ namespace bdlma {
                         // -------------------------
 
 // PRIVATE MANIPULATORS
+// ensures: (__out == 0) || (__out != 0)
 void *ConcurrentFixedPool::allocateNew()
 {
     Node *node;
@@ -112,6 +113,7 @@ ConcurrentFixedPool::~ConcurrentFixedPool()
 }
 
 // MANIPULATORS
+// ensures: __out != 0
 void *ConcurrentFixedPool::allocate()
 {
     int contentionCount = 0;

--- a/groups/bdl/bdlma/bdlma_concurrentmultipool.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentmultipool.cpp
@@ -292,6 +292,7 @@ ConcurrentMultipool::~ConcurrentMultipool()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *ConcurrentMultipool::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlma/bdlma_concurrentmultipoolallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentmultipoolallocator.cpp
@@ -19,6 +19,7 @@ ConcurrentMultipoolAllocator::~ConcurrentMultipoolAllocator()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *ConcurrentMultipoolAllocator::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {

--- a/groups/bdl/bdlma/bdlma_concurrentpool.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentpool.cpp
@@ -52,6 +52,7 @@ enum {
 
 /// Round up the specified `x` to the nearest whole integer multiple of the
 /// specified `y`.
+// ensures: (__out == ((x + y - 1) / y) * y) && (__out % y == 0) && (__out >= x)
 static inline
 bsls::Types::size_type roundUp(bsls::Types::size_type x,
                                bsls::Types::size_type y)
@@ -60,6 +61,7 @@ bsls::Types::size_type roundUp(bsls::Types::size_type x,
 }
 
 /// Return a linked-list link at the specified `address`.
+// ensures: __out == static_cast<LLink*>(static_cast<void*>(address))
 static inline
 LLink *toLink(char *address)
 {
@@ -76,6 +78,7 @@ LLink *toLink(char *address)
 /// free list).  Note that this value is the maximum of either the size of a
 /// `LLink` object or `blockSize` rounded up to the alignment required for a
 /// `LLink` object (i.e., the maximum platform alignment).
+// ensures: __out == roundUp(bsl::max(blockSize + HEADER_LENGTH, MINIMUM_LENGTH), bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT)
 static inline
 bsls::Types::size_type computeInternalBlockSize(
                                               bsls::Types::size_type blockSize)
@@ -202,6 +205,7 @@ ConcurrentPool::~ConcurrentPool()
 }
 
 // MANIPULATORS
+// ensures: __out != 0 && (__out ↦ _)
 void *ConcurrentPool::allocate()
 {
     Link *p;

--- a/groups/bdl/bdlma/bdlma_concurrentpoolallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentpoolallocator.cpp
@@ -20,6 +20,7 @@ enum {
 };
 
 // STATIC METHODS
+// ensures: (__out == ((totalSize + (bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1)) & ~(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))) && (bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT == bsls::AlignmentUtil::calculateAlignmentFromSize(__out))
 static inline
 BloombergLP::bsls::Types::size_type calculateMaxAlignedSize(
                                  BloombergLP::bsls::Types::size_type totalSize)
@@ -142,6 +143,7 @@ ConcurrentPoolAllocator::~ConcurrentPoolAllocator()
 }
 
 // MANIPULATORS
+// ensures: (__out == 0 ==> size == 0) && (__out != 0 ==> (__out ↦ _))
 void *ConcurrentPoolAllocator::allocate(size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {

--- a/groups/bdl/bdlma/bdlma_countingallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_countingallocator.cpp
@@ -65,6 +65,7 @@ CountingAllocator::~CountingAllocator()
 }
 
 // MANIPULATORS
+// ensures: (__out == 0 ==> size == 0) && (__out != 0 ==> ((__out - OFFSET) ↦ size ⋆ SEPFORALL(0, size, i, ((__out + i) ↦ _))))
 void *CountingAllocator::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {
@@ -105,6 +106,7 @@ void CountingAllocator::deallocate(void *address)
 }
 
 // ACCESSORS
+// ensures: __out == &stream
 bsl::ostream& CountingAllocator::print(bsl::ostream& stream) const
 {
     stream << "----------------------------------------\n"

--- a/groups/bdl/bdlma/bdlma_guardingallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_guardingallocator.cpp
@@ -49,6 +49,7 @@ struct AfterUserBlockDeallocationData
 
 /// Utility function to compute the `AfterUserBlockDeallocationData*`
 /// corresponding to the specified `address`.
+// ensures: __out == static_cast<AfterUserBlockDeallocationData*>(static_cast<char*>(address) - OFFSET * 2)
 AfterUserBlockDeallocationData *getDataBlockAddress(void *address)
 {
     return static_cast<AfterUserBlockDeallocationData*>(
@@ -62,6 +63,7 @@ BSLMF_ASSERT(sizeof(AfterUserBlockDeallocationData) <= OFFSET * 2);
 // HELPER FUNCTIONS
 
 /// Return the size (in bytes) of a system memory page.
+// ensures: __out == pageSize.loadRelaxed()
 int getSystemPageSize()
 {
     static bsls::AtomicInt pageSize(0);
@@ -88,6 +90,7 @@ int getSystemPageSize()
 /// Allocate a page-aligned block of memory of the specified `size` (in
 /// bytes), and return the address of the allocated block.  The behavior is
 /// undefined unless `size > 0`.
+// ensures: (__out == 0 ==> size <= 0) && (__out != 0 ==> (__out ↦ _ ⋆ size == size))
 void *systemAlloc(bsl::size_t size)
 {
     BSLS_ASSERT(size > 0);
@@ -141,6 +144,7 @@ void systemFree(void *address, size_t size)
 /// Protect from read/write access the page of memory at the specified
 /// `address` having the specified `pageSize` (in bytes).  The behavior is
 /// undefined unless `pageSize == getSystemPageSize()`.
+// ensures: (__out == true ==> (address ↦ _)) && (__out == false ==> true)
 int systemProtect(void *address, int pageSize)
 {
     BSLS_ASSERT(address);
@@ -199,6 +203,7 @@ GuardingAllocator::~GuardingAllocator()
 }
 
 // MANIPULATORS
+// ensures: (__out == 0 ==> size == 0) && (__out != 0 ==> (__out ↦ _))
 void *GuardingAllocator::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {

--- a/groups/bdl/bdlma/bdlma_infrequentdeleteblocklist.cpp
+++ b/groups/bdl/bdlma/bdlma_infrequentdeleteblocklist.cpp
@@ -21,6 +21,7 @@ namespace BloombergLP {
 /// supplied allocator returning naturally-aligned memory, the size of the
 /// overall allocation will be rounded up to an integral multiple of
 /// `bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT`.
+// ensures: __out == ((size + sizeOfBlock - 1) & ~static_cast<bsls::Types::size_type>(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))
 inline
 static bsls::Types::size_type alignedAllocationSize(
                                             bsls::Types::size_type size,
@@ -53,6 +54,7 @@ InfrequentDeleteBlockList::~InfrequentDeleteBlockList()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *InfrequentDeleteBlockList::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlma/bdlma_multipool.cpp
+++ b/groups/bdl/bdlma/bdlma_multipool.cpp
@@ -314,6 +314,7 @@ Multipool::~Multipool()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size > 0 ==> (__out != 0 && (__out - 1) ↦ _))
 void *Multipool::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlma/bdlma_pool.cpp
+++ b/groups/bdl/bdlma/bdlma_pool.cpp
@@ -37,6 +37,7 @@ enum {
 
 /// Round up the specified `x` to the nearest whole integer multiple of the
 /// specified `y`.  The behavior is undefined unless `1 <= y`.
+// ensures: (__out % y == 0) && (__out >= x)
 static inline
 bsls::Types::size_type roundUp(bsls::Types::size_type x,
                                bsls::Types::size_type y)

--- a/groups/bdl/bdlma/bdlma_sequentialpool.cpp
+++ b/groups/bdl/bdlma/bdlma_sequentialpool.cpp
@@ -30,6 +30,7 @@ namespace BloombergLP {
 /// in the presence of a supplied allocator returning naturally-aligned
 /// memory, the size of the overall allocation will be rounded up to an
 /// integral multiple of `bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT`.
+// ensures: __out == ((size + sizeOfBlock - 1) & ~(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))
 inline
 static bsls::Types::size_type alignedAllocationSize(
                                             bsls::Types::size_type size,
@@ -73,6 +74,7 @@ uint64_t SequentialPool::initAlwaysUnavailable(
 }
 
 // PRIVATE MANIPULATORS
+// ensures: (__out != 0 ==> (__out ↦ _)) && (__out == 0 ==> size == 0)
 void *SequentialPool::allocateNonFastPath(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp
+++ b/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp
@@ -140,6 +140,7 @@ EventSchedulerTestTimeSource_Data::EventSchedulerTestTimeSource_Data(
 }
 
 // MANIPULATORS
+// ensures: __out == d_currentTime && d_currentTime == old_d_currentTime + amount
 bsls::TimeInterval EventSchedulerTestTimeSource_Data::advanceTime(
                                                      bsls::TimeInterval amount)
 {
@@ -151,6 +152,7 @@ bsls::TimeInterval EventSchedulerTestTimeSource_Data::advanceTime(
 }
 
 // ACCESSORS
+// ensures: __out == d_currentTime
 bsls::TimeInterval EventSchedulerTestTimeSource_Data::currentTime() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_currentTimeMutex);
@@ -165,6 +167,7 @@ bsls::TimeInterval EventSchedulerTestTimeSource_Data::currentTime() const
 const char EventScheduler::s_defaultThreadName[16] = { "bdl.EventSched" };
 
 // PRIVATE CLASS METHODS
+// ensures: __out == 0
 bsls::Types::Int64 EventScheduler::returnZero()
 {
     return 0;
@@ -176,6 +179,7 @@ bsls::Types::Int64 EventScheduler::returnZeroInt(int)
 }
 
 // PRIVATE MANIPULATORS
+// ensures: __out >= 0
 bsls::Types::Int64 EventScheduler::chooseNextEvent(bsls::AtomicInt64 *now)
 {
     BSLS_ASSERT(0 != d_currentRecurringEvent || 0 != d_currentEvent);
@@ -881,6 +885,7 @@ EventScheduler::~EventScheduler()
 }
 
 // MANIPULATORS
+// ensures: (__out == EventQueue::e_INVALID ==> (*handle == 0)) && (__out != EventQueue::e_INVALID ==> (*handle == 0))
 int EventScheduler::cancelEvent(EventHandle *handle)
 {
     if (0 == (const Event *) *handle) {
@@ -1224,6 +1229,7 @@ void EventScheduler::stop()
 }
 
 // ACCESSORS
+// ensures: __out == d_running
 bool EventScheduler::isStarted() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
@@ -1343,6 +1349,7 @@ bsls::TimeInterval EventSchedulerTestTimeSource::advanceTime(
 }
 
 // ACCESSORS
+// ensures: __out == d_data_p->currentTime()
 bsls::TimeInterval EventSchedulerTestTimeSource::now() const
 {
     return d_data_p->currentTime();

--- a/groups/bdl/bdlmt/bdlmt_fixedthreadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_fixedthreadpool.cpp
@@ -266,6 +266,7 @@ FixedThreadPool::~FixedThreadPool()
 }
 
 // MANIPULATORS
+// ensures: (__out == 0) || (__out == -1)
 int FixedThreadPool::start()
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_metaMutex);

--- a/groups/bdl/bdlmt/bdlmt_multiprioritythreadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_multiprioritythreadpool.cpp
@@ -202,6 +202,7 @@ MultipriorityThreadPool::~MultipriorityThreadPool()
 }
 
 // MANIPULATORS
+// ensures: (__out == d_queue.pushBack(job, priority)) && (0 <= priority && priority < d_queue.numPriorities())
 int MultipriorityThreadPool::enqueueJob(const ThreadFunctor& job,
                                         int                  priority)
 {
@@ -457,6 +458,7 @@ void MultipriorityThreadPool::shutdown()
 }
 
 // ACCESSORS
+// ensures: __out == d_queue.isEnabled()
 bool MultipriorityThreadPool::isEnabled() const
 {
     return d_queue.isEnabled();

--- a/groups/bdl/bdlmt/bdlmt_multiqueuethreadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_multiqueuethreadpool.cpp
@@ -557,6 +557,7 @@ MultiQueueThreadPool::~MultiQueueThreadPool()
 }
 
 // MANIPULATORS
+// ensures: __out == d_nextId - 1 && (d_queueRegistry[__out] ↦ _)
 int MultiQueueThreadPool::createQueue()
 {
     bslmt::WriteLockGuard<bslmt::ReaderWriterMutex> guard(&d_lock);

--- a/groups/bdl/bdlmt/bdlmt_threadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_threadpool.cpp
@@ -90,7 +90,8 @@ struct ThreadPoolWaitNode {
                             // ===============
 
 /// Entry point for processing threads.
-extern "C" void *ThreadPoolEntry(void *aThis)
+extern "C" // ensures: __out == 0
+void *ThreadPoolEntry(void *aThis)
 {
     ((bdlmt::ThreadPool*)aThis)->workerThread();
     return 0;
@@ -658,6 +659,7 @@ void ThreadPool::stop()
 }
 
 // ACCESSORS
+// ensures: __out == d_numActiveThreads
 int ThreadPool::numActiveThreads() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);

--- a/groups/bdl/bdlmt/bdlmt_throttle.cpp
+++ b/groups/bdl/bdlmt/bdlmt_throttle.cpp
@@ -185,6 +185,7 @@ int Throttle::requestPermissionIfValid(bool                      *result,
 }
 
 // ACCESSOR
+// ensures: (numActions <= 0 || d_maxSimultaneousActions < numActions || d_nanosecondsPerAction == k_ALLOW_NONE) ==> __out == -1 && (numActions > 0 && d_maxSimultaneousActions >= numActions && d_nanosecondsPerAction != k_ALLOW_NONE) ==> __out == 0
 int Throttle::nextPermit(bsls::TimeInterval *result, int numActions) const
 {
     if (numActions <= 0 || d_maxSimultaneousActions < numActions ||

--- a/groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp
+++ b/groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp
@@ -345,6 +345,7 @@ TimerEventSchedulerTestTimeSource_Data::TimerEventSchedulerTestTimeSource_Data(
 }
 
 // MANIPULATORS
+// ensures: __out == d_currentTime && d_currentTime == old_d_currentTime + amount
 bsls::TimeInterval TimerEventSchedulerTestTimeSource_Data::advanceTime(
                                                      bsls::TimeInterval amount)
 {
@@ -356,6 +357,7 @@ bsls::TimeInterval TimerEventSchedulerTestTimeSource_Data::advanceTime(
 }
 
 // ACCESSORS
+// ensures: __out == d_currentTime
 bsls::TimeInterval TimerEventSchedulerTestTimeSource_Data::currentTime() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_currentTimeMutex);
@@ -1316,6 +1318,7 @@ void TimerEventScheduler::cancelAllClocks(bool wait)
 }
 
 // ACCESSORS
+// ensures: __out.totalMicroseconds() == minTime
 bsls::TimeInterval TimerEventScheduler::nextPendingEventTime() const
 {
     bsls::Types::Int64 minTime =
@@ -1422,6 +1425,7 @@ bsls::TimeInterval TimerEventSchedulerTestTimeSource::advanceTime(
 }
 
 // ACCESSORS
+// ensures: __out == d_data_p->currentTime()
 bsls::TimeInterval TimerEventSchedulerTestTimeSource::now() const
 {
     return d_data_p->currentTime();

--- a/groups/bdl/bdlpcre/bdlpcre_regex.cpp
+++ b/groups/bdl/bdlpcre/bdlpcre_regex.cpp
@@ -339,6 +339,7 @@ RegEx_MatchContext::~RegEx_MatchContext()
 }
 
 // PRIVATE ACCESSORS
+// ensures: (__out == 0 ==> (matchContextData->d_matchData_p != 0 ⋆ matchContextData->d_matchContext_p != 0 ⋆ (matchContextData->d_jitStack_p == 0 || (matchContextData->d_jitStack_p != 0)))) && (__out == k_INTERNAL_ERROR ==> true)
 int
 RegEx_MatchContext::allocateMatchContext(
                                 RegEx_MatchContextData *matchContextData) const
@@ -401,6 +402,7 @@ RegEx_MatchContext::deallocateMatchContext(
 }
 
 // MANIPULATORS
+// ensures: (d_pcre2Context_p ↦ pcre2Context) ⋆ (d_pcre2PatternCode_p ↦ patternCode) ⋆ (d_depthLimit ↦ depthLimit) ⋆ (d_jitStackSize ↦ jitStackSize) ⋆ (__out == allocateMatchContext(&d_mainThreadMatchData))
 int RegEx_MatchContext::initialize(pcre2_general_context *pcre2Context,
                                    pcre2_code            *patternCode,
                                    int                    depthLimit,
@@ -430,6 +432,7 @@ void RegEx_MatchContext::setDepthLimit(int depthLimit)
 }
 
 // ACCESSORS
+// ensures: (bslmt::ThreadUtil::isEqual(d_mainThread, bslmt::ThreadUtil::self()) ==> __out == RegEx::k_STATUS_SUCCESS) && (!bslmt::ThreadUtil::isEqual(d_mainThread, bslmt::ThreadUtil::self()) ==> __out == allocateMatchContext(matchContextData))
 int
 RegEx_MatchContext::acquireMatchContext(
                                 RegEx_MatchContextData *matchContextData) const
@@ -468,6 +471,7 @@ const size_t RegEx::k_INVALID_OFFSET = ~(size_t)0;
 
 
 // PRIVATE MANIPULATORS
+// ensures: ((__out == k_STATUS_SUCCESS) ==> (d_patternCode_p != nullptr)) && ((__out == k_INTERNAL_ERROR) ==> (d_patternCode_p == nullptr)) && (__out == k_STATUS_SUCCESS || __out == k_INTERNAL_ERROR)
 int RegEx::prepareImp(char       *errorMessage,
                       size_t      errorMessageLength,
                       size_t     *errorOffset,
@@ -820,6 +824,7 @@ int RegEx::replaceImp(STRING                  *result,
 }
 
 // CLASS METHODS
+// ensures: __out == k_IS_JIT_SUPPORTED
 bool RegEx::isJitAvailable()
 {
     unsigned int result = 0;

--- a/groups/bdl/bdls/bdls_fdstreambuf.cpp
+++ b/groups/bdl/bdls/bdls_fdstreambuf.cpp
@@ -68,6 +68,7 @@ typedef bdls::FilesystemUtil FileUtil;
 /// Return `true` if the specified file descriptor `fd` refers to a regular
 /// file and `false` otherwise.  Note that a regular file is a file and not
 /// a directory, pipe, printer, keyboard or other device.
+// ensures: (__out == true ==> "fd refers to a regular file") && (__out == false ==> "fd does not refer to a regular file")
 static
 bool getRegularFileInfo(bdls::FilesystemUtil::FileDescriptor fd)
 {
@@ -524,6 +525,7 @@ FdStreamBuf::~FdStreamBuf()
 }
 
 // PRIVATE MANIPULATORS
+// ensures: (__out == 0 ==> d_mode == e_INPUT_MODE) && (__out == -1 ==> d_mode != e_INPUT_MODE)
 int FdStreamBuf::switchToInputMode()
 {
     switch (d_mode) {
@@ -812,6 +814,7 @@ int FdStreamBuf::flush()
 }
 
 // PROTECTED MANIPULATORS
+// ensures: (__out != traits_type::eof()) || (__out == traits_type::eof())
 bsl::streambuf::int_type
 FdStreamBuf::underflow()
 {
@@ -997,6 +1000,7 @@ FdStreamBuf::overflow(int_type c)
     return ret;
 }
 
+// ensures: (buffer == 0 && numBytes == 0 ==> d_buf_p ↦ _ ⋆ d_mode == e_NULL_MODE) && (buffer != 0 && numBytes > 0 ==> d_buf_p ↦ buffer ⋆ d_mode == e_NULL_MODE)
 FdStreamBuf *FdStreamBuf::setbuf(char *buffer, bsl::streamsize numBytes)
     // 'buffer == 0 && n == 0' means to make this object have a 1 byte buffer.
     // 'buffer != 0 && n > 0' means to use 'buffer' as this object's internal

--- a/groups/bdl/bdls/bdls_filesystemutil.cpp
+++ b/groups/bdl/bdls/bdls_filesystemutil.cpp
@@ -525,6 +525,7 @@ int getProcessId()
 /// otherwise.  This is equivalent to `isDotOrDots`, except it is called in
 /// the case where we know there are no `/`s in the file name, making the
 /// check simpler and faster.
+// ensures: __out == ('.' == *path && (!path[1] || ('.' == path[1] && !path[2])))
 static inline
 bool shortIsDotOrDots(const char *path)
 {
@@ -824,6 +825,7 @@ void invokeCloseFD(void *fd_p, void *)
 
 /// Return `true` if the specified `path` is "." or ".." or ends in
 /// "/." or "/..", and `false` otherwise.
+// ensures: (__out == true ==> (path[0] == '.' && strlen(path) == 1) || (path[strlen(path) - 1] == '.' && path[strlen(path) - 2] == '.' && (strlen(path) == 2 || path[strlen(path) - 3] == '/'))) && (__out == false ==> !(path[0] == '.' && strlen(path) == 1) && !(path[strlen(path) - 1] == '.' && path[strlen(path) - 2] == '.' && (strlen(path) == 2 || path[strlen(path) - 3] == '/')))
 static inline
 bool isDotOrDots(const char *path)
 {
@@ -902,6 +904,7 @@ int makeDirectory(const char *path, bool isPrivate)
 /// specified open file descriptor `dirFD`, not including the root.  Close
 /// `dirFd`.  The behavior is undefined unless `dirFD` refers to a directory
 /// and not a symlink.  Return 0 on success and a non-zero value otherwise.
+// ensures: (__out == 0) ==> "Directory contents successfully removed" && (__out != 0) ==> "Error occurred while removing directory contents"
 static
 int u_removeContentsOfTree(
                  const BloombergLP::bdls::FilesystemUtil::FileDescriptor dirFD)

--- a/groups/bdl/bdls/bdls_pathutil.cpp
+++ b/groups/bdl/bdls/bdls_pathutil.cpp
@@ -192,6 +192,7 @@ void findFirstNonSeparatorChar(int *result, const char *path, int length = -1)
 /// `length` is not given, assume `path` is null-terminated.  Note that this
 /// file may be a directory.  Also note that trailing separators are
 /// ignored.
+// ensures: (__out >= (path + rootEnd)) && (__out <= (path + length)) && (__out <= (path + bsl::strlen(path)))
 static
 const char *leafDelimiter(const char *path, int rootEnd, int length = -1)
 {

--- a/groups/bdl/bdls/bdls_pipeutil.cpp
+++ b/groups/bdl/bdls/bdls_pipeutil.cpp
@@ -103,6 +103,7 @@ namespace bdls {
                               // ---------------
 
 // CLASS METHODS
+// ensures: pipeName != 0 && (pipeName ↦ _)
 int PipeUtil::makeCanonicalName(bsl::string             *pipeName,
                                 const bsl::string_view&  baseName)
 {

--- a/groups/bdl/bdls/bdls_processutil.cpp
+++ b/groups/bdl/bdls/bdls_processutil.cpp
@@ -71,6 +71,7 @@ using namespace BloombergLP;
     } while (false)
 
 /// Return a ptr to a string describing whether "/proc" exists or not.
+// ensures: __out != 0
 static
 const char *doesProcExist()
 {
@@ -99,6 +100,7 @@ int getPid()
 /// not a directory, and is executable (or is a symbolic link to such a
 /// file) and `false` otherwise.  On Windows, return `true` if the file
 /// exists and is not a directory.
+// ensures: (__out == true ==> (0 == rc && !(s.st_mode & S_IFDIR) && (s.st_mode & executableBits))) && (__out == false ==> (rc != 0 || (s.st_mode & S_IFDIR) || !(s.st_mode & executableBits)))
 static inline
 bool isExecutable(const char *path)
 {

--- a/groups/bdl/bdls/bdls_tempdirectoryguard.cpp
+++ b/groups/bdl/bdls/bdls_tempdirectoryguard.cpp
@@ -49,6 +49,7 @@ void TempDirectoryGuard::release()
 
 
 // ACCESSORS
+// ensures: __out == d_dirName
 const bsl::string& TempDirectoryGuard::getTempDirName() const
 {
     return d_dirName;

--- a/groups/bdl/bdlsb/bdlsb_fixedmeminput.cpp
+++ b/groups/bdl/bdlsb/bdlsb_fixedmeminput.cpp
@@ -16,6 +16,7 @@ namespace bdlsb {
                         // -------------------
 
 // MANIPULATORS
+// ensures: (__out == -1 ==> (!(which & bsl::ios_base::in) || (static_cast<bsl::size_t>(position) > d_bufferSize || off_type(position) < 0))) && (__out != -1 ==> (d_pos ↦ position))
 FixedMemInput::pos_type
 FixedMemInput::pubseekpos(pos_type                position,
                           bsl::ios_base::openmode which)

--- a/groups/bdl/bdlsb/bdlsb_fixedmeminstreambuf.cpp
+++ b/groups/bdl/bdlsb/bdlsb_fixedmeminstreambuf.cpp
@@ -13,6 +13,7 @@ namespace BloombergLP {
 namespace bdlsb {
 
 // PROTECTED MANIPULATORS
+// ensures: (!(which & bsl::ios_base::in) || way != bsl::ios_base::beg && way != bsl::ios_base::cur && way != bsl::ios_base::end || __out < 0 || static_cast<bsl::size_t>(__out) > d_bufferSize) ==> __out == pos_type(-1) && (which & bsl::ios_base::in) && (way == bsl::ios_base::beg || way == bsl::ios_base::cur || way == bsl::ios_base::end) && __out >= 0 && static_cast<bsl::size_t>(__out) <= d_bufferSize ==> __out != pos_type(-1)
 FixedMemInStreamBuf::pos_type
 FixedMemInStreamBuf::seekoff(off_type                offset,
                              bsl::ios_base::seekdir  way,

--- a/groups/bdl/bdlsb/bdlsb_memoutstreambuf.cpp
+++ b/groups/bdl/bdlsb/bdlsb_memoutstreambuf.cpp
@@ -49,6 +49,7 @@ void MemOutStreamBuf::grow(size_t newLength)
 }
 
 // PROTECTED MANIPULATORS
+// ensures: (insertionChar == traits_type::eof() ==> __out == traits_type::not_eof(insertionChar)) && (insertionChar != traits_type::eof() ==> __out != traits_type::eof())
 int MemOutStreamBuf::overflow(int_type insertionChar)
 {
     if (traits_type::eof() == insertionChar) {

--- a/groups/bdl/bdlsb/bdlsb_overflowmemoutput.cpp
+++ b/groups/bdl/bdlsb/bdlsb_overflowmemoutput.cpp
@@ -64,6 +64,7 @@ OverflowMemOutput::OverflowMemOutput(char             *buffer,
 }
 
 // MANIPULATORS
+// ensures: (!(which & bsl::ios_base::out) || way != bsl::ios_base::beg && way != bsl::ios_base::cur && way != bsl::ios_base::end || __out < 0 ==> __out == -1) && (!(which & bsl::ios_base::out) && way == bsl::ios_base::beg && way == bsl::ios_base::cur && way == bsl::ios_base::end && __out >= 0 ==> __out != -1)
 OverflowMemOutput::pos_type
 OverflowMemOutput::pubseekoff(off_type                offset,
                               bsl::ios_base::seekdir  way,

--- a/groups/bdl/bdlsb/bdlsb_overflowmemoutstreambuf.cpp
+++ b/groups/bdl/bdlsb/bdlsb_overflowmemoutstreambuf.cpp
@@ -53,6 +53,7 @@ void OverflowMemOutStreamBuf::privateSync() const
 
 
 // PROTECTED MANIPULATORS
+// ensures: (c == EOF ==> __out == traits_type::not_eof(c)) && (c != EOF ==> __out == c)
 OverflowMemOutStreamBuf::int_type
 OverflowMemOutStreamBuf::overflow(OverflowMemOutStreamBuf::int_type c)
 {

--- a/groups/bdl/bdlt/bdlt_calendar.cpp
+++ b/groups/bdl/bdlt/bdlt_calendar.cpp
@@ -90,6 +90,7 @@ void Calendar::synchronizeCache()
 }
 
 // PRIVATE ACCESSORS
+// ensures: (__out == true ==> (d_packedCalendar.length() == static_cast<int>(d_nonBusinessDays.length()) && (d_packedCalendar.length() == 0 || FORALL(d_packedCalendar.beginBusinessDays(), d_packedCalendar.endBusinessDays(), iter, *iter - d_packedCalendar.firstDate() == static_cast<int>(d_nonBusinessDays.find0AtMinIndex(*iter - d_packedCalendar.firstDate())))))) && (__out == false ==> (d_packedCalendar.length() != static_cast<int>(d_nonBusinessDays.length()) || EXISTS(d_packedCalendar.beginBusinessDays(), d_packedCalendar.endBusinessDays(), iter, *iter - d_packedCalendar.firstDate() != static_cast<int>(d_nonBusinessDays.find0AtMinIndex(*iter - d_packedCalendar.firstDate())))))
 bool Calendar::isCacheSynchronized() const
 {
     if (d_packedCalendar.length() !=
@@ -306,6 +307,7 @@ void Calendar::unionNonBusinessDays(const PackedCalendar& other)
 }
 
 // ACCESSORS
+// ensures: (__out == e_SUCCESS ==> (nextBusinessDay != 0 && *nextBusinessDay ↦ _)) && (__out == e_FAILURE)
 int Calendar::getNextBusinessDay(Date        *nextBusinessDay,
                                  const Date&  date,
                                  int          nth) const
@@ -334,6 +336,7 @@ int Calendar::getNextBusinessDay(Date        *nextBusinessDay,
 #ifndef BDE_OMIT_INTERNAL_DEPRECATED  // BDE3.0
 
 // DEPRECATED METHODS
+// ensures: __out > initialDate && !isWeekendDay(__out) && (length() == 0 || isBusinessDay(__out))
 Date Calendar::getNextBusinessDay(const Date& initialDate) const
 {
     Date currentDate = initialDate;

--- a/groups/bdl/bdlt/bdlt_calendarcache.cpp
+++ b/groups/bdl/bdlt/bdlt_calendarcache.cpp
@@ -52,6 +52,7 @@ CalendarCache_Entry::~CalendarCache_Entry()
 }
 
 // MANIPULATORS
+// ensures: (this->d_ptr ↦ rhs.d_ptr) ⋆ (this->d_loadTime ↦ rhs.d_loadTime)
 CalendarCache_Entry& CalendarCache_Entry::operator=(
                                                 const CalendarCache_Entry& rhs)
 {
@@ -62,6 +63,7 @@ CalendarCache_Entry& CalendarCache_Entry::operator=(
 }
 
 // ACCESSORS
+// ensures: __out ↦ d_ptr
 bsl::shared_ptr<const Calendar> CalendarCache_Entry::get() const
 {
     return d_ptr;
@@ -109,6 +111,7 @@ CalendarCache::~CalendarCache()
 }
 
 // MANIPULATORS
+// ensures: (__out != nullptr) || (__out == nullptr && !d_loader_p->load(&packedCalendar, calendarName))
 bsl::shared_ptr<const Calendar>
 CalendarCache::getCalendar(const char *calendarName)
 {
@@ -197,6 +200,7 @@ int CalendarCache::invalidateAll()
 }
 
 // ACCESSORS
+// ensures: (__out != nullptr) || (__out == nullptr)
 bsl::shared_ptr<const Calendar>
 CalendarCache::lookupCalendar(const char *calendarName) const
 {

--- a/groups/bdl/bdlt/bdlt_date.cpp
+++ b/groups/bdl/bdlt/bdlt_date.cpp
@@ -33,6 +33,7 @@ static const char *const months[] = {
                                   // ----------
 
 // MANIPULATORS
+// ensures: __out == 0 || __out == -1
 int Date::addDaysIfValid(int numDays)
 {
     enum { k_SUCCESS = 0, k_FAILURE = -1 };
@@ -53,6 +54,7 @@ int Date::addDaysIfValid(int numDays)
 }
 
 // ACCESSORS
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& Date::print(bsl::ostream& stream,
                           int           level,
                           int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_datetime.cpp
+++ b/groups/bdl/bdlt/bdlt_datetime.cpp
@@ -152,6 +152,7 @@ const bsls::Types::Uint64 Datetime::k_MAX_US_FROM_EPOCH =
 bsls::AtomicInt64 Datetime::s_invalidRepresentationCount(0);
 
 // ACCESSORS
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream& Datetime::print(bsl::ostream& stream,
                               int           level,
                               int           spacesPerLevel) const
@@ -275,6 +276,7 @@ int Datetime::printToBuffer(char *result,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& bdlt::operator<<(bsl::ostream& stream, const Datetime& object)
 {
     return object.print(stream, 0, -1);

--- a/groups/bdl/bdlt/bdlt_datetimeimputil.cpp
+++ b/groups/bdl/bdlt/bdlt_datetimeimputil.cpp
@@ -50,6 +50,7 @@ BSLMF_ASSERT(  DatetimeImpUtil::k_1970_01_01_VALUE
              < DatetimeImpUtil::k_MAX_VALUE);
 
 // CLASS METHODS
+// ensures: __out != 0
 const Datetime *DatetimeImpUtil::epoch_0001_01_01()
 {
     return reinterpret_cast<const bdlt::Datetime *>(&k_0001_01_01_VALUE);

--- a/groups/bdl/bdlt/bdlt_datetimeinterval.cpp
+++ b/groups/bdl/bdlt/bdlt_datetimeinterval.cpp
@@ -56,6 +56,7 @@ const double maxInt64AsDouble = static_cast<double>(k_MAX_INT64);
 const double minInt64AsDouble = static_cast<double>(k_MIN_INT64);
 
 // HELPER FUNCTIONS
+// ensures: __out >= 0
 int printToBufferFormatted(char       *result,
                            int         numBytes,
                            const char *spec,
@@ -245,6 +246,7 @@ int DatetimeInterval::assignIfValid(bsls::Types::Int64 days,
 }
 
 // CLASS METHODS
+// ensures: (u::k_HOURS_FLOOR <= hours && hours <= u::k_HOURS_CEILING && u::k_MINUTES_FLOOR <= minutes && minutes <= u::k_MINUTES_CEILING && u::k_SECONDS_FLOOR <= seconds && seconds <= u::k_SECONDS_CEILING && u::k_MILLISECONDS_FLOOR <= milliseconds && milliseconds <= u::k_MILLISECONDS_CEILING) ==> __out == true && (!(u::k_HOURS_FLOOR <= hours && hours <= u::k_HOURS_CEILING && u::k_MINUTES_FLOOR <= minutes && minutes <= u::k_MINUTES_CEILING && u::k_SECONDS_FLOOR <= seconds && seconds <= u::k_SECONDS_CEILING && u::k_MILLISECONDS_FLOOR <= milliseconds && milliseconds <= u::k_MILLISECONDS_CEILING)) ==> __out == false
 bool DatetimeInterval::isValid(int                days,
                                bsls::Types::Int64 hours,
                                bsls::Types::Int64 minutes,
@@ -632,6 +634,7 @@ bsl::ostream& DatetimeInterval::print(bsl::ostream& stream,
 #ifndef BDE_OMIT_INTERNAL_DEPRECATED  // BDE2.22
 
 // DEPRECATED METHODS
+// ensures: __out == &stream && *__out == stream
 bsl::ostream& DatetimeInterval::streamOut(bsl::ostream& stream) const
 {
     return stream << *this;

--- a/groups/bdl/bdlt/bdlt_datetimetz.cpp
+++ b/groups/bdl/bdlt/bdlt_datetimetz.cpp
@@ -33,6 +33,7 @@ BSLMF_ASSERT(bslmf::IsBitwiseCopyable<DatetimeTz>::value);
                              // ----------------
 
 // ACCESSORS
+// ensures: (__out == &stream) && (!__out->bad() ==> (__out ↦ _))
 bsl::ostream& DatetimeTz::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_datetz.cpp
+++ b/groups/bdl/bdlt/bdlt_datetz.cpp
@@ -29,6 +29,7 @@ BSLMF_ASSERT(!bslmf::IsTriviallyCopyableCheck<DateTz>::value);
                              // ------------
 
 // ACCESSORS
+// ensures: (__out == stream) && (!stream.bad()) && (stream ↦ _)
 bsl::ostream& DateTz::print(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_dateutil.cpp
+++ b/groups/bdl/bdlt/bdlt_dateutil.cpp
@@ -10,6 +10,7 @@ namespace {
 
 /// Return the difference in number of days from the specified `day1` to the
 /// specified `day2`.
+// ensures: (day1 > day2 ==> __out == 7 - day1 + day2) && (day1 <= day2 ==> __out == day2 - day1) && (0 <= __out && __out < 7)
 int dayOfWeekDifference(DayOfWeek::Enum day1, DayOfWeek::Enum day2)
 {
     if (day1 > day2) {
@@ -27,6 +28,7 @@ int dayOfWeekDifference(DayOfWeek::Enum day1, DayOfWeek::Enum day2)
                              // ---------------
 
 // PRIVATE CLASS METHODS
+// ensures: (__out.year() == original.year() + numYears) && (__out.month() == 2) && ((__out.day() == original.day()) || (__out.day() == (SerialDateImpUtil::isLeapYear(__out.year()) ? 29 : 28)))
 Date DateUtil::addYearsEomEndOfFebruary(const Date& original, int numYears)
 {
     // Implementation note: The complete 'addYearsEom' was too long to be
@@ -59,6 +61,7 @@ Date DateUtil::addYearsEomEndOfFebruary(const Date& original, int numYears)
 }
 
 // CLASS METHODS
+// ensures: (original.day() == SerialDateImpUtil::lastDayOfMonth(original.year(), original.month()) ==> __out.day() == SerialDateImpUtil::lastDayOfMonth(__out.year(), __out.month())) && (original.day() != SerialDateImpUtil::lastDayOfMonth(original.year(), original.month()) && SerialDateImpUtil::lastDayOfMonth(__out.year(), __out.month()) < original.day() ==> __out.day() == SerialDateImpUtil::lastDayOfMonth(__out.year(), __out.month())) && (original.day() != SerialDateImpUtil::lastDayOfMonth(original.year(), original.month()) && SerialDateImpUtil::lastDayOfMonth(__out.year(), __out.month()) >= original.day() ==> __out.day() == original.day())
 Date DateUtil::addMonthsEom(const Date& original, int numMonths)
 {
     const int totalMonths = original.year() * 12 + original.month() +

--- a/groups/bdl/bdlt/bdlt_dayofweek.cpp
+++ b/groups/bdl/bdlt/bdlt_dayofweek.cpp
@@ -19,6 +19,7 @@ namespace bdlt {
                             // ---------------
 
 // CLASS METHODS
+// ensures: (__out == stream) && (stream ↦ _)
 bsl::ostream& DayOfWeek::print(bsl::ostream&   stream,
                                DayOfWeek::Enum value,
                                int             level,

--- a/groups/bdl/bdlt/bdlt_dayofweekset.cpp
+++ b/groups/bdl/bdlt/bdlt_dayofweekset.cpp
@@ -53,6 +53,7 @@ DayOfWeekSet_Iter::DayOfWeekSet_Iter(int data, int index)
 }
 
 // MANIPULATORS
+// ensures: (d_index < 8 && ((1 << d_index) & d_data) != 0) || d_index == 8
 DayOfWeekSet_Iter& DayOfWeekSet_Iter::operator++()
 {
     while (d_index < 8) {
@@ -82,6 +83,7 @@ DayOfWeekSet_Iter& DayOfWeekSet_Iter::operator--()
                          // ------------------
 
 // ACCESSORS
+// ensures: __out == &stream && (stream.bad() == false) && (__out ↦ _)
 bsl::ostream& DayOfWeekSet::print(bsl::ostream& stream,
                                   int           level,
                                   int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_defaultcalendarcache.cpp
+++ b/groups/bdl/bdlt/bdlt_defaultcalendarcache.cpp
@@ -41,6 +41,7 @@ bsls::ObjectBuffer<CalendarCache>            g_buffer;
 
 /// Return the address of the lock used to initialize and destroy the
 /// default calendar cache in a thread-safe manner.
+// ensures: __out != 0
 static
 bslmt::Mutex *getLock()
 {
@@ -68,6 +69,7 @@ bslmt::Mutex *getLock()
 /// `allocator` remain valid until a subsequent call to
 /// `bdlt::DefaultCalendarCache::destroy`, and
 /// `bsls::TimeInterval() <= timeout <= bsls::TimeInterval(INT_MAX, 0)`.
+// ensures: __out == 0 || __out == 1
 static
 int initializePrivate(CalendarLoader            *loader,
                       bool                       hasTimeOutFlag,

--- a/groups/bdl/bdlt/bdlt_defaulttimetablecache.cpp
+++ b/groups/bdl/bdlt/bdlt_defaulttimetablecache.cpp
@@ -40,6 +40,7 @@ bsls::ObjectBuffer<TimetableCache>           g_buffer;
 
 /// Return the address of the lock used to initialize and destroy the
 /// default timetable cache in a thread-safe manner.
+// ensures: __out != 0
 static
 bslmt::Mutex *getLock()
 {
@@ -67,6 +68,7 @@ bslmt::Mutex *getLock()
 /// `allocator` remain valid until a subsequent call to
 /// `bdlt::DefaultTimetableCache::destroy`, and
 /// `bsls::TimeInterval() <= timeout <= bsls::TimeInterval(INT_MAX, 0)`.
+// ensures: __out == 0 || __out == 1
 static
 int initializePrivate(TimetableLoader           *loader,
                       bool                       hasTimeOutFlag,

--- a/groups/bdl/bdlt/bdlt_fixutil.cpp
+++ b/groups/bdl/bdlt/bdlt_fixutil.cpp
@@ -224,6 +224,7 @@ int Impl::generate(STRING                      *string,
 /// non-zero value (with no effect) otherwise.  All characters in the range
 /// `[begin .. end)` must be decimal digits.  The behavior is undefined
 /// unless `begin < end` and the parsed value does not exceed `INT_MAX`.
+// ensures: (__out == 0 ==> (*result ↦ tmp ⋆ *nextPos ↦ end)) && (__out == -1 ==> true)
 int asciiToInt(const char **nextPos,
                int         *result,
                const char  *begin,
@@ -262,6 +263,7 @@ int asciiToInt(const char **nextPos,
 /// `*nextPos`) otherwise.  The behavior is undefined unless `begin <= end`.
 /// Note that successfully parsing a date before `end` is reached is not an
 /// error.
+// ensures: __out == 0 || __out == -1
 int parseDate(const char **nextPos,
               Date        *date,
               const char  *begin,
@@ -315,6 +317,7 @@ int parseDate(const char **nextPos,
 /// the first 7 are parsed but ignored.  The behavior is undefined unless
 /// `begin <= end`.  Note that successfully parsing a fractional second
 /// before `end` is reached is not an error.
+// ensures: (__out == 0 ==> (*nextPos == begin || SEPFORALL(begin, *nextPos, p, (p ↦ _) && isdigit(*p)) ⋆ *microsecond == tmp)) && (__out == -1 ==> (*nextPos == old_nextPos ⋆ *microsecond == old_microsecond))
 int parseFractionalSecond(const char **nextPos,
                           int         *microsecond,
                           const char  *begin,
@@ -376,6 +379,7 @@ int parseFractionalSecond(const char **nextPos,
 /// otherwise.  The behavior is undefined unless `begin <= end`.  Note that
 /// successfully parsing a timezone offset before `end` is reached is not an
 /// error.
+// ensures: (__out == 0 ==> (*nextPos > begin && *minuteOffset >= -1439 && *minuteOffset <= 1439)) && (__out == -1 ==> (*nextPos == begin || *minuteOffset == 0))
 int parseTimezoneOffset(const char **nextPos,
                         int         *minuteOffset,
                         const char  *begin,
@@ -457,6 +461,7 @@ int parseTimezoneOffset(const char **nextPos,
 /// `*nextPos`) otherwise.  The behavior is undefined unless
 /// `begin <= end`.  Note that successfully parsing a time before `end` is
 /// reached is not an error.
+// ensures: __out == 0 || __out == -1
 int parseTime(const char **nextPos,
               Time        *time,
               int         *tzOffset,
@@ -575,6 +580,7 @@ int parseTime(const char **nextPos,
 /// that if the decimal string representation of `value` is more than
 /// `paddedLen` digits, only the low-order `paddedLen` digits of `value` are
 /// output.
+// ensures: __out == paddedLen && FORALL(0, paddedLen, i, buffer[i] >= '0' && buffer[i] <= '9')
 int generateInt(char *buffer, int value, int paddedLen)
 {
     BSLS_ASSERT(buffer);
@@ -599,6 +605,7 @@ int generateInt(char *buffer, int value, int paddedLen)
 /// sufficient capacity to hold `paddedLen` characters.  Note that if the
 /// decimal string representation of `value` is more than `paddedLen`
 /// digits, only the low-order `paddedLen` digits of `value` are output.
+// ensures: __out == paddedLen + 1
 inline
 int generateInt(char *buffer, int value, int paddedLen, char separator)
 {
@@ -616,6 +623,7 @@ int generateInt(char *buffer, int value, int paddedLen, char separator)
 /// indicated by the specified `tzOffset` and `configuration`, and return
 /// the number of bytes written.  The behavior is undefined unless `buffer`
 /// has sufficient capacity and `-(24 * 60) < tzOffset < 24 * 60`.
+// ensures: (0 == tzOffset && configuration.useZAbbreviationForUtc() ==> __out == 1) && (0 != tzOffset || !configuration.useZAbbreviationForUtc() ==> __out >= 4)
 int generateTimezoneOffset(char                        *buffer,
                            int                          tzOffset,
                            const FixUtilConfiguration&  configuration)
@@ -785,6 +793,7 @@ namespace bdlt {
                               // --------------
 
 // CLASS METHODS
+// ensures: __out == k_DATE_STRLEN
 int FixUtil::generate(char                        *buffer,
                       int                          bufferLength,
                       const Date&                  object,

--- a/groups/bdl/bdlt/bdlt_fixutilconfiguration.cpp
+++ b/groups/bdl/bdlt/bdlt_fixutilconfiguration.cpp
@@ -61,6 +61,7 @@ FixUtilConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& bdlt::operator<<(bsl::ostream&               stream,
                                const FixUtilConfiguration& object)
 {

--- a/groups/bdl/bdlt/bdlt_iso8601utilconfiguration.cpp
+++ b/groups/bdl/bdlt/bdlt_iso8601utilconfiguration.cpp
@@ -84,6 +84,7 @@ Iso8601UtilConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& bdlt::operator<<(bsl::ostream&                   stream,
                                const Iso8601UtilConfiguration& object)
 {

--- a/groups/bdl/bdlt/bdlt_iso8601utilparseconfiguration.cpp
+++ b/groups/bdl/bdlt/bdlt_iso8601utilparseconfiguration.cpp
@@ -36,6 +36,7 @@ Iso8601UtilParseConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: __out == &stream
 bsl::ostream& bdlt::operator<<(bsl::ostream&                        stream,
                                const Iso8601UtilParseConfiguration& object)
 {

--- a/groups/bdl/bdlt/bdlt_monthofyear.cpp
+++ b/groups/bdl/bdlt/bdlt_monthofyear.cpp
@@ -16,6 +16,7 @@ namespace bdlt {
                      // ------------------
 
 // CLASS METHODS
+// ensures: __out == stream ⋆ (stream ↦ _)
 bsl::ostream& MonthOfYear::print(bsl::ostream&     stream,
                                  MonthOfYear::Enum value,
                                  int               level,

--- a/groups/bdl/bdlt/bdlt_packedcalendar.cpp
+++ b/groups/bdl/bdlt/bdlt_packedcalendar.cpp
@@ -137,6 +137,7 @@ void appendHoliday(
 /// product of the specified `level` and `spacesPerLevel` to the specified
 /// output `stream` and return a reference to the modifiable `stream`.  If
 /// the `level` is negative, this function has no effect.
+// ensures: __out == stream && (__out.rdbuf()->invariant())
 static
 bsl::ostream& indent(bsl::ostream& stream,
                      int           level,
@@ -499,6 +500,7 @@ void PackedCalendar::unionHolidays(
 }
 
 // PRIVATE MANIPULATORS
+// ensures: (0 <= offset && d_holidayOffsets.back() < offset) ==> __out == static_cast<int>(d_holidayOffsets.length()) && (0 <= offset && d_holidayOffsets.back() >= offset) ==> (0 <= __out && __out < static_cast<int>(d_holidayOffsets.length()))
 int PackedCalendar::addHolidayImp(int offset)
 {
     BSLS_ASSERT(0 <= offset && d_lastDate - d_firstDate >= offset);
@@ -604,6 +606,7 @@ PackedCalendar::~PackedCalendar()
 }
 
 // MANIPULATORS
+// ensures: __out == *this
 PackedCalendar& PackedCalendar::operator=(const PackedCalendar& rhs)
 {
     PackedCalendar(rhs, d_allocator_p).swap(*this);
@@ -1360,6 +1363,7 @@ bsl::ostream& PackedCalendar::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.d_firstDate == rhs.d_firstDate && lhs.d_lastDate == rhs.d_lastDate && lhs.d_weekendDaysTransitions == rhs.d_weekendDaysTransitions && lhs.d_holidayOffsets == rhs.d_holidayOffsets && lhs.d_holidayCodesIndex == rhs.d_holidayCodesIndex && lhs.d_holidayCodes == rhs.d_holidayCodes)) && (__out == false ==> !(lhs.d_firstDate == rhs.d_firstDate && lhs.d_lastDate == rhs.d_lastDate && lhs.d_weekendDaysTransitions == rhs.d_weekendDaysTransitions && lhs.d_holidayOffsets == rhs.d_holidayOffsets && lhs.d_holidayCodesIndex == rhs.d_holidayCodesIndex && lhs.d_holidayCodes == rhs.d_holidayCodes))
 bool bdlt::operator==(const PackedCalendar& lhs, const PackedCalendar& rhs)
 {
     return lhs.d_firstDate              == rhs.d_firstDate
@@ -1526,6 +1530,7 @@ void PackedCalendar_BusinessDayConstIterator::previousBusinessDay()
 }
 
 // MANIPULATORS
+// ensures: __out.d_offsetIter == rhs.d_offsetIter ⋆ __out.d_calendar_p == rhs.d_calendar_p ⋆ __out.d_currentOffset == rhs.d_currentOffset ⋆ __out.d_endFlag == rhs.d_endFlag
 PackedCalendar_BusinessDayConstIterator&
 PackedCalendar_BusinessDayConstIterator::operator=(
                             const PackedCalendar_BusinessDayConstIterator& rhs)

--- a/groups/bdl/bdlt/bdlt_posixdateimputil.cpp
+++ b/groups/bdl/bdlt/bdlt_posixdateimputil.cpp
@@ -101,6 +101,7 @@ static const int leapDaysPerMonth[] = { 0,
 /// indicated by an integer index in the range `[ 0 .. k_MAX_MONTH ]`, where
 /// an index of 0 always results in the value 0.  The behavior is undefined
 /// unless `k_MIN_YEAR <= year <= k_MAX_YEAR`.
+// ensures: (k_MIN_YEAR <= year && year <= k_MAX_YEAR) ==> ((bdlt::PosixDateImpUtil::isLeapYear(year) && (year == k_YEAR_1752 ==> __out == y1752DaysThroughMonth) && (year != k_YEAR_1752 ==> __out == leapDaysThroughMonth)) || (!bdlt::PosixDateImpUtil::isLeapYear(year) && __out == normDaysThroughMonth))
 static inline
 const int *getArrayDaysThroughMonth(int year)
 {
@@ -184,6 +185,7 @@ int numLeapYearsSoFar(int year)
                            // -----------------------
 
 // CLASS METHODS
+// ensures: (month == k_FEBRUARY && isLeapYear(year)) ==> (__out == normDaysPerMonth[month] + 1) && ((month != k_FEBRUARY || !isLeapYear(year)) ==> (__out == normDaysPerMonth[month]))
 int PosixDateImpUtil::lastDayOfMonth(int year, int month)
 {
     BSLS_ASSERT(k_MIN_YEAR  <= year);

--- a/groups/bdl/bdlt/bdlt_prolepticdateimputil.cpp
+++ b/groups/bdl/bdlt/bdlt_prolepticdateimputil.cpp
@@ -164,6 +164,7 @@ int numLeapYearsSoFar(int);
 /// `year` and including the days in the specified `month`.  The behavior is
 /// undefined unless `k_MIN_YEAR <= year <= k_MAX_YEAR` and
 /// `0 <= month <= k_MAX_MONTH`.
+// ensures: __out == getArrayDaysThroughMonth(year)[month]
 static inline
 int calendarDaysThroughMonth(int year, int month)
 {
@@ -189,6 +190,7 @@ const int *getArrayDaysThroughMonth(int year)
 /// Return the total number of days in all years, beginning with the year 1,
 /// up to but not including the specified `year`.  The behavior is undefined
 /// unless `k_MIN_YEAR <= year <= k_MAX_YEAR`.
+// ensures: __out == (year - 1) * k_DAYS_IN_NON_LEAP_YEAR + numLeapYearsSoFar(year - 1)
 static inline
 int numDaysInPreviousYears(int year)
 {
@@ -216,6 +218,7 @@ int numLeapYearsSoFar(int year)
                            // ---------------------------
 
 // CLASS METHODS
+// ensures: (month == k_FEB && isLeapYear(year) ==> __out == normDaysPerMonth[month] + 1) && (month != k_FEB || !isLeapYear(year) ==> __out == normDaysPerMonth[month])
 int ProlepticDateImpUtil::lastDayOfMonth(int year, int month)
 {
     BSLS_ASSERT(k_MIN_YEAR  <= year);

--- a/groups/bdl/bdlt/bdlt_time.cpp
+++ b/groups/bdl/bdlt/bdlt_time.cpp
@@ -49,6 +49,7 @@ BSLMF_ASSERT(!bslmf::IsTriviallyCopyableCheck<Time>::value);
 /// ```
 /// *number == *number % base + (*number / base) * base
 /// ```
+// ensures: (__out == old_initial / base) && (number ↦ old_initial % base) && (old_initial == *number + __out * base)
 static
 bsls::Types::Int64 fastMod(int *number, int base)
 {
@@ -100,6 +101,7 @@ bsls::Types::Int64 fastMod(bsls::Types::Int64 *number, bsls::Types::Int64 base)
 /// *number == *number % base + (*number / base) * base
 /// ```
 /// The behavior is undefined unless `1 <= base`.
+// ensures: (__out == old(*number) / base) && (number != 0) && (number ↦ (*number >= 0 && *number < base))
 static
 bsls::Types::Int64 modulo(bsls::Types::Int64 *number, bsls::Types::Int64 base)
 {
@@ -203,6 +205,7 @@ int printToBufferFormatted(char       *result,
 bsls::AtomicInt64 Time::s_invalidRepresentationCount(0);
 
 // PRIVATE ACCESSORS
+// ensures: __out == (BSLS_PLATFORM_IS_LITTLE_ENDIAN ? (d_value * TimeUnitRatio::k_US_PER_MS) : ((d_value >> 32) * TimeUnitRatio::k_US_PER_MS))
 bsls::Types::Int64 Time::invalidMicrosecondsFromMidnight() const
 {
     BSLS_ASSERT(k_REP_MASK > d_value);
@@ -217,6 +220,7 @@ bsls::Types::Int64 Time::invalidMicrosecondsFromMidnight() const
 }
 
 // MANIPULATORS
+// ensures: __out == static_cast<int>(wholeDays)
 int Time::addHours(int hours)
 {
     bsls::Types::Int64 totalMicroseconds =

--- a/groups/bdl/bdlt/bdlt_timetable.cpp
+++ b/groups/bdl/bdlt/bdlt_timetable.cpp
@@ -92,6 +92,7 @@ bsl::ostream& TimetableTransition::print(bsl::ostream& stream,
                            // -------------------
 
 // MANIPULATORS
+// ensures: (__out == true ==> (previousFinalCode != finalTransitionCode())) && (__out == false ==> (previousFinalCode == finalTransitionCode()))
 bool Timetable_Day::addTransition(const Time& time, int code)
 {
     BSLS_ASSERT(24 > time.hour());
@@ -137,6 +138,7 @@ bool Timetable_Day::removeTransition(const Time& time)
 }
 
 // ACCESSORS
+// ensures: (time.hour() < 24) ==> (__out == iter->d_code || __out == finalTransitionCode() || __out == d_initialTransitionCode)
 int Timetable_Day::transitionCodeInEffect(const Time& time) const
 {
     BSLS_ASSERT(24 > time.hour());
@@ -438,6 +440,7 @@ void Timetable::setValidRange(const Date& firstDate, const Date& lastDate)
 }
 
 // ACCESSORS
+// ensures: __out != Timetable_ConstIterator()
 Timetable::const_iterator Timetable::begin() const
 {
     bsl::size_t dayIndex = 0;
@@ -479,6 +482,7 @@ bsl::ostream& Timetable::print(bsl::ostream& stream,
                       // -----------------------------
 
 // MANIPULATORS
+// ensures: &__out == this
 Timetable_ConstIterator& Timetable_ConstIterator::operator++()
 {
     BSLS_ASSERT(d_dayIndex < d_timetable_p->d_timetable.length());

--- a/groups/bdl/bdlt/bdlt_timetablecache.cpp
+++ b/groups/bdl/bdlt/bdlt_timetablecache.cpp
@@ -53,6 +53,7 @@ TimetableCache_Entry::~TimetableCache_Entry()
 }
 
 // MANIPULATORS
+// ensures: __out.d_ptr ↦ rhs.d_ptr ⋆ __out.d_loadTime ↦ rhs.d_loadTime
 TimetableCache_Entry& TimetableCache_Entry::operator=(
                                                const TimetableCache_Entry& rhs)
 {
@@ -63,6 +64,7 @@ TimetableCache_Entry& TimetableCache_Entry::operator=(
 }
 
 // ACCESSORS
+// ensures: __out ↦ d_ptr
 bsl::shared_ptr<const Timetable> TimetableCache_Entry::get() const
 {
     return d_ptr;
@@ -110,6 +112,7 @@ TimetableCache::~TimetableCache()
 }
 
 // MANIPULATORS
+// ensures: (timetableName != nullptr ==> __out != nullptr && __out.use_count() > 0) || (timetableName == nullptr ==> __out == nullptr && __out.use_count() == 0)
 bsl::shared_ptr<const Timetable>
 TimetableCache::getTimetable(const char *timetableName)
 {
@@ -195,6 +198,7 @@ int TimetableCache::invalidateAll()
 }
 
 // ACCESSORS
+// ensures: (__out.use_count() > 0) || (__out == bsl::shared_ptr<const Timetable>())
 bsl::shared_ptr<const Timetable>
 TimetableCache::lookupTimetable(const char *timetableName) const
 {

--- a/groups/bdl/bdlt/bdlt_timetz.cpp
+++ b/groups/bdl/bdlt/bdlt_timetz.cpp
@@ -30,6 +30,7 @@ BSLMF_ASSERT(!bslmf::IsTriviallyCopyableCheck<TimeTz>::value);
                              // ------------
 
 // ACCESSORS
+// ensures: __out == stream && stream.bad() == false
 bsl::ostream& TimeTz::print(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel) const

--- a/groups/bsl/bslalg/bslalg_rbtreeutil.cpp
+++ b/groups/bsl/bslalg/bslalg_rbtreeutil.cpp
@@ -17,6 +17,7 @@ namespace BloombergLP {
 namespace bslalg {
 
 /// Return `true` if `node` is 0 or colored black, and `false` otherwise.
+// ensures: (__out == true ==> (node == 0 || (node->isBlack() == true))) && (__out == false ==> (node != 0 && (node->isBlack() == false)))
 static inline bool isBlackOrNull(const RbTreeNode *node)
 {
     return !node || node->isBlack();
@@ -157,6 +158,7 @@ static void recolorTreeAfterRemoval(RbTreeAnchor *tree,
                         // class RbTreeUtil
                         // ----------------
 // CLASS METHODS
+// ensures: (__out->leftChild() == 0) && (__out != 0)
 const RbTreeNode *RbTreeUtil::leftmost(const RbTreeNode *subtree)
 {
     BSLS_ASSERT(subtree);

--- a/groups/bsl/bslfmt/bslfmt_unicodecodepoint.cpp
+++ b/groups/bsl/bslfmt/bslfmt_unicodecodepoint.cpp
@@ -147,6 +147,7 @@ static bool isByteOrderMarker(const void *bytes, size_t maxBytes)
 /// 2-byte UTF-8 sequence referred to by the specified `pc`.  The behavior is
 /// undefined unless the 2 bytes starting at `pc` contain a UTF-8 sequence
 /// describing a single valid code point.
+// ensures: __out == (((*pc & 0x1f) << 6) | ((pc[1] & k_UTF8_CONT_VALUE_MASK)))
 inline
 static int get2ByteUtf8Value(const unsigned char *pc)
 {
@@ -157,6 +158,7 @@ static int get2ByteUtf8Value(const unsigned char *pc)
 /// 3-byte UTF-8 sequence referred to by the specified `pc`.  The behavior is
 /// undefined unless the 3 bytes starting at `pc` contain a UTF-8 sequence
 /// describing a single valid code point.
+// ensures: __out == (((*pc & 0xf) << 12) | ((pc[1] & k_UTF8_CONT_VALUE_MASK) << 6) | (pc[2] & k_UTF8_CONT_VALUE_MASK))
 inline
 static int get3ByteUtf8Value(const unsigned char *pc)
 {
@@ -168,6 +170,7 @@ static int get3ByteUtf8Value(const unsigned char *pc)
 /// 4-byte UTF-8 sequence referred to by the specified `pc`.  The behavior is
 /// undefined unless the 4 bytes starting at `pc` contain a UTF-8 sequence
 /// describing a single valid code point.
+// ensures: __out == (((*pc & 0x7) << 18) | ((pc[1] & k_UTF8_CONT_VALUE_MASK) << 12) | ((pc[2] & k_UTF8_CONT_VALUE_MASK) << 6) | ((pc[3] & k_UTF8_CONT_VALUE_MASK)))
 inline
 static int get4ByteUtf8Value(const unsigned char *pc)
 {
@@ -179,6 +182,7 @@ static int get4ByteUtf8Value(const unsigned char *pc)
 /// Determine the width of the specified `codepoint` per the rules in the C++
 /// standard in [format.string.std].  Note that this width may differ from that
 /// specified by the Unicode standard.
+// ensures: __out == 1 || __out == 2
 inline
 static int getCodepointWidth(unsigned long int codepoint)
 {
@@ -211,6 +215,7 @@ static int getCodepointWidth(unsigned long int codepoint)
 
 /// Return `true` if the specified `value` is NOT a UTF-8 continuation byte,
 /// and `false` otherwise.
+// ensures: (__out == true ==> (value & 0xc0) != 0x80) && (__out == false ==> (value & 0xc0) == 0x80)
 inline
 static bool isNotUtf8Continuation(unsigned char value)
 {
@@ -230,6 +235,7 @@ static bool isSurrogateValue(unsigned int value)
 
 /// Return `true` if the specified `value` is a high surrogate value, and
 /// `false` otherwise.
+// ensures: (__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) == k_UTF16_HIGH_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) != k_UTF16_HIGH_SURROGATE_START))
 inline
 static bool isHighSurrogateValue(unsigned int value)
 {
@@ -241,6 +247,7 @@ static bool isHighSurrogateValue(unsigned int value)
 
 /// Return `true` if the specified `value` is a high surrogate value, and
 /// `false` otherwise.
+// ensures: (__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) == k_UTF16_LOW_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) != k_UTF16_LOW_SURROGATE_START))
 inline
 static bool isLowSurrogateValue(unsigned int value)
 {

--- a/groups/bsl/bslh/bslh_siphashalgorithm.cpp
+++ b/groups/bsl/bslh/bslh_siphashalgorithm.cpp
@@ -86,6 +86,7 @@ typedef unsigned char       u8;
 /// Return the bits of the specified `x` rotated to the left by the
 /// specified `b` number of bits.  Bits that are rotated off the end are
 /// wrapped around to the beginning.
+// ensures: __out == ((x << b) | (x >> (64 - b)))
 inline
 static u64 rotl(u64 x, u64 b)
 {
@@ -116,6 +117,7 @@ static void sipround(u64& v0, u64& v1, u64& v2, u64& v3)
 /// Return the 64-bit integer representation of the specified `p` taking
 /// into account endianness.  Undefined unless `p` points to at least eight
 /// bytes of initialized memory.
+// ensures: __out == BSLS_BYTEORDER_LE_U64_TO_HOST(*((u64*)p))
 inline
 static u64 u8to64_le(const u8* p)
 {

--- a/groups/bsl/bslim/bslim_printer.cpp
+++ b/groups/bsl/bslim/bslim_printer.cpp
@@ -80,6 +80,7 @@ Printer::~Printer()
 }
 
 // ACCESSORS
+// ensures: __out == d_level
 int Printer::absLevel() const
 {
     return d_level;

--- a/groups/bsl/bslma/bslma_allocator.cpp
+++ b/groups/bsl/bslma/bslma_allocator.cpp
@@ -36,6 +36,7 @@ Allocator::~Allocator()
 }
 
 // PROTECTED MANIPULATORS
+// ensures: (bytes == 0 ==> __out != nullptr) && (bytes != 0 ==> __out != nullptr)
 void *Allocator::do_allocate(std::size_t bytes, std::size_t align)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == bytes)) {

--- a/groups/bsl/bslma/bslma_bufferallocator.cpp
+++ b/groups/bsl/bslma/bslma_bufferallocator.cpp
@@ -26,6 +26,7 @@ namespace BloombergLP {
 /// allocation.  The behavior is undefined unless
 /// `0 < alignment <= bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT` and alignment
 /// is an integral power of 2.
+// ensures: (__out == nullptr ==> *cursor + bsls::AlignmentUtil::calculateAlignmentOffset(buffer + *cursor, alignment) + size > bufSize) && (__out != nullptr ==> __out >= buffer && __out < buffer + bufSize)
 static
 void *allocateFromBufferImp(int                               *cursor,
                             char                              *buffer,
@@ -122,6 +123,7 @@ BufferAllocator::~BufferAllocator()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out == 0 || (__out != 0 ⋆ __out ↦ _)))
 void *BufferAllocator::allocate(size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {

--- a/groups/bsl/bslma/bslma_infrequentdeleteblocklist.cpp
+++ b/groups/bsl/bslma/bslma_infrequentdeleteblocklist.cpp
@@ -26,6 +26,7 @@ InfrequentDeleteBlockList::~InfrequentDeleteBlockList()
 }
 
 // MANIPULATORS
+// ensures: (numBytes == 0 ==> __out == 0) && (numBytes != 0 ==> __out != 0)
 void *InfrequentDeleteBlockList::allocate(int numBytes)
 {
     if (0 == numBytes) {

--- a/groups/bsl/bslma/bslma_mallocfreeallocator.cpp
+++ b/groups/bsl/bslma/bslma_mallocfreeallocator.cpp
@@ -41,6 +41,7 @@ static bsls::AtomicOperations::AtomicTypes::Pointer
 
 /// Construct a `bslma::MallocFreeAllocator` at the location specified by
 /// `p` in a thread-safe way.  Return `p`.
+// ensures: (__out == &p->object()) && (p->object() ↦ _)
 static inline
 bslma::MallocFreeAllocator *initSingleton(
                                         bslma_MallocFreeAllocator_Singleton *p)
@@ -103,6 +104,7 @@ MallocFreeAllocator& MallocFreeAllocator::singleton()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *MallocFreeAllocator::allocate(size_type size)
 {
     if (!size) {

--- a/groups/bsl/bslma/bslma_newdeleteallocator.cpp
+++ b/groups/bsl/bslma/bslma_newdeleteallocator.cpp
@@ -28,6 +28,7 @@ static bsls::AtomicOperations::AtomicTypes::Pointer
 
 /// Construct a `bslma::NewDeleteAllocator` at the specified `address` in a
 /// thread-safe way, and return `address`.
+// ensures: __out != 0 && (address->object() ↦ _)
 static inline
 bslma::NewDeleteAllocator *
 initSingleton(bslma_NewDeleteAllocator_Singleton *address)
@@ -95,6 +96,7 @@ NewDeleteAllocator::~NewDeleteAllocator()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *NewDeleteAllocator::allocate(size_type size)
 {
     return 0 == size ? 0 : ::operator new(size);

--- a/groups/bsl/bslma/bslma_sequentialpool.cpp
+++ b/groups/bsl/bslma/bslma_sequentialpool.cpp
@@ -191,6 +191,7 @@ SequentialPool::SequentialPool(
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *SequentialPool::allocate(int size)
 {
     BSLS_ASSERT(0 <= size);

--- a/groups/bsl/bslma/bslma_testallocator.cpp
+++ b/groups/bsl/bslma/bslma_testallocator.cpp
@@ -106,6 +106,7 @@ const std::size_t k_MAX_ALIGNMENT = bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT;
 
 /// Return `true` if the specified `address` is aligned on the specified
 /// `alignment` or `false` otherwise.
+// ensures: (__out == true ==> (bsls::AlignmentUtil::calculateAlignmentOffset(address, int(alignment)) == 0)) && (__out == false ==> (bsls::AlignmentUtil::calculateAlignmentOffset(address, int(alignment)) != 0))
 inline bool isAligned(const void *address, std::size_t alignment)
 {
     return 0 == bsls::AlignmentUtil::calculateAlignmentOffset(address,
@@ -412,6 +413,7 @@ TestAllocator::~TestAllocator()
 }
 
 // MANIPULATORS
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ (__out ↦ _)))
 void *TestAllocator::allocate(size_type size)
 {
     // All updates are protected by a mutex lock, so as to not interleave the
@@ -704,6 +706,7 @@ void TestAllocator::deallocate(void *address)
 }
 
 // PRIVATE ACCESSORS
+// ensures: (__out > 0) && (__out < k_BLOCKID_LINE_SZ) && (output[__out - 1] == '\n') && (output[__out] == '\0') && (*blockList == currBlock_p)
 std::size_t
 TestAllocator::formatEightBlockIds(const TestAllocator_BlockHeader** blockList,
                                    char*                             output)

--- a/groups/bsl/bslmt/bslmt_configuration.cpp
+++ b/groups/bsl/bslmt/bslmt_configuration.cpp
@@ -68,6 +68,7 @@ static int nativeDefaultThreadStackSizeImp()
 }
 # endif
 #else // WIN32_THREADS
+// ensures: (1 <= __out) && (__out <= INT_MAX)
 static int nativeDefaultThreadStackSizeImp()
     // Return the native thread stack size for Windows.
 {

--- a/groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp
+++ b/groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp
@@ -8,6 +8,7 @@ namespace BloombergLP {
 
 /// Interpreting `argument` as an `EntryPointFunctorAdapter_Base*`, invoke
 /// `argument->function(argument)`.  Do not use outside this component.
+// ensures: __out == 0
 void *bslmt_EntryPointFunctorAdapter_invoker(void* argument)
 {
     bslmt::EntryPointFunctorAdapter_Base* threadArg =

--- a/groups/bsl/bslmt/bslmt_latch.cpp
+++ b/groups/bsl/bslmt/bslmt_latch.cpp
@@ -99,6 +99,7 @@ void Latch::wait()
 }
 
 // ACCESSORS
+// ensures: __out == d_sigCount
 int Latch::currentCount() const
 {
     // Point 2: The following operation requires acquire semantics to ensure

--- a/groups/bsl/bslmt/bslmt_qlock.cpp
+++ b/groups/bsl/bslmt/bslmt_qlock.cpp
@@ -109,6 +109,7 @@ extern "C" void deleteThreadLocalSemaphore(void *semaphore)
 /// thread-safe: calling it multiple times simultaneously will result in the
 /// initialization of a single TLS key.  Note that the returned key can be
 /// used to access the thread-local semaphore for the current thread.
+// ensures: __out != 0
 TlsKey *initializeSemaphoreTLSKey()
 {
     TlsKey *key = new (semaphoreAllocator()) TlsKey;
@@ -143,6 +144,7 @@ TlsKey *initializeSemaphoreTLSKey()
 /// Create and initialize a new key if one has not been previously been
 /// created.  This operation is thread-safe: calling it multiple times
 /// simultaneously will return the same address to an initialized key.
+// ensures: __out != 0
 inline
 TlsKey *getSemaphoreTLSKey()
 {
@@ -157,6 +159,7 @@ TlsKey *getSemaphoreTLSKey()
 }
 
 /// Return the address of the semaphore unique to the calling thread.
+// ensures: __out != 0
 SemaphorePtr getSemaphoreForCurrentThread()
 {
 #ifdef BSLMT_THREAD_LOCAL_VARIABLE

--- a/groups/bsl/bslmt/bslmt_sluice.cpp
+++ b/groups/bsl/bslmt/bslmt_sluice.cpp
@@ -90,6 +90,7 @@ bslmt::Sluice::~Sluice()
 }
 
 // MANIPULATORS
+// ensures: __out != NULL
 const void *bslmt::Sluice::enter()
 {
     LockGuard<Mutex> lock(&d_mutex);

--- a/groups/bsl/bslmt/bslmt_testutil.cpp
+++ b/groups/bsl/bslmt/bslmt_testutil.cpp
@@ -18,6 +18,7 @@ namespace bslmt {
                                 // ---------------
 
 // CLASS METHODS
+// ensures: __out == ptr
 void *TestUtil::identityPtr(void *ptr)
 {
     return ptr;
@@ -28,6 +29,7 @@ void *TestUtil::identityPtr(void *ptr)
                              // --------------------
 
 /// Return a reference to the recursive mutex created by this singleton.
+// ensures: mutex_p != 0 && &__out == mutex_p && (mutex_p != 0 ==> &__out == mutex_p)
 RecursiveMutex& TestUtil_Guard::singletonMutex()
 {
     static RecursiveMutex *mutex_p;

--- a/groups/bsl/bslmt/bslmt_threadattributes.cpp
+++ b/groups/bsl/bslmt/bslmt_threadattributes.cpp
@@ -56,6 +56,7 @@ bslmt::ThreadAttributes::ThreadAttributes(
 }
 
 // MANIPULATORS
+// ensures: __out == *this ⋆ d_detachedState ↦ rhs.d_detachedState ⋆ d_guardSize ↦ rhs.d_guardSize ⋆ d_inheritScheduleFlag ↦ rhs.d_inheritScheduleFlag ⋆ d_schedulingPolicy ↦ rhs.d_schedulingPolicy ⋆ d_schedulingPriority ↦ rhs.d_schedulingPriority ⋆ d_stackSize ↦ rhs.d_stackSize ⋆ d_threadName ↦ rhs.d_threadName
 bslmt::ThreadAttributes& bslmt::ThreadAttributes::operator=(
                                             const bslmt::ThreadAttributes& rhs)
 {
@@ -71,6 +72,7 @@ bslmt::ThreadAttributes& bslmt::ThreadAttributes::operator=(
 }
 
 // ACCESSORS
+// ensures: (__out == &stream) && (__out ↦ _)
 bsl::ostream& bslmt::ThreadAttributes::print(
                                             bsl::ostream& stream,
                                             int           level,
@@ -92,6 +94,7 @@ bsl::ostream& bslmt::ThreadAttributes::print(
 }
 
 // FREE OPERATORS
+// ensures: (__out == true ==> (lhs.detachedState() == rhs.detachedState() && lhs.guardSize() == rhs.guardSize() && lhs.inheritSchedule() == rhs.inheritSchedule() && lhs.schedulingPolicy() == rhs.schedulingPolicy() && lhs.schedulingPriority() == rhs.schedulingPriority() && lhs.stackSize() == rhs.stackSize() && lhs.threadName() == rhs.threadName())) && (__out == false ==> !(lhs.detachedState() == rhs.detachedState() && lhs.guardSize() == rhs.guardSize() && lhs.inheritSchedule() == rhs.inheritSchedule() && lhs.schedulingPolicy() == rhs.schedulingPolicy() && lhs.schedulingPriority() == rhs.schedulingPriority() && lhs.stackSize() == rhs.stackSize() && lhs.threadName() == rhs.threadName()))
 bool bslmt::operator==(const ThreadAttributes& lhs,
                        const ThreadAttributes& rhs)
 {

--- a/groups/bsl/bslmt/bslmt_threadutil.cpp
+++ b/groups/bsl/bslmt/bslmt_threadutil.cpp
@@ -92,6 +92,7 @@ void *bslmt_threadutil_namedFuncPtrThunk(void *arg)
                             // -----------------
 
 // CLASS METHODS
+// ensures: (minPri == ThreadAttributes::e_UNSET_PRIORITY || maxPri == ThreadAttributes::e_UNSET_PRIORITY) ==> __out == ThreadAttributes::e_UNSET_PRIORITY
 int bslmt::ThreadUtil::convertToSchedulingPriority(
                ThreadAttributes::SchedulingPolicy policy,
                double                             normalizedSchedulingPriority)

--- a/groups/bsl/bslmt/bslmt_throughputbenchmark.cpp
+++ b/groups/bsl/bslmt/bslmt_throughputbenchmark.cpp
@@ -29,6 +29,7 @@ namespace bslmt {
                         // -------------------------
 
 // CLASS METHODS
+// ensures: __out == s_antiOptimization
 unsigned int ThroughputBenchmark::antiOptimization()
 {
     return s_antiOptimization;

--- a/groups/bsl/bslmt/bslmt_turnstile.cpp
+++ b/groups/bsl/bslmt/bslmt_turnstile.cpp
@@ -18,6 +18,7 @@ enum { k_MICROSECS_PER_SECOND = 1000 * 1000 };
 /// Increase the value stored at the specified `timestamp` to the current time.
 /// If another thread has updated `timestamp`, this method might not modify the
 /// stored value.  Return the current value of the `timestamp`.
+// ensures: __out >= old_timestamp->load() && (__out == old_timestamp->load() || __out == bsls::SystemTime::nowMonotonicClock().totalMicroseconds())
 static bsls::Types::Int64 updateTimestamp(bsls::AtomicInt64 *timestamp)
 {
     bsls::Types::Int64 nowUSec =
@@ -98,6 +99,7 @@ bsls::Types::Int64 bslmt::Turnstile::waitTurn(bool sleep)
 }
 
 // ACCESSORS
+// ensures: __out >= 0 && (__out == (nowUSecs - d_nextTurn) || __out == 0)
 bsls::Types::Int64 bslmt::Turnstile::lagTime() const
 {
     Int64 nowUSecs = updateTimestamp(&d_timestamp);

--- a/groups/bsl/bsls/bsls_alignment.cpp
+++ b/groups/bsl/bsls/bsls_alignment.cpp
@@ -16,6 +16,7 @@ namespace bsls {
                             // ----------------
 
 // CLASS METHODS
+// ensures: (value == Alignment::BSLS_MAXIMUM ==> __out == "MAXIMUM") && (value == Alignment::BSLS_NATURAL ==> __out == "NATURAL") && (value == Alignment::BSLS_BYTEALIGNED ==> __out == "BYTEALIGNED") && (value != Alignment::BSLS_MAXIMUM && value != Alignment::BSLS_NATURAL && value != Alignment::BSLS_BYTEALIGNED ==> __out == "(* UNKNOWN *)")
 const char *Alignment::toAscii(Alignment::Strategy value)
 {
 #define CASE(X) case(BSLS_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_asserttest.cpp
+++ b/groups/bsl/bsls/bsls_asserttest.cpp
@@ -132,6 +132,7 @@ ComponentName::ComponentName(const char *sourceFilename)
 }
 
 // ACCESSORS
+// ensures: (__out == true ==> (d_str_p == 0 && d_length == 0)) && (__out == false ==> (d_str_p != 0 || d_length != 0))
 bool ComponentName::isEmpty() const
 {
     return d_str_p == 0 && d_length == 0;
@@ -160,6 +161,7 @@ const char* ComponentName::str() const
 /// characters that compare equal.  Since the compare operation dereferences
 /// this type, and this type has two non-reference values (empty and error):
 /// The behavior is undefined if either `lhs` or `rhs` is empty or an error.
+// ensures: (__out == true ==> (lhs.length() == rhs.length() && 0 == memcmp(lhs.str(), rhs.str(), lhs.length()))) && (__out == false ==> (lhs.length() != rhs.length() || memcmp(lhs.str(), rhs.str(), lhs.length()) != 0))
 bool operator==(const ComponentName& lhs, const ComponentName& rhs)
 {
     return lhs.length() == rhs.length() &&
@@ -170,6 +172,7 @@ bool operator==(const ComponentName& lhs, const ComponentName& rhs)
 /// names are considered the same in testing:
 /// * If either of the names was missing, we assume they are the same.
 /// * If both component names are provided they must match, including case.
+// ensures: (__out == true ==> (testName.isEmpty() || throwName.isEmpty() || throwName == testName)) && (__out == false ==> !(testName.isEmpty() || throwName.isEmpty() || throwName == testName))
 static
 bool areTheSameComponent(const ComponentName& throwName,
                          const ComponentName& testName)

--- a/groups/bsl/bsls/bsls_blockgrowth.cpp
+++ b/groups/bsl/bsls/bsls_blockgrowth.cpp
@@ -13,6 +13,7 @@ namespace bsls {
                         // ------------------
 
 // CLASS METHODS
+// ensures: __out != 0
 const char *BlockGrowth::toAscii(BlockGrowth::Strategy value)
 {
 #define CASE(X) case(BSLS_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_bslsourcenameparserutil.cpp
+++ b/groups/bsl/bsls/bsls_bslsourcenameparserutil.cpp
@@ -49,6 +49,7 @@ bool startsWith(const char *begin, const char (&prefix)[CLEN])
 /// Return `true` if the specified character `ch` occurs at least the
 /// specified `count` times within the specified [`begin` .. `end`) range.
 /// The behavior is undefined unless `begin` is not less than `end`.
+// ensures: (__out == true ==> SEPEXISTS(0, end - begin, i, (begin + i ↦ ch) && count - 1 == SEPEXISTS(0, i, j, (begin + j ↦ ch)))) && (__out == false ==> SEPFORALL(0, end - begin, i, (begin + i ↦ _) && (a[i] != ch || count > 0)))
 static
 inline
 bool hasAtLeastCountChar(const char *       begin,
@@ -71,6 +72,7 @@ bool hasAtLeastCountChar(const char *       begin,
 /// right after it, or `end` if it is the last character.  If `ch` is not
 /// found return `begin`.  The behavior is undefined if `begin` is greater
 /// than `end`.
+// ensures: (__out == end) || (__out >= begin && __out < end)
 static
 inline
 const char *onePastLastChr(const char *const begin, const char *end, char ch)
@@ -89,6 +91,7 @@ const char *onePastLastChr(const char *const begin, const char *end, char ch)
 
 /// Return `true` if the specified `tag` is a lowercase US alphabetic/letter
 /// character or return `false` if it is some other character.
+// ensures: (__out == true ==> (tag >= 'a' && tag <= 'z')) && (__out == false ==> !(tag >= 'a' && tag <= 'z'))
 static
 inline
 bool isAlphaTag(char tag)
@@ -112,6 +115,7 @@ bool isAlphaTag(char tag)
 
 /// Return `true` if the specified `tag` is a valid test driver tag
 /// character from a source name (`t` or `g`).
+// ensures: (__out == true ==> (tag == 't' || tag == 'g')) && (__out == false ==> (tag != 't' && tag != 'g'))
 static
 inline
 bool isTestDriverTag(char tag)
@@ -121,6 +125,7 @@ bool isTestDriverTag(char tag)
 
 /// Return `true` if the specified `sourceType` is a test driver type
 /// according to `SourceTypes`.
+// ensures: (__out == true ==> (sourceType & BslSourceNameParserUtil::k_MASK_TEST != 0)) && (__out == false ==> (sourceType & BslSourceNameParserUtil::k_MASK_TEST == 0))
 static
 inline
 bool isTestDriverType(unsigned sourceType)
@@ -131,6 +136,7 @@ bool isTestDriverType(unsigned sourceType)
 
 /// Return a pointer to the first character of the specified `filename`
 /// after the last path delimiter.
+// ensures: __out >= filename
 static
 const char *skipPath(const char *filename)
 {
@@ -157,6 +163,7 @@ namespace bsls {
                       //-------------------------------
 
 // CLASS METHODS
+// ensures: (__out == 0 ==> componentNamePtr != NULL && componentNameLength != NULL) && (__out != 0 ==> __out == -1 || __out == -2 || __out == -3)
 int BslSourceNameParserUtil::getComponentName(const char **componentNamePtr,
                                               size_t      *componentNameLength,
                                               const char  *sourceName,

--- a/groups/bsl/bsls/bsls_bsltestutil.cpp
+++ b/groups/bsl/bsls/bsls_bsltestutil.cpp
@@ -14,6 +14,7 @@ namespace bsls {
                            // ------------------
 
 // PRIVATE CLASS METHODS
+// ensures: __out == ptr
 void *BslTestUtil::identityPtr(void *ptr)
 {
     return ptr;

--- a/groups/bsl/bsls/bsls_log.cpp
+++ b/groups/bsl/bsls/bsls_log.cpp
@@ -95,6 +95,7 @@ BufferScopedGuard::~BufferScopedGuard()
 }
 
 // MANIPULATORS
+// ensures: (__out == 0 ==> d_buffer_p == 0) && (__out != 0 ==> (__out ↦ _ ⋆ SEPFORALL(0, numBytes, i, (__out + i) ↦ _)))
 char* BufferScopedGuard::allocate(size_t numBytes) {
 
     // Note that we don't want to use realloc, because it guarantees that the
@@ -125,6 +126,7 @@ char* BufferScopedGuard::allocate(size_t numBytes) {
 /// undefined unless `buffer` contains sufficient space to store `size`
 /// bytes and `format` is a valid `printf`-style format string with all
 /// expected substitutions present in `substitutions`.
+// ensures: (__out >= 0) && (size > __out ==> (buffer + __out ↦ 0) && SEPFORALL(0, __out, i, (buffer + i ↦ _)))
 int vsnprintf_alwaysCount(char       *buffer,
                           size_t      size,
                           const char *format,

--- a/groups/bsl/bsls/bsls_logseverity.cpp
+++ b/groups/bsl/bsls/bsls_logseverity.cpp
@@ -14,6 +14,7 @@ namespace bsls {
                      // ------------------
 
 // CLASS METHODS
+// ensures: (value == LogSeverity::e_FATAL ==> __out == "FATAL") && (value == LogSeverity::e_ERROR ==> __out == "ERROR") && (value == LogSeverity::e_WARN ==> __out == "WARN") && (value == LogSeverity::e_DEBUG ==> __out == "DEBUG") && (value == LogSeverity::e_INFO ==> __out == "INFO") && (value == LogSeverity::e_TRACE ==> __out == "TRACE") && (value != LogSeverity::e_FATAL && value != LogSeverity::e_ERROR && value != LogSeverity::e_WARN && value != LogSeverity::e_DEBUG && value != LogSeverity::e_INFO && value != LogSeverity::e_TRACE ==> __out == "(* UNKNOWN *)")
 const char *LogSeverity::toAscii(LogSeverity::Enum value)
 {
 #define CASE(X) case(e_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_nameof.cpp
+++ b/groups/bsl/bsls/bsls_nameof.cpp
@@ -85,6 +85,7 @@ namespace bsls {
 /// Initialize the specified `*buffer` with the type name contained in the
 /// specified `functionName`, where `functionName` is the function name of
 /// the `NameOf` constructor.
+// ensures: (__out == buffer) && (buffer ↦ _)
 const char *NameOf_Base::initBuffer(char       *buffer,
                                     const char *functionName)
 {

--- a/groups/bsl/bsls/bsls_outputredirector.cpp
+++ b/groups/bsl/bsls/bsls_outputredirector.cpp
@@ -405,6 +405,7 @@ void OutputRedirector::clear()
 }
 
 // ACCESSORS
+// ensures: expected != 0
 int OutputRedirector::compare(const char *expected) const
 {
     BSLS_ASSERT(expected);

--- a/groups/bsl/bsls/bsls_stackaddressutil.cpp
+++ b/groups/bsl/bsls/bsls_stackaddressutil.cpp
@@ -99,6 +99,7 @@ int getProcessId()
 /// least `length` bytes.  Note that this has been adapted from
 /// `bdls_processutil` to work within the constraints of the level of this
 /// component.
+// ensures: (__out == -1 ==> (length <= 0 || output == nullptr)) && (__out != -1 ==> (length > 0 && output != nullptr))
 int getProcessName(char *output, int length)
 {
 #if defined(BSLS_PLATFORM_OS_AIX)
@@ -290,6 +291,7 @@ namespace {
 /// undefined unless `tag` is a non-empty null-terminated string.  Return
 /// `0` if the `plink_timestamp___` global variable does not contain the
 /// `tag` or is not well formed.
+// ensures: __out == 0 || *__out != '\0'
 const char *getPwhatVar(const char *const tag)
 {
     // This is a modified version of 'sysutil_pwhat_getvar', adjusted to not

--- a/groups/bsl/bsls/bsls_systemclocktype.cpp
+++ b/groups/bsl/bsls/bsls_systemclocktype.cpp
@@ -14,6 +14,7 @@ namespace bsls {
                      // ----------------------
 
 // CLASS METHODS
+// ensures: (value == SystemClockType::e_REALTIME ==> __out == "REALTIME") && (value == SystemClockType::e_MONOTONIC ==> __out == "MONOTONIC") && (value != SystemClockType::e_REALTIME && value != SystemClockType::e_MONOTONIC ==> __out == "(* UNKNOWN *)")
 const char *SystemClockType::toAscii(SystemClockType::Enum value)
 {
 #define CASE(X) case(e_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_timeinterval.cpp
+++ b/groups/bsl/bsls/bsls_timeinterval.cpp
@@ -81,6 +81,7 @@ TimeInterval::TimeInterval(double seconds)
 }
 
 // MANIPULATORS
+// ensures: __out == *this
 TimeInterval& TimeInterval::addInterval(bsls::Types::Int64 seconds,
                                         int                nanoseconds)
 {
@@ -117,6 +118,7 @@ TimeInterval& TimeInterval::addInterval(bsls::Types::Int64 seconds,
 }
 
 // ACCESSORS
+// ensures: __out == stream
 std::ostream& TimeInterval::print(std::ostream& stream,
                                   int           level,
                                   int           spacesPerLevel) const

--- a/groups/bsl/bslstl/bslstl_sharedptr.cpp
+++ b/groups/bsl/bslstl/bslstl_sharedptr.cpp
@@ -21,6 +21,7 @@ namespace bslstl {
                              // -------------------
 
 // MANIPULATORS
+// ensures: __out != nullptr && (__out.get() ↦ _ ⋆ SEPFORALL(0, bufferSize, i, (__out.get() + i) ↦ _))
 bsl::shared_ptr<char>
 SharedPtrUtil::createInplaceUninitializedBuffer(
                                               size_t            bufferSize,

--- a/groups/bsl/bslstl/bslstl_stopstate.cpp
+++ b/groups/bsl/bslstl/bslstl_stopstate.cpp
@@ -25,6 +25,7 @@ namespace {
 
 /// Return the thread ID of the calling thread.  We cannot depend on
 /// `bslmt_threadutil`, so we reimplement this functionality.
+// ensures: __out != 0
 unsigned long long currentThreadId()
 {
 #if defined(BSLS_PLATFORM_OS_WINDOWS)
@@ -138,6 +139,7 @@ bool StopState::requestStop()
 }
 
 // ACCESSORS
+// ensures: __out == d_stopRequested
 bool StopState::stopRequested() const
 {
     return d_stopRequested.loadAcquire();

--- a/groups/bsl/bsltf/bsltf_allocemplacabletesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_allocemplacabletesttype.cpp
@@ -446,6 +446,7 @@ AllocEmplacableTestType::~AllocEmplacableTestType()
 }
 
 // MANIPULATORS
+// ensures: __out == s_numDeletes
 int AllocEmplacableTestType::getNumDeletes()
 {
     return s_numDeletes;

--- a/groups/bsl/bsltf/bsltf_alloctesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_alloctesttype.cpp
@@ -62,6 +62,7 @@ AllocTestType::~AllocTestType()
 }
 
 // MANIPULATORS
+// ensures: &__out == this && (&rhs != this ==> *d_data_p == *rhs.d_data_p)
 AllocTestType& AllocTestType::operator=(const AllocTestType& rhs)
 {
     if (&rhs != this)

--- a/groups/bsl/bsltf/bsltf_emplacabletesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_emplacabletesttype.cpp
@@ -15,6 +15,7 @@ namespace bsltf {
 int EmplacableTestType::s_numDeletes = 0;
 
 // CLASS METHODS
+// ensures: __out == s_numDeletes
 int EmplacableTestType::getNumDeletes()
 {
     return s_numDeletes;
@@ -300,6 +301,7 @@ EmplacableTestType::~EmplacableTestType()
 }
 
 // MANIPULATORS
+// ensures: __out == *this ⋆ d_arg01 ↦ rhs.d_arg01 ⋆ d_arg02 ↦ rhs.d_arg02 ⋆ d_arg03 ↦ rhs.d_arg03 ⋆ d_arg04 ↦ rhs.d_arg04 ⋆ d_arg05 ↦ rhs.d_arg05 ⋆ d_arg06 ↦ rhs.d_arg06 ⋆ d_arg07 ↦ rhs.d_arg07 ⋆ d_arg08 ↦ rhs.d_arg08 ⋆ d_arg09 ↦ rhs.d_arg09 ⋆ d_arg10 ↦ rhs.d_arg10 ⋆ d_arg11 ↦ rhs.d_arg11 ⋆ d_arg12 ↦ rhs.d_arg12 ⋆ d_arg13 ↦ rhs.d_arg13 ⋆ d_arg14 ↦ rhs.d_arg14
 EmplacableTestType& EmplacableTestType::operator=(
                                                  const EmplacableTestType& rhs)
 {

--- a/groups/bsl/bsltf/bsltf_movestate.cpp
+++ b/groups/bsl/bsltf/bsltf_movestate.cpp
@@ -12,6 +12,7 @@ namespace bsltf {
                      // ----------------
 
 // CLASS METHODS
+// ensures: (value == MoveState::e_NOT_MOVED ==> __out == "NOT_MOVED") && (value == MoveState::e_MOVED ==> __out == "MOVED") && (value == MoveState::e_UNKNOWN ==> __out == "UNKNOWN") && (value != MoveState::e_NOT_MOVED && value != MoveState::e_MOVED && value != MoveState::e_UNKNOWN ==> __out == "(* UNKNOWN *)")
 const char *MoveState::toAscii(MoveState::Enum value)
 {
 #define CASE(X) case(e_ ## X): return #X;

--- a/groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.cpp
@@ -64,6 +64,7 @@ NonOptionalAllocTestType::~NonOptionalAllocTestType()
 }
 
 // MANIPULATORS
+// ensures: &__out == this && (&rhs != this ==> *d_data_p == *rhs.d_data_p)
 NonOptionalAllocTestType& NonOptionalAllocTestType::operator=(
                                            const NonOptionalAllocTestType& rhs)
 {

--- a/groups/bsl/bsltf/bsltf_stdtestallocator.cpp
+++ b/groups/bsl/bsltf/bsltf_stdtestallocator.cpp
@@ -29,6 +29,7 @@ namespace bsltf {
                         // -----------------------------------
 
 // CLASS METHODS
+// ensures: (s_StdTestAllocatorConfiguration_allocator_p != 0 ==> __out == s_StdTestAllocatorConfiguration_allocator_p) && (s_StdTestAllocatorConfiguration_allocator_p == 0 ==> __out == &bslma::NewDeleteAllocator::singleton())
 bslma::Allocator* StdTestAllocatorConfiguration::delegateAllocator()
 {
     return s_StdTestAllocatorConfiguration_allocator_p

--- a/groups/bsl/bslx/bslx_byteinstream.cpp
+++ b/groups/bsl/bslx/bslx_byteinstream.cpp
@@ -18,6 +18,7 @@ namespace bslx {
                         // ------------------
 
 // FREE OPERATORS
+// ensures: (__out == &stream) && (__out->flags() == old_stream.flags())
 bsl::ostream& operator<<(bsl::ostream& stream, const ByteInStream& object)
 {
     const bsl::size_t   len   = object.length();

--- a/groups/bsl/bslx/bslx_byteoutstream.cpp
+++ b/groups/bsl/bslx/bslx_byteoutstream.cpp
@@ -58,6 +58,7 @@ ByteOutStream& ByteOutStream::putString(const bsl::string& value)
 }
 
 // FREE OPERATORS
+// ensures: (__out == &stream) && (stream.flags() == old_flags)
 bsl::ostream& operator<<(bsl::ostream& stream, const ByteOutStream& object)
 {
     const int           len   = static_cast<int>(object.d_buffer.size());

--- a/groups/bsl/bslx/bslx_testinstream.cpp
+++ b/groups/bsl/bslx/bslx_testinstream.cpp
@@ -132,6 +132,7 @@ TestInStream::~TestInStream()
 }
 
 // MANIPULATORS
+// ensures: &__out == this && ((variable >= 0 && variable <= 127) || (variable > 127 && (variable & 0x800000) == 0)) && (isValid() ==> (variable >= 0))
 TestInStream& TestInStream::getLength(int& variable)
 {
     if (length() - cursor() < k_SIZEOF_CODE + Util::k_SIZEOF_INT8) {
@@ -843,6 +844,7 @@ TestInStream& TestInStream::getArrayFloat32(float *variables, int numVariables)
 }
 
 // FREE OPERATORS
+// ensures: (__out == &stream) && (stream.flags() == old_stream.flags())
 bsl::ostream& operator<<(bsl::ostream& stream, const TestInStream& object)
 {
     const bsl::size_t   len   = object.length();

--- a/groups/bsl/bslx/bslx_testoutstream.cpp
+++ b/groups/bsl/bslx/bslx_testoutstream.cpp
@@ -39,6 +39,7 @@ TestOutStream::~TestOutStream()
 }
 
 // MANIPULATORS
+// ensures: __out == *this
 TestOutStream& TestOutStream::putLength(int length)
 {
     BSLS_ASSERT(0 <= length);
@@ -833,6 +834,7 @@ TestOutStream& TestOutStream::putArrayFloat32(const float *values,
 }
 
 // FREE OPERATORS
+// ensures: __out == stream
 bsl::ostream& operator<<(bsl::ostream& stream, const TestOutStream& object)
 {
     return stream << object.d_imp;


### PR DESCRIPTION
This is autogenerated specifications for the given function

---
### Preconditions discovered from generation logs
- **groups/bal/balb/balb_pipetaskmanager.cpp**
  - `controlManager != 0 && basicAllocator != 0`
- **groups/bal/balb/balb_ratelimiter.cpp**
  - `limit > 0 && window > bsls::TimeInterval()`
- **groups/bal/balber/balber_berdecoder.cpp**
  - `FORALL(0, d_parent_count, i, d_parent[i] != 0 && d_parent[i]->d_consumedHeaderBytes ↦ _ && d_parent[i]->d_consumedBodyBytes ↦ _)`
  - `msg != nullptr`
- **groups/bal/balber/balber_berdecoderoptions.cpp**
  - `name != nullptr && nameLength >= 0 && SEPFORALL(0, nameLength, i, name + i ↦ _)`
- **groups/bal/balber/balber_berutil.cpp**
  - `-32768 <= value && value <= 32767`
  - `newSize >= d_oldSize`
  - `tagClass != 0 && tagType != 0 && tagNumber != 0 && accumNumBytesConsumed != 0 && streamBuf != 0`
  - `tagNumber >= 0 && streamBuf != NULL`
- **groups/bal/balcl/balcl_commandline.cpp**
  - `lhs.isParsed() && rhs.isParsed()`
  - `name != "" && EXISTS(0, d_options.size(), i, d_options[i].name == name && d_options[i].argType() == OptionInfo::e_FLAG)`
  - `rhs.d_state != e_INVALID`
  - `specTable != 0 && length >= 0`
  - `true ⋆ SEPFORALL(0, sizeof(n), i, stream + i ↦ _)`
- **groups/bal/balcl/balcl_optiontype.cpp**
  - `stream ↦ _`
- **groups/bal/balcl/balcl_typeinfo.cpp**
  - `value != NULL && (type == OptionType::e_CHAR || type == OptionType::e_INT || type == OptionType::e_INT64 || type == OptionType::e_DOUBLE || type == OptionType::e_STRING || type == OptionType::e_DATETIME || type == OptionType::e_DATE || type == OptionType::e_TIME)`
- **groups/bal/baljsn/baljsn_datumutil.cpp**
  - `formatter != 0 && datum.size() >= 0 && strictTypesCheckStatus != 0 && (name == 0 || name->size() >= 0)`
  - `formatter != nullptr && strictTypesCheckStatus != nullptr`
  - `maxNestedDepth >= 0`
  - `result != NULL && jsonBuffer != NULL`
  - `result != nullptr && tokenizer != nullptr`
- **groups/bal/baljsn/baljsn_encoder.cpp**
  - `formatter != nullptr`
- **groups/bal/baljsn/baljsn_encoder_testtypes.cpp**
  - `(SELECTION_ID_SIMPLE == d_selectionId ==> (d_simple.object() ↦ _)) && (SELECTION_ID_SIMPLE != d_selectionId ==> (d_simple.buffer() ↦ _))`
  - `d_selectionId == SELECTION_ID_SELECTION0 || d_selectionId == SELECTION_ID_UNDEFINED`
  - `d_selectionId == SELECTION_ID_SEQUENCE || d_selectionId == SELECTION_ID_UNDEFINED`
  - `name != nullptr && nameLength >= 0`
  - `name != nullptr && nameLength >= 0 && FORALL(0, nameLength, i, name[i] != '\0') && name[nameLength] == '\0'`
  - `name != nullptr && nameLength >= 0 && name[nameLength] == '\0'`
  - `result != nullptr && (number == EncoderTestChoiceWithAllCategoriesEnumeration::A || number == EncoderTestChoiceWithAllCategoriesEnumeration::B)`
  - `result != nullptr && (number == EncoderTestSequenceWithAllCategoriesEnumeration::A || number == EncoderTestSequenceWithAllCategoriesEnumeration::B)`
  - `result != nullptr && string != nullptr && stringLength >= 0`
  - `string != nullptr && stringLength >= 0 && result != nullptr`
- **groups/bal/baljsn/baljsn_parserutil.cpp**
  - `value != nullptr && data.size() >= 0`
- **groups/bal/ball/ball_attribute.cpp**
  - `0 < size && attribute.d_name.data() != nullptr && attribute.d_value.isValid()`
  - `stream ↦ _`
- **groups/bal/ball/ball_attributecontainerlist.cpp**
  - `lhs.numContainers() >= 0 && rhs.numContainers() >= 0 && SEPFORALL(0, lhs.numContainers(), i, (std::next(lhs.begin(), i) ↦ _)) && SEPFORALL(0, rhs.numContainers(), i, (std::next(rhs.begin(), i) ↦ _))`
- **groups/bal/ball/ball_attributecontext.cpp**
  - `category != NULL`
  - `stream`
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bal/ball/ball_category.cpp**
  - `Category::areValidThresholdLevels(recordLevel, passLevel, triggerLevel, triggerAllLevel)`
- **groups/bal/ball/ball_categorymanager.cpp**
  - `categoryName != NULL`
  - `categoryName != nullptr && EXISTS(0, strlen(categoryName) + 1, i, categoryName[i] == '\0')`
- **groups/bal/ball/ball_context.cpp**
  - `stream != nullptr`
- **groups/bal/ball/ball_defaultattributecontainer.cpp**
  - `lhs.numAttributes() == rhs.numAttributes()`
- **groups/bal/ball/ball_fileobserver2.cpp**
  - `0 <= interval.totalMilliseconds()`
  - `\[ \text{PRE}(0 < \text{interval.totalMilliseconds()}) \]`
  - `logFilePattern != NULL`
  - `stream != 0 && filename != 0`
- **groups/bal/ball/ball_log.cpp**
  - `numBytes >= 0`
- **groups/bal/ball/ball_loggercategoryutil.cpp**
  - `loggerManager != NULL \ && \ categoryName != NULL \ && \ loggerManager->lookupCategory(categoryName) == 0`
- **groups/bal/ball/ball_loggermanager.cpp**
  - `category != nullptr`
  - `fileName != nullptr`
  - `filteredNameBuffer != nullptr && originalName != nullptr`
- **groups/bal/ball/ball_managedattributeset.cpp**
  - `0 < size`
- **groups/bal/ball/ball_patternutil.cpp**
  - `FORALL(0, strlen(pattern), i, (pattern[i] == '\\' ==> (pattern[i+1] == '\\' || pattern[i+1] == '*')) && (pattern[i] == '*' ==> (i == strlen(pattern) - 1 || pattern[i+1] == '\0')))`
- **groups/bal/ball/ball_recordattributes.cpp**
  - `d_messageStreamBuf.data() != nullptr && d_messageStreamBuf.length() >= 0`
- **groups/bal/ball/ball_recordjsonformatter.cpp**
  - `!format.empty()`
  - `SEPFORALL(0, v.size(), i, v[i].value() ↦ _)`
  - `d_name ↦ _`
- **groups/bal/ball/ball_rule.cpp**
  - `0 < size`
  - `stream != nullptr ⋆ d_pattern ↦ _ ⋆ d_thresholds ↦ _ ⋆ SEPFORALL(d_attributeSet.begin(), d_attributeSet.end(), it, *it ↦ _)`
- **groups/bal/ball/ball_severity.cpp**
  - `string != NULL && (stringLength == 3 || stringLength == 4 || stringLength == 5)`
- **groups/bal/ball/ball_severityutil.cpp**
  - `level != NULL && name != NULL`
- **groups/bal/ball/ball_thresholdaggregate.cpp**
  - `size > 0`
- **groups/bal/ball/ball_userfields.cpp**
  - `stream.good()`
- **groups/bal/ball/ball_userfieldtype.cpp**
  - `stream && toAscii(value).size() >= 0`
- **groups/bal/balm/balm_category.cpp**
  - `stream ↦ _ ⋆ d_name_p ↦ _`
- **groups/bal/balm/balm_configurationutil.cpp**
  - `(manager == 0) || (manager != 0)`
- **groups/bal/balm/balm_defaultmetricsmanager.cpp**
  - `bslma::Default::globalAllocator(basicAllocator) != 0 && s_allocator_p == 0 && s_singleton_p == 0`
- **groups/bal/balm/balm_metricdescription.cpp**
  - `d_category_p != 0 && d_name_p != "" && stream.good()`
- **groups/bal/balm/balm_metricformat.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
  - `stream.good()`
- **groups/bal/balm/balm_metricregistry.cpp**
  - `SEPFORALL(0, strlen(candidatePrefix), i, (candidatePrefix + i ↦ _)) ⋆ SEPFORALL(0, strlen(string), i, (string + i ↦ _))`
  - `category != NULL && name != NULL`
- **groups/bal/balm/balm_metricsample.cpp**
  - `stream ↦ _ ⋆ true`
  - `stream.good()`
- **groups/bal/balm/balm_metricsmanager.cpp**
  - `category != nullptr`
- **groups/bal/balm/balm_publicationscheduler.cpp**
  - `SEPFORALL(0, categories.size(), i, (*categories.begin() + i)->name() ↦ _)`
  - `result != 0 && category != 0`
- **groups/bal/balst/balst_stacktrace.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bal/balst/balst_stacktraceframe.cpp**
  - `!stream.bad()`
  - `stream.bad() == false && (stream.bad() == false ==> SEPFORALL(0, 7, i, stream + i ↦ _))`
- **groups/bal/balst/balst_stacktraceprinter.cpp**
  - `stream && !stream.fail()`
- **groups/bal/balst/balst_stacktraceprintutil.cpp**
  - `(0 <= maxFrames || maxFrames == -1) && (0 <= additionalIgnoreFrames) && (stream != 0)`
- **groups/bal/balst/balst_stacktracetestallocator.cpp**
  - `blockHdr != nullptr && (blockHdr->d_magic == k_ALLOCATED_BLOCK_MAGIC || blockHdr->d_magic == k_DEALLOCATED_BLOCK_MAGIC) && blockHdr->d_allocator_p != nullptr && (blockHdr->d_prevNext_p == nullptr || *blockHdr->d_prevNext_p != nullptr) && (blockHdr->d_next_p == nullptr || blockHdr->d_next_p->d_magic == k_ALLOCATED_BLOCK_MAGIC || blockHdr->d_next_p->d_magic == k_DEALLOCATED_BLOCK_MAGIC)`
  - `specifiedMaxRecordedFrames >= 0`
- **groups/bal/balst/balst_stacktraceutil.cpp**
  - `pathName != nullptr && EXISTS(0, bsl::strlen(pathName) + 1, i, pathName[i] == '\0')`
- **groups/bal/baltzo/baltzo_datafileloader.cpp**
  - `path != nullptr`
  - `result != nullptr && timeZoneId != nullptr`
  - `timeZoneId != nullptr ⋆ SEPFORALL(0, strlen(timeZoneId) + 1, i, timeZoneId + i ↦ _)`
- **groups/bal/baltzo/baltzo_errorcode.cpp**
  - `stream.good() && (value >= ErrorCode::Enum::MIN_VALUE && value <= ErrorCode::Enum::MAX_VALUE) && (level >= 0) && (spacesPerLevel >= 0) && (stream ↦ _ ⋆ SEPFORALL(0, level + strlen(ErrorCode::toAscii(value)) + 1, i, stream + i ↦ _))`
- **groups/bal/baltzo/baltzo_localtimeoffsetutil.cpp**
  - `timezone != NULL`
- **groups/bal/baltzo/baltzo_localtimeperiod.cpp**
  - `stream.good()`
- **groups/bal/baltzo/baltzo_localtimevalidity.cpp**
  - `stream && value == LocalTimeValidity::Enum(value)`
- **groups/bal/baltzo/baltzo_timezoneutil.cpp**
  - `result != 0`
- **groups/bal/baltzo/baltzo_timezoneutilimp.cpp**
  - `result != 0 && resultTimeZoneId != 0 && cache != 0`
  - `start >= timeZone.beginTransitions() && start < timeZone.endTransitions()`
  - `timeZone != 0 && timeZoneId != 0 && cache != 0`
- **groups/bal/baltzo/baltzo_windowstimezoneutil.cpp**
  - `(a.d_key != nullptr && a.d_key[0] != '\0') && (b.d_key != nullptr && b.d_key[0] != '\0')`
  - `result != nullptr && windowsTimeZoneId != nullptr`
- **groups/bal/baltzo/baltzo_zoneinfo.cpp**
  - `SEPFORALL(0, transitions.size(), i, transitions[i]->descriptor() ↦ _)`
  - `stream && object`
  - `stream && object.identifier().size() >= 0 && object.posixExtendedRangeDescription().size() >= 0`
  - `stream.good()`
- **groups/bal/baltzo/baltzo_zoneinfobinaryreader.cpp**
  - `address != 0 && SEPFORALL(0, 4, i, address + i ↦ _)`
  - `buffer != 0 && length >= 0 && SEPFORALL(0, length, i, (buffer + i) ↦ _)`
  - `result != 0 && stream.good()`
  - `zoneinfoResult != nullptr && stream.good()`
- **groups/bal/baltzo/baltzo_zoneinfocache.cpp**
  - `rc != 0 && timeZoneId != 0`
  - `timeZoneId != 0`
- **groups/bal/baltzo/baltzo_zoneinfoutil.cpp**
  - `resultTime != NULL && resultTransition != NULL && isWellFormed(timeZone)`
- **groups/bal/balxml/balxml_decoder.cpp**
  - `context != nullptr`
- **groups/bal/balxml/balxml_formatter_prettyimpl.cpp**
  - `state != nullptr && (state->id() == StateId::e_IN_TAG || state->id() == StateId::e_FIRST_DATA_BETWEEN_TAGS || state->id() == StateId::e_TRAILING_DATA_BETWEEN_TAGS || state->id() == StateId::e_FIRST_DATA_AT_LINE_BETWEEN_TAGS)`
- **groups/bal/balxml/balxml_minireader.cpp**
  - `d_scanPtr != nullptr && d_endPtr != nullptr && SEPFORALL(d_scanPtr, d_endPtr, ptr, (ptr ↦ _))`
  - `val < 0x110000U`
- **groups/bal/balxml/balxml_prefixstack.cpp**
  - `namespaceUri.empty() ==> res_tmp == -1`
- **groups/bal/balxml/balxml_typesparserutil.cpp**
  - `input != NULL && ((inputLength == 1 && (input[0] == '1' || input[0] == '0')) || (inputLength == 4 && (input[0] == 't' || input[0] == 'T') && (input[1] == 'r' || input[1] == 'R') && (input[2] == 'u' || input[2] == 'U') && (input[3] == 'e' || input[3] == 'E')) || (inputLength == 5 && (input[0] == 'f' || input[0] == 'F') && (input[1] == 'a' || input[1] == 'A') && (input[2] == 'l' || input[2] == 'L') && (input[3] == 's' || input[3] == 'S') && (input[4] == 'e' || input[4] == 'E')))`
  - `inputLength > 0`
  - `inputLength > 0 && result != 0`
  - `result != 0 && input != 0 && input[bsl::strlen(input)] == '\0'`
- **groups/bal/balxml/balxml_typesprintutil.cpp**
  - `(dataLength >= 0 && SEPFORALL(0, dataLength, i, data + i ↦ _)) || (dataLength == -1 && SEPEXISTS(0, (const char *)-1, i, data + i == 0) && SEPFORALL(0, EXISTS(data, (const char *)-1, i, data + i == 0), i, data + i ↦ _))`
  - `(maxTotalDigits >= 2 && maxTotalDigits <= 326`
- **groups/bal/balxml/balxml_utf8readerwrapper.cpp**
  - `url != nullptr && encoding != nullptr`
- **groups/bbl/bblb/bblb_schedulegenerationutil.cpp**
  - `(1 <= year && 9999 >= year) && (1 <= month && 12 >= month) && (1 <= day && day <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, month)) && (dayOfFeb == 0 || (1 <= dayOfFeb && dayOfFeb <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, 2)))`
  - `denominator > 0`
- **groups/bbl/bbldc/bbldc_basicdaycountutil.cpp**
  - `convention >= DayCountConvention::e_ACTUAL_360 && convention <= DayCountConvention::e_SIA_30_360_NEOM`
- **groups/bbl/bbldc/bbldc_basicisdaactualactual.cpp**
  - `beginDate <= endDate`
- **groups/bbl/bbldc/bbldc_basicnl365.cpp**
  - `beginDate <= endDate`
- **groups/bbl/bbldc/bbldc_basicpsa30360eom.cpp**
  - `bdlt::Date::isValidYearMonthDay(year, month, day)`
- **groups/bbl/bbldc/bbldc_basicsia30360eom.cpp**
  - `bdlt::Date::isValidYearMonthDay(year, month, day)`
- **groups/bbl/bbldc/bbldc_calendardaycountutil.cpp**
  - `calendar.isInRange(beginDate) && calendar.isInRange(endDate)`
- **groups/bbl/bbldc/bbldc_daycountconvention.cpp**
  - `value >= DayCountConvention::Enum_MIN && value <= DayCountConvention::Enum_MAX && stream.good()`
- **groups/bbl/bbldc/bbldc_periodicmaactualactual.cpp**
  - `(beginDate == endDate) || (beginDate != endDate)`
- **groups/bbl/bbldc/bbldc_terminatedisda30360eom.cpp**
  - `beginDate.isValid() && endDate.isValid() && terminationDate.isValid()`
- **groups/bdl/bdlb/bdlb_bigendian.cpp**
  - `!stream.bad()`
  - `!stream.bad() && (level >= 0) && (spacesPerLevel >= 0)`
  - `stream.good() && (stream ↦ _)`
- **groups/bdl/bdlb/bdlb_bitstringutil.cpp**
  - `(0 <= numBits) && (numBits < 64)`
  - `0 <= numBits && numBits < 64`
  - `level >= 0`
  - `numBits + pos1 <= k_BITS_PER_UINT64 && numBits + pos2 <= k_BITS_PER_UINT64`
- **groups/bdl/bdlb/bdlb_caselessstringviewhash.cpp**
  - `argument.data() != nullptr && argument.length() >= 0`
- **groups/bdl/bdlb/bdlb_doublecompareutil.cpp**
  - `bdlb::Float::isFinite(relTol) && bdlb::Float::signBit(relTol) == false && bdlb::Float::isFinite(absTol) && bdlb::Float::signBit(absTol) == false`
- **groups/bdl/bdlb/bdlb_guid.cpp**
  - `0 <= x && x <= 15`
- **groups/bdl/bdlb/bdlb_hashutil.cpp**
  - `(0 <= length) && (data || 0 == length)`
- **groups/bdl/bdlb/bdlb_numericparseutil.cpp**
  - `!positiveNum.empty()`
  - `2 <= base && base <= 36`
  - `stdlibInput.size() >= 2`
- **groups/bdl/bdlb/bdlb_print.cpp**
  - `level >= 0 && spacesPerLevel != 0`
- **groups/bdl/bdlb/bdlb_randomdevice.cpp**
  - `(numBytes == 0) || (buffer != NULL)`
- **groups/bdl/bdlb/bdlb_string.cpp**
  - `lhsString != nullptr && rhsString != nullptr && SEPFORALL(0, strlen(lhsString), i, (lhsString + i ↦ _)) && SEPFORALL(0, strlen(rhsString), i, (rhsString + i ↦ _))`
- **groups/bdl/bdlb/bdlb_stringrefutil.cpp**
  - `0 <= ch && ch <= 255`
- **groups/bdl/bdlb/bdlb_stringviewutil.cpp**
  - `0 <= ch && ch <= 255`
- **groups/bdl/bdlbb/bdlbb_blob.cpp**
  - `stream.good() && stream.tellp() >= 0`
- **groups/bdl/bdlbb/bdlbb_blobstreambuf.cpp**
  - `(gptr() == 0) || (eback() != 0 && egptr() != 0 && gptr() - eback() <= egptr() - eback() && static_cast<unsigned>(d_getBufferIndex) < d_blob_p->numBuffers() && egptr() - eback() <= d_blob_p->buffer(d_getBufferIndex).size() && d_previousBuffersLength + egptr() - eback() <= d_blob_p->length()) && (gptr() == 0 ==> (eback() == 0 && egptr() == 0 && static_cast<unsigned>(d_getBufferIndex) <= d_blob_p->numBuffers()))`
- **groups/bdl/bdlbb/bdlbb_blobutil.cpp**
  - `0 <= bufferIndex && 0 <= numBytes && bufferIndex < source.numDataBuffers() && SEPFORALL(bufferIndex, source.numDataBuffers(), i, EXISTS(0, source.buffer(i).size(), j, j < numBytes))`
- **groups/bdl/bdlc/bdlc_bitarray.cpp**
  - `0 <= numBits && numBits < BitArray::k_BITS_PER_UINT64`
- **groups/bdl/bdlc/bdlc_hashtable.cpp**
  - `hint != 0`
- **groups/bdl/bdlc/bdlc_indexclerk.cpp**
  - `(unsigned int)index < (unsigned int)d_nextNewIndex`
  - `FORALL(0, unusedStack.size(), i, (unsigned int) unusedStack[i] < (unsigned int) nextNewIndex) && FORALL(0, unusedStack.size(), i, FORALL(i + 1, unusedStack.size(), j, unusedStack[i] != unusedStack[j]))`
- **groups/bdl/bdld/bdld_datum.cpp**
  - `stream.bad() || (stream.good() ⋆ d_key_p ↦ _ ⋆ d_value ↦ _)`
  - `stream.good() && (stream ↦ _)`
  - `stream.good() && SEPFORALL(0, d_length, i, (d_data_p + i ↦ _))`
- **groups/bdl/bdld/bdld_datumarraybuilder.cpp**
  - `length < bsl::numeric_limits<DatumArrayBuilder::SizeType>::max() / 2 && capacity >= 0`
- **groups/bdl/bdld/bdld_datumerror.cpp**
  - `stream.good()`
- **groups/bdl/bdld/bdld_datummapbuilder.cpp**
  - `size < bsl::numeric_limits<DatumMapBuilder::SizeType>::max() / 2 && capacity >= 0`
- **groups/bdl/bdld/bdld_datumudt.cpp**
  - `(stream ↦ _) && (!stream.bad())`
- **groups/bdl/bdlde/bdlde_base64alphabet.cpp**
  - `stream && stream.good()) &`
- **groups/bdl/bdlde/bdlde_base64decoderoptions.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bdl/bdlde/bdlde_base64encoderoptions.cpp**
  - `stream != nullptr && level >= 0 && spacesPerLevel >= 0`
- **groups/bdl/bdlde/bdlde_base64ignoremode.cpp**
  - `(stream.bad()) || (!stream.bad() && (stream ↦ _))`
- **groups/bdl/bdlde/bdlde_byteorder.cpp**
  - `!stream.bad()`
- **groups/bdl/bdlde/bdlde_charconvertucs2.cpp**
  - `(dstBuffer != nullptr && dstCapacity > 0) && (srcString != nullptr) && (numCharsWritten == nullptr || numCharsWritten != nullptr)`
- **groups/bdl/bdlde/bdlde_charconvertutf32.cpp**
  - `SEPFORALL(0, 4, i, octBuf + i ↦ _)`
  - `SEPFORALL(0, n, i, (octBuf + i ↦ _))`
  - `input != NULL`
  - `oct >= 0 && oct <= 255`
  - `octBuf != nullptr && SEPFORALL(0, 3, i, octBuf + i ↦ _)`
  - `octBuf ↦ _ ⋆ (octBuf + 1) ↦ _`
  - `position != NULL`
  - `position <= d_end`
  - `position ↦ _`
  - `ptr != nullptr`
  - `uc < (1u << (k_TWO_OCT_CONT_WID + k_CONTINUE_CONT_WID))`
- **groups/bdl/bdlde/bdlde_crc32c.cpp**
  - `(length == 0) || (data != nullptr)`
  - `length == 0 || data != NULL`
- **groups/bdl/bdlde/bdlde_crc64.cpp**
  - `stream.good()`
- **groups/bdl/bdlde/bdlde_hexdecoder.cpp**
  - `(d_state == e_ERROR_STATE || d_firstDigit) ==> (d_state == e_ERROR_STATE || d_firstDigit) && (!d_firstDigit) ==> (d_state != e_ERROR_STATE)`
- **groups/bdl/bdlde/bdlde_quotedprintabledecoder.cpp**
  - `out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL && maxNumOut >= 0`
- **groups/bdl/bdlde/bdlde_quotedprintableencoder.cpp**
  - `out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL && (d_state != e_ERROR_STATE && d_state != e_DONE_STATE)`
- **groups/bdl/bdlde/bdlde_sha1.cpp**
  - `bytes != NULL`
- **groups/bdl/bdlde/bdlde_sha2.cpp**
  - `lhs.d_bufferSize >= 0 && rhs.d_bufferSize >= 0 && SEPFORALL(0, lhs.d_bufferSize, i, lhs.d_buffer + i ↦ _) && SEPFORALL(0, rhs.d_bufferSize, i, rhs.d_buffer + i ↦ _) && SEPFORALL(0, 8, i, lhs.d_state + i ↦ _) && SEPFORALL(0, 8, i, rhs.d_state + i ↦ _)`
- **groups/bdl/bdlde/bdlde_utf8util.cpp**
  - `!input.empty()`
  - `(character & k_ONEBYTEHEAD_TEST) == k_ONEBYTEHEAD_RES ==> res_tmp == 1`
  - `(pc ↦ _) ⋆ (pc + 1 ↦ _)`
  - `(pc ↦ _) ⋆ (pc + 1 ↦ _) ⋆ (pc + 2 ↦ _)`
  - `invalidString != NULL && (string != NULL || length == 0)`
  - `invalidString != NULL && string != NULL`
  - `pc ↦ _ ⋆ (pc + 1) ↦ _ ⋆ (pc + 2) ↦ _ ⋆ (pc + 3) ↦ _`
- **groups/bdl/bdldfp/bdldfp_decimal.cpp**
  - `stream.good()`
- **groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp**
  - `buffer != nullptr && count > 0`
  - `low <= high`
- **groups/bdl/bdldfp/bdldfp_decimalimputil.cpp**
  - `v != NULL`
- **groups/bdl/bdldfp/bdldfp_decimalutil.cpp**
  - `str != nullptr && str[0] != 0 && str[1] != 0 && str[2] != 0 && (str[3] == 0 || (str[0] == 's' && str[1] != 0 && str[2] != 0 && str[3] != 0 && str[4] == 0))`
- **groups/bdl/bdljsn/bdljsn_error.cpp**
  - `stream.good() && object.location().size() >= 0 && object.message().size() >= 0`
- **groups/bdl/bdljsn/bdljsn_jsontestsuiteutil.cpp**
  - `index < s_numData`
- **groups/bdl/bdljsn/bdljsn_jsonutil.cpp**
  - `d_it != d_end`
  - `d_it != d_sortedMembers.end()`
  - `d_it != nullptr`
  - `lhs != nullptr && rhs != nullptr`
  - `maxNestedDepth >= 0 && tokenizer != nullptr && result != nullptr && error != nullptr`
  - `result != 0 && error != 0 && tokenizer != 0`
  - `result != nullptr && errorDescription != nullptr && input != nullptr`
- **groups/bdl/bdljsn/bdljsn_numberutil.cpp**
  - `SEPFORALL(iter, end, i, (i ↦ _) && (bdlb::CharType::isDigit(*i) || !bdlb::CharType::isDigit(*i)))`
  - `begin <= end`
  - `lhs.d_isExpNegative == rhs.d_isExpNegative && lhs.d_significantDigits == rhs.d_significantDigits`
- **groups/bdl/bdljsn/bdljsn_stringutil.cpp**
  - `value != nullptr && string.size() >= 0`
- **groups/bdl/bdljsn/bdljsn_tokenizer.cpp**
  - `d_streambuf_p != nullptr`
  - `data != nullptr`
- **groups/bdl/bdlma/bdlma_aligningallocator.cpp**
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_blocklist.cpp**
  - `size >= 0 && sizeOfBlock >= 0`
- **groups/bdl/bdlma/bdlma_bufferimputil.cpp**
  - `(cursor != 0) && (buffer != 0) && (0 < size) && (0 <= *cursor) && (static_cast<bsls::Types::size_type>(*cursor) <= bufferSize)`
- **groups/bdl/bdlma/bdlma_concurrentallocatoradapter.cpp**
  - `numBytes >= 0`
- **groups/bdl/bdlma/bdlma_concurrentpool.cpp**
  - `y > 0`
- **groups/bdl/bdlma/bdlma_concurrentpoolallocator.cpp**
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_guardingallocator.cpp**
  - `(size == 0) ==> res_tmp == 0 && (size > 0) ==> res_tmp != 0 && (res_tmp ↦ _)`
  - `address != 0 && pageSize == getSystemPageSize()`
  - `size > 0`
- **groups/bdl/bdlma/bdlma_infrequentdeleteblocklist.cpp**
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_multipool.cpp**
  - `size <= d_maxBlockSize`
- **groups/bdl/bdlma/bdlma_pool.cpp**
  - `1 <= y && x >= 0`
- **groups/bdl/bdlma/bdlma_sequentialpool.cpp**
  - `size >= 0`
  - `size >= 0 && sizeOfBlock >= 0`
- **groups/bdl/bdlmt/bdlmt_eventscheduler.cpp**
  - `amount > 0`
  - `d_data_p != 0`
  - `handle != 0 && ((*handle == 0) || ((const Event *) *handle != 0))`
- **groups/bdl/bdlmt/bdlmt_multiprioritythreadpool.cpp**
  - `(unsigned) priority < (unsigned) d_queue.numPriorities()`
- **groups/bdl/bdlmt/bdlmt_threadpool.cpp**
  - `aThis != 0`
- **groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp**
  - `amount > 0`
  - `d_data_p != 0`
- **groups/bdl/bdlpcre/bdlpcre_regex.cpp**
  - `errorMessage != NULL && errorOffset != NULL && pattern != NULL && (flags & ~VALID_FLAGS) == 0`
  - `matchContextData != 0 && d_pcre2Context_p != 0 && d_pcre2PatternCode_p != 0 && (d_jitStackSize >= 0 || d_jitStackSize == 0)`
  - `matchContextData != NULL`
  - `pcre2Context != 0 && patternCode != 0`
  - `subject.data() != nullptr && subject.length() >= 0 && subjectOffset <= subject.length()`
- **groups/bdl/bdls/bdls_fdstreambuf.cpp**
  - `d_mode != e_ERROR_MODE && (d_mode != e_OUTPUT_MODE || (isOpened() && ((int) d_fileHandler.openMode() & (int) bsl::ios_base::in) != 0 && d_buf_p != 0 || allocateBuffer() == 0))`
- **groups/bdl/bdls/bdls_filesystemutil.cpp**
  - `(idx < str.size()) && (len == bsl::string::npos || (idx + len <= str.size()))`
  - `path != NULL`
  - `path != nullptr`
  - `path != nullptr && (path ↦ _ ⋆ (path + 1 ↦ _ ⋆ (path + 2 ↦ _)))`
- **groups/bdl/bdls/bdls_pathutil.cpp**
  - `path != nullptr`
  - `path != nullptr && rootEnd >= 0 && rootEnd <= static_cast<int>(bsl::strlen(path))`
- **groups/bdl/bdls/bdls_pipeutil.cpp**
  - `pipeName ↦ _`
- **groups/bdl/bdls/bdls_processutil.cpp**
  - `path != nullptr && path[0] != '\0'`
- **groups/bdl/bdlsb/bdlsb_fixedmeminput.cpp**
  - `(which & bsl::ios_base::in) && (static_cast<bsl::size_t>(position) <= d_bufferSize && off_type(position) >= 0)`
- **groups/bdl/bdlsb/bdlsb_fixedmeminstreambuf.cpp**
  - `(which & bsl::ios_base::in) && (way == bsl::ios_base::beg || way == bsl::ios_base::cur || way == bsl::ios_base::end)`
- **groups/bdl/bdlt/bdlt_calendar.cpp**
  - `d_packedCalendar.length() >= 0 && d_nonBusinessDays.length() >= 0`
  - `nextBusinessDay != 0 && date < Date(9999, 12, 31) && isInRange(date + 1) && nth > 0`
- **groups/bdl/bdlt/bdlt_calendarcache.cpp**
  - `calendarName != NULL`
  - `calendarName != nullptr`
- **groups/bdl/bdlt/bdlt_datetime.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bdl/bdlt/bdlt_datetimeinterval.cpp**
  - `result != NULL && numBytes >= 0`
- **groups/bdl/bdlt/bdlt_datetimetz.cpp**
  - `stream.good() && (stream ↦ _)`
- **groups/bdl/bdlt/bdlt_dateutil.cpp**
  - `(1 <= original.year() && original.year() <= 9999) && (1 <= original.month() && original.month() <= 12) && (1 <= original.day() && original.day() <= SerialDateImpUtil::lastDayOfMonth(original.year(), original.month()))`
  - `(original.month() == 2) && (original.day() == 28 || original.day() == 29)`
  - `0 <= day1 && day1 <= 6 && 0 <= day2 && day2 <= 6`
- **groups/bdl/bdlt/bdlt_dayofweek.cpp**
  - `stream`
- **groups/bdl/bdlt/bdlt_dayofweekset.cpp**
  - `!stream.bad()`
  - `d_index < 8`
- **groups/bdl/bdlt/bdlt_defaultcalendarcache.cpp**
  - `loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)`
- **groups/bdl/bdlt/bdlt_defaulttimetablecache.cpp**
  - `loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)`
- **groups/bdl/bdlt/bdlt_fixutil.cpp**
  - `buffer != 0 && paddedLen >= 0 && value >= 0 && (buffer + paddedLen + 1 ↦ _)`
  - `buffer != NULL && -(24 * 60) < tzOffset && tzOffset < 24 * 60`
  - `buffer != NULL && 0 <= value && 0 <= paddedLen && paddedLen <= static_cast<int>(strlen(buffer))`
  - `buffer != NULL && bufferLength >= k_DATE_STRLEN`
  - `nextPos != 0 && result != 0 && begin != 0 && end != 0 && begin < end && (SEPFORALL(0, end - begin, i, isdigit(*(begin + i))) || SEPEXISTS(0, end - begin, i, !isdigit(*(begin + i))))`
  - `nextPos != NULL && date != NULL && begin != NULL && end != NULL && begin <= end && (end - begin >= sizeof "YYYYMMDD" - 1)`
  - `nextPos != NULL && time != NULL && tzOffset != NULL && isNextDay != NULL && begin != NULL && end != NULL && begin <= end && (end - begin >= k_MINIMUM_LENGTH)`
  - `nextPos != nullptr && microsecond != nullptr && begin != nullptr && end != nullptr && begin <= end`
- **groups/bdl/bdlt/bdlt_fixutilconfiguration.cpp**
  - `stream.good()`
- **groups/bdl/bdlt/bdlt_fuzzutil.cpp**
  - `fuzzDataView != NULL`
- **groups/bdl/bdlt/bdlt_iso8601utilconfiguration.cpp**
  - `stream.good()`
- **groups/bdl/bdlt/bdlt_monthofyear.cpp**
  - `stream ↦ _ && value >= MonthOfYear::Enum::Jan && value <= MonthOfYear::Enum::Dec`
- **groups/bdl/bdlt/bdlt_packedcalendar.cpp**
  - `0 <= offset && d_lastDate - d_firstDate >= offset`
  - `isHoliday(date)`
  - `level >= 0 && spacesPerLevel != 0`
- **groups/bdl/bdlt/bdlt_posixdateimputil.cpp**
  - `0 <= year && year <= k_MAX_YEAR`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR && k_MIN_MONTH <= month && month <= k_MAX_MONTH`
- **groups/bdl/bdlt/bdlt_prolepticdateimputil.cpp**
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR && 0 <= month && month <= k_MAX_MONTH`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR && k_MIN_MONTH <= month && month <= k_MAX_MONTH`
- **groups/bdl/bdlt/bdlt_time.cpp**
  - `number != nullptr && base >= 1`
  - `number != nullptr && base >= 1 && number ↦ _`
  - `number ↦ _ && base >= 1`
- **groups/bdl/bdlt/bdlt_timetable.cpp**
  - `24 > time.hour() && (0 <= code || code == Timetable::k_UNSET_TRANSITION_CODE)`
- **groups/bdl/bdlt/bdlt_timetablecache.cpp**
  - `d_ptr != nullptr`
  - `timetableName != NULL`
- **groups/bdl/bdlt/bdlt_timetz.cpp**
  - `!stream.bad() && SEPFORALL(0, stream.tellp(), i, stream + i ↦ _)`
- **groups/bsl/bslalg/bslalg_hashutil.cpp**
  - `0 <= length && (data || 0 == length)`
- **groups/bsl/bslalg/bslalg_rbtreeutil.cpp**
  - `node == 0 || (node ↦ _ ⋆ node->isBlack() ↦ _)`
  - `subtree != 0 && SEPEXISTS(0, INT_MAX, i, EXISTS(subtree, subtree + i, node, node->leftChild() == 0))`
- **groups/bsl/bslfmt/bslfmt_unicodecodepoint.cpp**
  - `(pc ↦ _ ⋆ (pc + 1 ↦ _ ⋆ (pc + 2 ↦ _)))`
  - `(pc ↦ _ ⋆ pc + 1 ↦ _)`
  - `codepoint >= 0`
  - `pc != nullptr && pc + 3 < reinterpret_cast<unsigned char*>(std::numeric_limits<std::size_t>::max())`
- **groups/bsl/bslh/bslh_siphashalgorithm.cpp**
  - `b >= 0 && b < 64`
  - `p ↦ _ ⋆ (p + 1) ↦ _ ⋆ (p + 2) ↦ _ ⋆ (p + 3) ↦ _ ⋆ (p + 4) ↦ _ ⋆ (p + 5) ↦ _ ⋆ (p + 6) ↦ _ ⋆ (p + 7) ↦ _`
- **groups/bsl/bslma/bslma_allocator.cpp**
  - `bytes >= 0 && align > 0`
- **groups/bsl/bslma/bslma_bufferallocator.cpp**
  - `cursor != nullptr && buffer != nullptr && 0 < alignment && alignment <= bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT && (alignment & (alignment - 1)) == 0`
- **groups/bsl/bslma/bslma_infrequentdeleteblocklist.cpp**
  - `numBytes >= 0`
- **groups/bsl/bslma/bslma_mallocfreeallocator.cpp**
  - `p != 0`
  - `size >= 0`
- **groups/bsl/bslma/bslma_newdeleteallocator.cpp**
  - `address != 0`
- **groups/bsl/bslma/bslma_sequentialpool.cpp**
  - `0 <= size`
- **groups/bsl/bslma/bslma_testallocator.cpp**
  - `SEPFORALL(0, 8, i, (*blockList + i) ↦ _ ⋆ (*blockList + i)->d_next_p ↦ _`
  - `size >= 0`
- **groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp**
  - `argument != 0 && dynamic_cast<bslmt::EntryPointFunctorAdapter_Base*>(argument) != 0`
- **groups/bsl/bslmt/bslmt_threadattributes.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bsl/bslmt/bslmt_threadutil.cpp**
  - `((int) policy >= ThreadAttributes::e_SCHED_MIN && (int) policy <= ThreadAttributes::e_SCHED_MAX) && (normalizedSchedulingPriority >= 0.0 && normalizedSchedulingPriority <= 1.0)`
- **groups/bsl/bslmt/bslmt_turnstile.cpp**
  - `timestamp ↦ _`
- **groups/bsl/bsls/bsls_bslsourcenameparserutil.cpp**
  - `begin <= end`
  - `begin <= end && SEPFORALL(0, end - begin, i, begin + i ↦ _)`
  - `filename != nullptr && EXISTS(0, strlen(filename) + 1, i, filename[i] ↦ _)`
  - `sourceName != NULL && componentNamePtr != NULL && componentNameLength != NULL`
- **groups/bsl/bsls/bsls_log.cpp**
  - `(size > 0) ==> (buffer != nullptr && format != nullptr)`
  - `numBytes >= 0`
  - `originalBuffer != 0 && originalBufferSize > 0 && outputBuffer != 0 && outputBufferSize != 0 && format != 0 && SEPFORALL(0, originalBufferSize, i, originalBuffer + i ↦ _)`
- **groups/bsl/bsls/bsls_nameof.cpp**
  - `buffer != nullptr && functionName != nullptr && std::strlen(functionName) >= k_USELESS`
- **groups/bsl/bsls/bsls_outputredirector.cpp**
  - `expected != 0`
- **groups/bsl/bsls/bsls_stackaddressutil.cpp**
  - `output != NULL && length > 0`
  - `tag != NULL && strlen(tag) > 0`
- **groups/bsl/bsls/bsls_timeinterval.cpp**
  - `isSumValidInt64(d_seconds, seconds) && isSumValidInt64(d_seconds + seconds, (static_cast<bsls::Types::Int64>(d_nanoseconds) + nanoseconds) / k_NANOSECS_PER_SEC)`
  - `stream != nullptr && SEPFORALL(0, sizeof(buffer), i, stream + i ↦ buffer[i])`
- **groups/bsl/bslstl/bslstl_sharedptr.cpp**
  - `bufferSize > 0`
- **groups/bsl/bsltf/bsltf_copymovestate.cpp**
  - `value == CopyMoveState::e_ORIGINAL || value == CopyMoveState::e_COPIED_INTO || value == CopyMoveState::e_COPIED_CONST_INTO || value == CopyMoveState::e_COPIED_NONCONST_INTO || value == CopyMoveState::e_MOVED_INTO || value == CopyMoveState::e_MOVED_FROM || value == CopyMoveState::e_COPIED_INTO | CopyMoveState::e_MOVED_FROM || value == CopyMoveState::e_COPIED_CONST_INTO | CopyMoveState::e_MOVED_FROM || value == CopyMoveState::e_COPIED_NONCONST_INTO | CopyMoveState::e_MOVED_FROM || value == CopyMoveState::e_MOVED_INTO | CopyMoveState::e_MOVED_FROM || value == CopyMoveState::e_UNKNOWN`
- **groups/bsl/bsltf/bsltf_movestate.cpp**
  - `value == MoveState::e_NOT_MOVED || value == MoveState::e_MOVED || value == MoveState::e_UNKNOWN`
- **groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.cpp**
  - `rhs.d_data_p != 0`
- **groups/bsl/bslx/bslx_byteinstream.cpp**
  - `object.length() >= 0 && object.data() != nullptr && stream.good()`
- **groups/bsl/bslx/bslx_byteoutstream.cpp**
  - `stream.good() && object.d_buffer.size() >= 0`
- **groups/bsl/bslx/bslx_testoutstream.cpp**
  - `0 <= length`
- **groups/bsl/bslx/bslx_typecode.cpp**
  - `!stream.bad()`
