### PR TITLE
Automatic specifications

### DIFF
--- a/AUTO_SPECS_SUMMARY.md
+++ b/AUTO_SPECS_SUMMARY.md
@@ -1,0 +1,2076 @@
+# Specs found
+
+- **groups/bal/balb/balb_controlmanager.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == 0 || __out == 1`
+    - `__out == d_defaultHandler.has_value()`
+- **groups/bal/balb/balb_leakybucket.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == bsls::TimeInterval(0, 0) ==> (d_unitsInBucket + d_unitsReserved < d_capacity)) && (__out != bsls::TimeInterval(0, 0) ==> (d_unitsInBucket + d_unitsReserved >= d_capacity))`
+    - `__out >= 0 && *fractionalUnitDrainedInNanoUnits < 1000000000`
+- **groups/bal/balb/balb_performancemonitor.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == (bsl::fabs(lhs - rhs) < bsl::numeric_limits<double>::epsilon())`
+- **groups/bal/balb/balb_pipetaskmanager.cpp**
+  - requires:
+    - `controlManager != 0 && basicAllocator != 0`
+  - ensures:
+    - `__out != 0`
+- **groups/bal/balb/balb_ratelimiter.cpp**
+  - requires:
+    - `limit > 0 && window > bsls::TimeInterval()`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (limit > 0 && window > bsls::TimeInterval() && (limit == 1 || window <= LeakyBucket::calculateDrainTime(ULLONG_MAX, limit, true)) && window == LeakyBucket::calculateTimeWindow(limit, LeakyBucket::calculateCapacity(limit, window)))) && (__out == false ==> !(limit > 0 && window > bsls::TimeInterval() && (limit == 1 || window <= LeakyBucket::calculateDrainTime(ULLONG_MAX, limit, true)) && window == LeakyBucket::calculateTimeWindow(limit, LeakyBucket::calculateCapacity(limit, window))))`
+    - `__out == bsl::max(d_peakRateBucket.calculateTimeToSubmit(currentTime), d_sustainedRateBucket.calculateTimeToSubmit(currentTime))`
+- **groups/bal/balber/balber_berdecoder.cpp**
+  - requires:
+    - `FORALL(0, d_parent_count, i, d_parent[i] != 0 && d_parent[i]->d_consumedHeaderBytes ↦ _ && d_parent[i]->d_consumedBodyBytes ↦ _)`
+    - `true`
+  - ensures:
+    - `__out == (d_parent == 0 ? 0 : d_parent->d_consumedHeaderBytes + d_parent->d_consumedBodyBytes + d_parent->startPos())`
+    - `__out == d_decoder->logError(msg)`
+- **groups/bal/balber/balber_berdecoderoptions.cpp**
+  - requires:
+    - `nameLength >= 0 && SEPFORALL(0, nameLength, i, name[i] ↦ _)`
+  - ensures:
+    - `(__out == 0) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_MAX_DEPTH] && nameLength == 8) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_TRACE_LEVEL] && nameLength == 10) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_MAX_SEQUENCE_SIZE] && nameLength == 15) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_SKIP_UNKNOWN_ELEMENTS] && nameLength == 19) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_DEFAULT_EMPTY_STRINGS] && nameLength == 19)`
+- **groups/bal/balber/balber_berencoder.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(static_cast<int>(d_severity) >= static_cast<int>(e_BER_ERROR)) && (__out == logMsg("ERROR", tagClass, tagNumber, name, index))`
+- **groups/bal/balber/balber_beruniversaltagnumber.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(value == e_BER_BOOL ==> __out == "BOOL") && (value == e_BER_INT ==> __out == "INT") && (value == e_BER_OCTET_STRING ==> __out == "OCTET_STRING") && (value == e_BER_REAL ==> __out == "REAL") && (value == e_BER_ENUMERATION ==> __out == "ENUMERATION") && (value == e_BER_UTF8_STRING ==> __out == "UTF8_STRING") && (value == e_BER_SEQUENCE ==> __out == "SEQUENCE") && (value == e_BER_VISIBLE_STRING ==> __out == "VISIBLE_STRING") && (value != e_BER_BOOL && value != e_BER_INT && value != e_BER_OCTET_STRING && value != e_BER_REAL && value != e_BER_ENUMERATION && value != e_BER_UTF8_STRING && value != e_BER_SEQUENCE && value != e_BER_VISIBLE_STRING ==> __out == "(* UNKNOWN *)")`
+- **groups/bal/balber/balber_berutil.cpp**
+  - requires:
+    - `newSize >= d_oldSize`
+    - `tagClass != NULL && tagType != NULL && tagNumber != NULL && accumNumBytesConsumed != NULL && streamBuf != NULL`
+    - `tagNumber >= 0 && streamBuf != NULL`
+    - `true`
+  - ensures:
+    - `(__out == SUCCESS || __out == FAILURE)`
+    - `(__out == true ==> (k_MIN_OFFSET <= value && k_MAX_OFFSET >= value)) && (__out == false ==> !(k_MIN_OFFSET <= value && k_MAX_OFFSET >= value))`
+    - `__out == (value == 0 ? 1 : ((31 - bdlb::BitUtil::numLeadingUnsetBits(static_cast<bsl::uint32_t>(value > 0 ? value : ~value)) + 2 + Constants::k_NUM_BITS_PER_OCTET - 1) / Constants::k_NUM_BITS_PER_OCTET))`
+    - `__out == SUCCESS || __out == FAILURE`
+    - `__out == d_oldSize + nRead`
+    - `true`
+- **groups/bal/balcl/balcl_commandline.cpp**
+  - requires:
+    - `rhs.d_state != e_INVALID`
+    - `specTable != 0 && length >= 0`
+    - `true`
+  - ensures:
+    - `(__out != -1 ==> EXISTS(d_schema_p->cbegin(), d_schema_p->cend(), itr, (itr->d_name_p == name))) && (__out == -1 ==> FORALL(d_schema_p->cbegin(), d_schema_p->cend(), itr, (itr->d_name_p != name)))`
+    - `(__out != -1 ==> d_options[__out].name() == name) && (__out == -1 ==> FORALL(0, d_options.size(), i, d_options[i].name() != name))`
+    - `(__out == *this) && (d_options == rhs.d_options) && (d_state == e_NOT_PARSED || (d_state == e_PARSED && d_arguments == rhs.d_arguments))`
+    - `__out == (0 <= findName(name))`
+    - `__out == (lhs.isParsed() && rhs.isParsed() && lhs.options() == rhs.options())`
+    - `__out == (status == 0)`
+    - `__out == 0 || __out == 1 || __out == 2 || __out == 3 || __out == 4 || __out == 5 || __out == 6 || __out == 7 || __out == 8 || __out == 9 || __out == 10 || __out == 11 || __out == 12 || __out == 14 || __out == -1 || __out == -2 || __out == -3`
+    - `__out == d_returnValue`
+    - `__out == stream`
+    - `true`
+- **groups/bal/balcl/balcl_occurrenceinfo.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == *this) && ((&rhs != this) ==> (d_defaultValue ↦ rhs.d_defaultValue ⋆ d_isRequired ↦ rhs.d_isRequired ⋆ d_isHidden ↦ rhs.d_isHidden))`
+    - `(__out == true ==> (lhs.occurrenceType() == rhs.occurrenceType() && lhs.hasDefaultValue() == rhs.hasDefaultValue() && (!lhs.hasDefaultValue() || lhs.defaultValue() == rhs.defaultValue()))) && (__out == false ==> !(lhs.occurrenceType() == rhs.occurrenceType() && lhs.hasDefaultValue() == rhs.hasDefaultValue() && (!lhs.hasDefaultValue() || lhs.defaultValue() == rhs.defaultValue())))`
+    - `__out == d_defaultValue`
+- **groups/bal/balcl/balcl_option.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == (static_cast<const OptionInfo&>(lhs) == static_cast<const OptionInfo&>(rhs))`
+    - `__out == *this ⋆ (*this == rhs)`
+- **groups/bal/balcl/balcl_optioninfo.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bal/balcl/balcl_optiontype.cpp**
+  - requires:
+    - `stream ↦ _`
+  - ensures:
+    - `__out == stream && (stream ↦ _)`
+- **groups/bal/balcl/balcl_optionvalue.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == (d_value.is<OptionValue_NullOf>() ? d_value.the<OptionValue_NullOf>().type() : static_cast<OptionType::Enum>(d_value.typeIndex()))`
+- **groups/bal/balcl/balcl_typeinfo.cpp**
+  - requires:
+    - `true`
+    - `value != NULL && input.size() >= 0`
+  - ensures:
+    - `(this != &rhs ==> (d_elemType == rhs.d_elemType && d_linkedVariable_p == rhs.d_linkedVariable_p && d_isOptionalLinkedVariable == rhs.d_isOptionalLinkedVariable && d_constraint_p == rhs.d_constraint_p)) && (__out == *this)`
+    - `(type == OptionType::e_STRING ==> __out == true) && (type != OptionType::e_STRING ==> (__out == true || __out == false))`
+    - `__out == (lhs.type() == rhs.type() && lhs.linkedVariable() == rhs.linkedVariable() && lhs.constraint() == rhs.constraint())`
+    - `__out == OptionType::e_BOOL`
+    - `__out == d_constraint_p`
+- **groups/bal/baljsn/baljsn_datumutil.cpp**
+  - requires:
+    - `formatter != 0 && strictTypesCheckStatus != 0 && datum.length() >= 0 && (name == 0 || name != 0)`
+    - `formatter != nullptr && strictTypesCheckStatus != nullptr && (name == nullptr || (*name == bsl::string_view() && formatter->canAddMemberName())) && datum.size() >= 0`
+    - `maxNestedDepth >= 0`
+    - `result != NULL && jsonBuffer != NULL`
+    - `result != NULL && tokenizer != NULL`
+  - ensures:
+    - `(__out == 0 || __out == -1)`
+    - `(__out == 0) ==> (FORALL(0, datum.length(), i, u::encodeValue(formatter, datum[i], strictTypesCheckStatus) == 0)) && (__out != 0) ==> EXISTS(0, datum.length(), i, u::encodeValue(formatter, datum[i], strictTypesCheckStatus) == __out)`
+    - `__out == -4 || __out == -1 || __out == -2 || __out == -3 || __out == 0`
+    - `__out == -4 || __out == -1 || __out == -2 || __out == 0`
+    - `__out == 0 || __out == -1 || __out == -2 || __out == -3`
+    - `__out == result`
+- **groups/bal/baljsn/baljsn_decoder.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == d_logStream`
+- **groups/bal/baljsn/baljsn_encoder.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == encodeSimpleValue(formatter, base64String, encoderOptions) || __out < 0`
+- **groups/bal/baljsn/baljsn_encoder_testtypes.cpp**
+  - requires:
+    - `(number == EncoderTestChoiceWithAllCategoriesEnumeration::A || number == EncoderTestChoiceWithAllCategoriesEnumeration::B) && result != 0`
+    - `(value == EncoderTestChoiceWithAllCategoriesEnumeration::A) || (value == EncoderTestChoiceWithAllCategoriesEnumeration::B)`
+    - `(value == EncoderTestSequenceWithAllCategoriesEnumeration::A) || (value == EncoderTestSequenceWithAllCategoriesEnumeration::B)`
+    - `EXISTS(0, 2, i, (stringLength == EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength && 0 == bsl::memcmp(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength))) || (FORALL(0, 2, i, stringLength != EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength || 0 != bsl::memcmp(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength)) && *result == old_result)`
+    - `name != nullptr && nameLength >= 0 && FORALL(0, nameLength, i, name[i] != 0) && name[nameLength] == 0`
+    - `name != nullptr && nameLength >= 0 && name[nameLength - 1] == '\0'`
+    - `result != 0 && (number == EncoderTestSequenceWithAllCategoriesEnumeration::A || number == EncoderTestSequenceWithAllCategoriesEnumeration::B)`
+    - `true`
+  - ensures:
+    - `&__out == this`
+    - `(SELECTION_ID_SIMPLE == d_selectionId) ==> (__out == value) && (SELECTION_ID_SIMPLE != d_selectionId) ==> (__out ↦ value)`
+    - `(__out == -1 ==> lookupSelectionInfo(name, nameLength) == 0) && (__out != -1 ==> __out == makeSelection(lookupSelectionInfo(name, nameLength)->d_id))`
+    - `(__out == -1 ==> lookupSelectionInfo(name, nameLength) == nullptr) && (__out != -1 ==> __out == makeSelection(lookupSelectionInfo(name, nameLength)->d_id))`
+    - `(__out == -1 ==> selectionInfo == 0) && (__out != -1 ==> __out == makeSelection(selectionInfo->d_id))`
+    - `(__out == 0 ==> ((*result ↦ static_cast<EncoderTestChoiceWithAllCategoriesEnumeration::Value>(number)) && (number == EncoderTestChoiceWithAllCategoriesEnumeration::A || number == EncoderTestChoiceWithAllCategoriesEnumeration::B))) && (__out == -1 ==> true)`
+    - `(__out == 0 ==> ((*result ↦ static_cast<EncoderTestSequenceWithAllCategoriesEnumeration::Value>(number)) && (number == EncoderTestSequenceWithAllCategoriesEnumeration::A || number == EncoderTestSequenceWithAllCategoriesEnumeration::B))) && (__out == -1 ==> (number != EncoderTestSequenceWithAllCategoriesEnumeration::A && number != EncoderTestSequenceWithAllCategoriesEnumeration::B))`
+    - `(__out == 0 ==> EXISTS(0, 2, i, (stringLength == EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength && 0 == bsl::memcmp(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength) && (*result == static_cast<EncoderTestChoiceWithAllCategoriesEnumeration::Value>(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_value))))) && (__out == -1 ==> *result == old_result)`
+    - `(__out == 0 ==> EXISTS(0, 2, i, (stringLength == EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength && 0 == bsl::memcmp(EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength) && (*result ↦ EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_value)))) && (__out == -1 ==> *result ↦ old_result)`
+    - `(__out == SELECTION_INFO_ARRAY[SELECTION_INDEX_CHAR_ARRAY].name(`
+    - `(d_selectionId == SELECTION_ID_ENUMERATION && d_enumeration.object() == value) && (__out == d_enumeration.object())`
+    - `(d_selectionId == SELECTION_ID_SELECTION0 ==> (d_selection0.object() ↦ value)) && (d_selectionId != SELECTION_ID_SELECTION0 ==> (d_selection0.buffer() ↦ value ⋆ d_selectionId == SELECTION_ID_SELECTION0)) && (__out ↦ value)`
+    - `(d_selectionId == SELECTION_ID_SELECTION0 ==> (d_selection0.object() ↦ value)) && (d_selectionId != SELECTION_ID_SELECTION0 ==> (d_selectionId == SELECTION_ID_SELECTION0 ⋆ d_selection0.object() ↦ value))`
+    - `(d_selectionId == SELECTION_ID_SELECTION0 ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SELECTION0].name()) && (d_selectionId != SELECTION_ID_SELECTION0 ==> __out == "(* UNDEFINED *)")`
+    - `(d_selectionId == SELECTION_ID_SEQUENCE ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SEQUENCE].name()) && (d_selectionId != SELECTION_ID_SEQUENCE ==> __out == "(* UNDEFINED *)")`
+    - `(selectionId == SELECTION_ID_SELECTION0 || selectionId == SELECTION_ID_UNDEFINED) ==> __out == 0 && (selectionId != SELECTION_ID_SELECTION0 && selectionId != SELECTION_ID_UNDEFINED) ==> __out == -1`
+    - `(this != &rhs ==> (d_name ↦ rhs.d_name ⋆ d_homeAddress ↦ rhs.d_homeAddress ⋆ d_age ↦ rhs.d_age)) && (__out == *this)`
+    - `(this != &rhs ==> (d_selectionId == rhs.d_selectionId && (d_selectionId == SELECTION_ID_SELECTION0 ==> (d_selection0.object() == rhs.d_selection0.object())))) && (this == &rhs ==> true)`
+    - `(this != &rhs ==> (d_street ↦ rhs.d_street ⋆ d_city ↦ rhs.d_city ⋆ d_state ↦ rhs.d_state)) && __out == *this`
+    - `(value == A ==> __out == "A") && (value == B ==> __out == "B") && (value != A && value != B ==> __out == 0)`
+    - `(value == EncoderTestSequenceWithAllCategoriesEnumeration::A ==> __out == "A") && (value == EncoderTestSequenceWithAllCategoriesEnumeration::B ==> __out == "B") && (value != EncoderTestSequenceWithAllCategoriesEnumeration::A && value != EncoderTestSequenceWithAllCategoriesEnumeration::B ==> __out == 0)`
+    - `__out == *this && (this != &rhs ==> (d_charArray == rhs.d_charArray ⋆ d_aString == rhs.d_aString ⋆ d_array == rhs.d_array ⋆ d_choice == rhs.d_choice ⋆ d_customizedType == rhs.d_customizedType ⋆ d_enumeration == rhs.d_enumeration ⋆ d_nullableValue == rhs.d_nullableValue ⋆ d_sequence == rhs.d_sequence ⋆ d_simple == rhs.d_simple))`
+- **groups/bal/baljsn/baljsn_parserutil.cpp**
+  - requires:
+    - `value != nullptr && data.size() >= 0`
+  - ensures:
+    - `__out == bdljsn::StringUtil::readUnquotedString(value, data, bdljsn::StringUtil::e_ACCEPT_CAPITAL_UNICODE_ESCAPE)`
+- **groups/bal/ball/ball_administration.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == 0) || (__out == 1)`
+- **groups/bal/ball/ball_asyncfileobserver.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == true ==> record.d_record.get() == 0) && (__out == false ==> record.d_record.get() != 0)`
+    - `true`
+- **groups/bal/ball/ball_attribute.cpp**
+  - requires:
+    - `size > 0`
+    - `stream ↦ _`
+    - `true`
+  - ensures:
+    - `(attribute.d_hashValue == __out) && (0 <= __out && __out < size)`
+    - `__out == output`
+    - `__out == stream && (stream ↦ _)`
+- **groups/bal/ball/ball_attributecollectorregistry.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == 0 || __out == 1)`
+- **groups/bal/ball/ball_attributecontainerlist.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == *this`
+    - `__out == true || __out == false`
+- **groups/bal/ball/ball_attributecontext.cpp**
+  - requires:
+    - `FORALL(0, RuleSet::e_MAX_NUM_RULES, i, (relevantRulesMask & (1 << i)) != 0 ==> rules.getRuleById(i) != nullptr)`
+    - `category != nullptr`
+    - `stream ↦ _`
+    - `true`
+  - ensures:
+    - `(__out == false ==> category->relevantRuleMask() == 0) && (__out == true ==> (category->relevantRuleMask() & d_ruleCache_p.knownActiveRules()) != 0 || (category->relevantRuleMask() & d_ruleCache_p.update(s_categoryManager_p->ruleSetSequenceNumber(), category->relevantRuleMask(), s_categoryManager_p->ruleSet(), d_containerList)) != 0)`
+    - `__out != 0`
+    - `__out == &s_contextKey`
+    - `__out == d_resultMask`
+    - `__out == stream && (stream ↦ _)`
+- **groups/bal/ball/ball_broadcastobserver.cpp**
+  - requires:
+    - `!observerName.empty()`
+    - `true`
+  - ensures:
+    - `(__out == 1 ==> d_observers.find(observerName) == d_observers.end()) && (__out == 0 ==> d_observers.find(observerName) == d_observers.end())`
+    - `(d_observers.find(observerName) == d_observers.end() ==> __out.use_count() == 0) && (d_observers.find(observerName) != d_observers.end() ==> __out.use_count() > 0)`
+- **groups/bal/ball/ball_category.cpp**
+  - requires:
+    - `Category::areValidThresholdLevels(recordLevel, passLevel, triggerLevel, triggerAllLevel)`
+  - ensures:
+    - `(__out == 0 ==> (d_thresholdLevels ↦ ThresholdAggregateUtil::pack(ThresholdAggregate(recordLevel, passLevel, triggerLevel, triggerAllLevel)) ⋆ d_threshold ↦ ThresholdAggregate::maxLevel(recordLevel, passLevel, triggerLevel, triggerAllLevel))) && (__out == -1 ==> true)`
+- **groups/bal/ball/ball_categorymanager.cpp**
+  - requires:
+    - `categoryName != NULL`
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> d_registry.find(categoryName) == d_registry.end()) && (__out != 0 ==> (d_registry.find(categoryName) != d_registry.end() && __out == d_categories[d_registry.find(categoryName)->second]))`
+    - `__out != NULL`
+- **groups/bal/ball/ball_context.cpp**
+  - requires:
+    - `stream.good() && (stream ↦ _)`
+  - ensures:
+    - `__out == stream && (__out.good() && (__out ↦ _))`
+- **groups/bal/ball/ball_defaultattributecontainer.cpp**
+  - requires:
+    - `lhs.numAttributes() == rhs.numAttributes() && FORALL(lhs.begin(), lhs.end(), attr, rhs.hasValue(attr))`
+    - `true`
+  - ensures:
+    - `(__out == true ==> d_attributeSet.find(value) != d_attributeSet.end()) && (__out == false ==> d_attributeSet.find(value) == d_attributeSet.end())`
+    - `(lhs.numAttributes() == rhs.numAttributes() && lhs.begin() == lhs.end()) || (lhs.numAttributes() == rhs.numAttributes() && std::all_of(lhs.begin(), lhs.end(), [&rhs](const auto& attr) { return rhs.hasValue(attr); })) == __out`
+    - `(this != &rhs ==> (__out == *this && __out == rhs)) && (this == &rhs ==> __out == *this)`
+- **groups/bal/ball/ball_fileobserver.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out != 0`
+- **groups/bal/ball/ball_fileobserver2.cpp**
+  - requires:
+    - `0 < interval.totalMilliseconds()`
+    - `0 <= interval.totalMilliseconds()`
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> (stream->rdbuf() != nullptr && FileUtil::exists(filename))) && (__out == -1 ==> (stream->rdbuf() == nullptr || FileUtil::exists(filename) == false))`
+    - `(__out == true ==> abs((a - b).totalMilliseconds()) < (interval.totalMilliseconds() / 10)) && (__out == false ==> abs((a - b).totalMilliseconds()) >= (interval.totalMilliseconds() / 10))`
+    - `__out == d_logStreamBuf.isOpened()`
+    - `__out == fileCreationTimeUtc + interval || __out > fileCreationTimeUtc`
+    - `__out >= 0`
+- **groups/bal/ball/ball_log.cpp**
+  - requires:
+    - `buffer != NULL && numBytes > 0`
+  - ensures:
+    - `(__out == -1) || (__out >= 0 && __out < (signed)numBytes)`
+- **groups/bal/ball/ball_loggercategoryutil.cpp**
+  - requires:
+    - `loggerManager != 0 && categoryName != 0`
+  - ensures:
+    - `(__out == 0 ==> (loggerManager->lookupCategory(categoryName) != 0 || loggerManager->thresholdLevelsForNewCategory(nullptr, categoryName) != 0)) && (__out != 0 ==> true)`
+- **groups/bal/ball/ball_loggermanager.cpp**
+  - requires:
+    - `fileName != nullptr && fileName[0] != '\0' && lineNumber >= 0`
+    - `fileName != nullptr && lineNumber >= 0`
+    - `filteredNameBuffer != nullptr && originalName != nullptr`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (category->relevantRuleMask() && ThresholdAggregate::maxLevel(levels) >= severity) || (!category->relevantRuleMask() && category->maxLevel() >= severity)) && (__out == false ==> (category->relevantRuleMask() && ThresholdAggregate::maxLevel(levels) < severity) || (!category->relevantRuleMask() && category->maxLevel() < severity))`
+    - `(nameFilter != nullptr ==> __out == filteredNameBuffer->c_str()) && (nameFilter == nullptr ==> __out == originalName)`
+    - `__out != 0`
+    - `__out != nullptr`
+- **groups/bal/ball/ball_loggermanagerconfiguration.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == (lhs.d_defaults == rhs.d_defaults && (bool)lhs.d_userPopulator == (bool)rhs.d_userPopulator && (bool)lhs.d_categoryNameFilter == (bool)rhs.d_categoryNameFilter && (bool)lhs.d_defaultThresholdsCb == (bool)rhs.d_defaultThresholdsCb && lhs.d_logOrder == rhs.d_logOrder && lhs.d_triggerMarkers == rhs.d_triggerMarkers))`
+    - `__out == *this`
+    - `__out == LoggerManagerDefaults::isValidDefaultRecordBufferSize(numBytes)`
+    - `__out == d_defaults`
+- **groups/bal/ball/ball_loggermanagerdefaults.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == true ==> numBytes > 0) && (__out == false ==> numBytes <= 0)`
+    - `(__out == true) ==> (lhs.d_recordBufferSize == rhs.d_recordBufferSize && lhs.d_loggerBufferSize == rhs.d_loggerBufferSize && lhs.d_defaultRecordLevel == rhs.d_defaultRecordLevel && lhs.d_defaultPassLevel == rhs.d_defaultPassLevel && lhs.d_defaultTriggerLevel == rhs.d_defaultTriggerLevel && lhs.d_defaultTriggerAllLevel == rhs.d_defaultTriggerAllLevel) && (__out == false) ==> !(lhs.d_recordBufferSize == rhs.d_recordBufferSize && lhs.d_loggerBufferSize == rhs.d_loggerBufferSize && lhs.d_defaultRecordLevel == rhs.d_defaultRecordLevel && lhs.d_defaultPassLevel == rhs.d_defaultPassLevel && lhs.d_defaultTriggerLevel == rhs.d_defaultTriggerLevel && lhs.d_defaultTriggerAllLevel == rhs.d_defaultTriggerAllLevel)`
+    - `__out == *this ⋆ d_recordBufferSize ↦ rhs.d_recordBufferSize ⋆ d_loggerBufferSize ↦ rhs.d_loggerBufferSize ⋆ d_defaultRecordLevel ↦ rhs.d_defaultRecordLevel ⋆ d_defaultPassLevel ↦ rhs.d_defaultPassLevel ⋆ d_defaultTriggerLevel ↦ rhs.d_defaultTriggerLevel ⋆ d_defaultTriggerAllLevel ↦ rhs.d_defaultTriggerAllLevel`
+    - `__out == d_recordBufferSize`
+- **groups/bal/ball/ball_managedattribute.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == output`
+    - `__out == stream && (d_attribute.print(stream, level, spacesPerLevel) == stream)`
+- **groups/bal/ball/ball_managedattributeset.cpp**
+  - requires:
+    - `0 < size`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (lhs.numAttributes() == rhs.numAttributes() && FORALL(0, lhs.numAttributes(), i, rhs.isMember(*(lhs.begin() + i))))) && (__out == false ==> (lhs.numAttributes() != rhs.numAttributes() || EXISTS(0, lhs.numAttributes(), i, !rhs.isMember(*(lhs.begin() + i)))))`
+    - `(__out == true) || (__out == false)`
+    - `(this != &rhs ==> d_attributeSet == rhs.d_attributeSet) && (__out == *this)`
+    - `__out == (hashValue % size)`
+- **groups/bal/ball/ball_patternutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `true`
+- **groups/bal/ball/ball_record.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bal/ball/ball_recordattributes.cpp**
+  - requires:
+    - `d_messageStreamBuf.data() != 0`
+    - `true`
+  - ensures:
+    - `__out != 0`
+    - `__out == (lhs.d_timestamp == rhs.d_timestamp && lhs.d_processID == rhs.d_processID && lhs.d_threadID == rhs.d_threadID && lhs.d_severity == rhs.d_severity && lhs.d_lineNumber == rhs.d_lineNumber && lhs.d_fileName == rhs.d_fileName && lhs.d_category == rhs.d_category && lhs.messageRef() == rhs.messageRef())`
+- **groups/bal/ball/ball_recordjsonformatter.cpp**
+  - requires:
+    - `(EXISTS(0, v.size(), i, !v[i].value().isString()) ==> res_tmp == -1) && (FORALL(0, v.size(), i, v[i].value().isString()) ==> res_tmp == 0)`
+    - `SEPEXISTS(0, 9, i, v == k_KEY_TIMESTAMP || v == k_KEY_PROCESS_ID || v == k_KEY_THREAD_ID || v == k_KEY_SEVERITY || v == k_KEY_FILE || v == k_KEY_LINE || v == k_KEY_CATEGORY || v == k_KEY_MESSAGE || v == k_KEY_ATTRIBUTES)`
+    - `true`
+  - ensures:
+    - `(__out == -1 ==> EXISTS(0, v.size(), i, !v[i].value().isString())) && (__out == 0 ==> FORALL(0, v.size(), i, v[i].value().isString()))`
+    - `(format.empty() ==> __out == -1) && (!format.empty() ==> __out == 0 || __out != 0)`
+    - `__out != 0 && (__out ↦ _)`
+    - `__out ↦ d_key`
+    - `__out ↦ d_name`
+    - `true`
+- **groups/bal/ball/ball_recordstringformatter.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == true ==> (bsl::strcmp(lhs.format(), rhs.format()) == 0 && lhs.timestampOffset() == rhs.timestampOffset())) && (__out == false ==> (bsl::strcmp(lhs.format(), rhs.format()) != 0 || lhs.timestampOffset() != rhs.timestampOffset()))`
+- **groups/bal/ball/ball_rule.cpp**
+  - requires:
+    - `0 < size && rule.d_attributeSet != nullptr && rule.d_thresholds != nullptr && rule.d_pattern != ""`
+    - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
+    - `true`
+  - ensures:
+    - `(rule.d_hashValue < 0 || rule.d_hashSize != size) ==> (rule.d_hashValue == ((ManagedAttributeSet::hash(rule.d_attributeSet, size) + ThresholdAggregate::hash(rule.d_thresholds, size) + bdlb::HashUtil::hash0(rule.d_pattern.c_str(), size)) % size) ⋆ rule.d_hashSize == size) ⋆ __out == rule.d_hashValue`
+    - `__out == stream && (__out ↦ _)`
+    - `__out.d_pattern ↦ rhs.d_pattern ⋆ __out.d_thresholds ↦ rhs.d_thresholds ⋆ __out.d_attributeSet ↦ rhs.d_attributeSet ⋆ __out.d_hashValue ↦ rhs.d_hashValue ⋆ __out.d_hashSize ↦ rhs.d_hashSize`
+- **groups/bal/ball/ball_ruleset.cpp**
+  - requires:
+    - `lhs.numRules() == rhs.numRules()`
+    - `true`
+  - ensures:
+    - `(__out == -1 ==> d_ruleHashtable.find(value) == d_ruleHashtable.end()) && (__out != -1 ==> (0 <= __out && __out < d_ruleAddresses.size() && d_ruleAddresses[__out] == &*d_ruleHashtable.find(value)))`
+    - `(__out == -1 || __out == -2 || __out >= 0)`
+    - `(lhs.numRules() == rhs.numRules() && __out == true) || (lhs.numRules() != rhs.numRules() || __out == false)`
+- **groups/bal/ball/ball_scopedattribute.cpp**
+  - requires:
+    - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
+  - ensures:
+    - `(__out == stream) && (stream ↦ _)`
+- **groups/bal/ball/ball_severity.cpp**
+  - requires:
+    - `level != NULL && string != NULL`
+  - ensures:
+    - `__out == 0 || __out == -1`
+- **groups/bal/ball/ball_severityutil.cpp**
+  - requires:
+    - `level != nullptr && name != nullptr`
+  - ensures:
+    - `(__out == BALL_SUCCESS ==> (bdlb::String::areEqualCaseless("OFF", 3, name) || bdlb::String::areEqualCaseless("FATAL", 5, name) || bdlb::String::areEqualCaseless("ERROR", 5, name) || bdlb::String::areEqualCaseless("WARN", 4, name) || bdlb::String::areEqualCaseless("INFO", 4, name) || bdlb::String::areEqualCaseless("DEBUG", 5, name) || bdlb::String::areEqualCaseless("TRACE", 5, name))) && (__out == BALL_FAILURE ==> !(bdlb::String::areEqualCaseless("OFF", 3, name) || bdlb::String::areEqualCaseless("FATAL", 5, name) || bdlb::String::areEqualCaseless("ERROR", 5, name) || bdlb::String::areEqualCaseless("WARN", 4, name) || bdlb::String::areEqualCaseless("INFO", 4, name) || bdlb::String::areEqualCaseless("DEBUG", 5, name) || bdlb::String::areEqualCaseless("TRACE", 5, name)))`
+- **groups/bal/ball/ball_thresholdaggregate.cpp**
+  - requires:
+    - `0 < size`
+    - `true`
+  - ensures:
+    - `__out == (bdlb::HashUtil::hash1((const char*)&value, sizeof(value)) % size)`
+    - `__out == stream && SEPFORALL(0, n, i, stream + i ↦ sep_v)`
+    - `__out.d_recordLevel == rhs.d_recordLevel ⋆ __out.d_passLevel == rhs.d_passLevel ⋆ __out.d_triggerLevel == rhs.d_triggerLevel ⋆ __out.d_triggerAllLevel == rhs.d_triggerAllLevel`
+- **groups/bal/ball/ball_userfields.cpp**
+  - requires:
+    - `!stream.bad()`
+  - ensures:
+    - `__out == stream`
+- **groups/bal/ball/ball_userfieldtype.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream && SEPFORALL(0, sizeof(toAscii(value)), i, stream + i ↦ toAscii(value)[i])`
+- **groups/bal/ball/ball_userfieldvalue.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == ball::UserFieldType::e_VOID || __out == ball::UserFieldType::e_INT64 || __out == ball::UserFieldType::e_DOUBLE || __out == ball::UserFieldType::e_STRING || __out == ball::UserFieldType::e_DATETIMETZ || __out == ball::UserFieldType::e_CHAR_ARRAY)`
+- **groups/bal/balm/balm_bdlmmetricsadapter.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `true`
+- **groups/bal/balm/balm_category.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream && SEPFORALL(0, sizeof(d_name_p), i, stream + i ↦ d_name_p[i])`
+- **groups/bal/balm/balm_collectorrepository.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `&__out == &d_collectors`
+    - `__out == d_collectors`
+- **groups/bal/balm/balm_configurationutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == -1 ==> manager == 0) && (__out == 0 ==> manager != 0)`
+- **groups/bal/balm/balm_defaultmetricsmanager.cpp**
+  - requires:
+    - `basicAllocator != 0 && s_singleton_p == 0 && s_allocator_p == 0`
+  - ensures:
+    - `(__out != 0) && (s_singleton_p == __out) && (s_allocator_p != 0)`
+- **groups/bal/balm/balm_metricdescription.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream && SEPFORALL(0, strlen(d_category_p->name() + "." + d_name_p), i, stream + i ↦ (d_category_p->name() + "." + d_name_p)[i])`
+- **groups/bal/balm/balm_metricformat.cpp**
+  - requires:
+    - `SEPFORALL(0, level, i, (stream + i ↦ sep_v) && (sep_v == sep_v))`
+    - `true`
+  - ensures:
+    - `__out == stream`
+    - `__out == stream && SEPFORALL(0, level, i, (stream + i ↦ sep_v) && (sep_v == d_scale || sep_v == d_format))`
+    - `__out == stream ⋆ SEPFORALL(0, d_formatSpecs.size(), i, (__out + i ↦ _))`
+- **groups/bal/balm/balm_metricid.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(d_description_p == 0 ==> SEPFORALL(0, sizeof("INVALID_ID"), i, stream + i ↦ "INVALID_ID"[i])) && (d_description_p != 0 ==> SEPFORALL(0, strlen(*d_description_p), i, stream + i ↦ (*d_description_p)[i])) && (__out == stream)`
+- **groups/bal/balm/balm_metricrecord.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == stream) && SEPFORALL(0, sizeof("[ " << d_metricId << ": " << d_count << " " << d_total << " " << d_min << " " << d_max << " ]"), i, stream + i ↦ "[ " << d_metricId << ": " << d_count << " " << d_total << " " << d_min << " " << d_max << " ]"[i])`
+- **groups/bal/balm/balm_metricregistry.cpp**
+  - requires:
+    - `(candidatePrefix != NULL) && (string != NULL)`
+    - `true`
+  - ensures:
+    - `(__out != MetricId() ==> ret.second) && (__out == MetricId() ==> !ret.second)`
+    - `(__out == true ==> *candidatePrefix == 0) && (__out == false ==> EXISTS(0, strlen(candidatePrefix), i, candidatePrefix[i] != string[i]))`
+    - `(__out.second == false) || (__out.second == true)`
+    - `__out == d_metrics.size()`
+- **groups/bal/balm/balm_metricsample.cpp**
+  - requires:
+    - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
+    - `true`
+  - ensures:
+    - `(__out == *this) && ((this != &rhs) ==> (d_records ↦ rhs.d_records ⋆ d_timeStamp ↦ rhs.d_timeStamp ⋆ d_numRecords ↦ rhs.d_numRecords))`
+    - `__out == stream`
+    - `__out == stream && (__out ↦ _)`
+- **groups/bal/balm/balm_metricsmanager.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == -1 ==> (d_generalPublishers.find(publisher) != d_generalPublishers.end() || (d_registry.find(publisher) != d_registry.end() && !d_registry.find(publisher)->second.empty()))) && (__out == 0 ==> (d_generalPublishers.find(publisher) == d_generalPublishers.end() || (d_registry.find(publisher) == d_registry.end() || d_registry.find(publisher)->second.empty())) && d_generalPublishers.find(publisher) != d_generalPublishers.end())`
+    - `__out == d_nextHandle - 1 && d_callbacks.find(category) != d_callbacks.end() && d_handles.find(__out) != d_handles.end() && d_handles.find(__out)->second->first == category`
+- **groups/bal/balm/balm_publicationscheduler.cpp**
+  - requires:
+    - `categories.size() >= 0 && SEPFORALL(categories.begin(), categories.end(), it, (*it)->name() ↦ _)`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (*result ↦ catIt->second)) && (__out == false ==> *result ↦ old_result)`
+    - `__out == &d_mutex`
+    - `__out == stream`
+    - `__out.seconds() == 0 && __out.nanoseconds() == 0`
+- **groups/bal/balst/balst_stacktrace.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bal/balst/balst_stacktraceframe.cpp**
+  - requires:
+    - `!stream.bad()`
+  - ensures:
+    - `__out == stream && (stream ↦ _)`
+    - `__out == stream && (stream.bad() || (stream.good() && (stream << object.address() && stream << object.libraryFileName().c_str() && stream << object.lineNumber() && stream << object.mangledSymbolName().c_str() && stream << object.offsetFromSymbol() && stream << object.sourceFileName().c_str() && stream << object.symbolName().c_str())))`
+- **groups/bal/balst/balst_stacktraceprinter.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bal/balst/balst_stacktraceprintutil.cpp**
+  - requires:
+    - `(0 <= maxFrames || maxFrames == -1) && (0 <= additionalIgnoreFrames) && (&stream != 0)`
+  - ensures:
+    - `__out == &stream`
+- **groups/bal/balst/balst_stacktracetestallocator.cpp**
+  - requires:
+    - `size >= 0`
+    - `specifiedMaxRecordedFrames >= 0`
+    - `true`
+  - ensures:
+    - `(__out == -1 ==> (k_ALLOCATED_BLOCK_MAGIC != blockHdr->d_magic || this != blockHdr->d_allocator_p || 0 == d_blocks || 0 == blockHdr->d_prevNext_p || 0 == *blockHdr->d_prevNext_p || (blockHdr->d_next_p && k_ALLOCATED_BLOCK_MAGIC != blockHdr->d_next_p->d_magic))) && (__out == 0 ==> (k_ALLOCATED_BLOCK_MAGIC == blockHdr->d_magic && this == blockHdr->d_allocator_p && d_blocks != 0 && blockHdr->d_prevNext_p != 0 && *blockHdr->d_prevNext_p != 0 && (!blockHdr->d_next_p || k_ALLOCATED_BLOCK_MAGIC == blockHdr->d_next_p->d_magic)))`
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))`
+    - `__out == d_allocationLimit.loadRelaxed()`
+    - `__out >= specifiedMaxRecordedFrames && __out % k_PTRS_PER_MAX == 0`
+- **groups/bal/balst/balst_stacktraceutil.cpp**
+  - requires:
+    - `pathName != nullptr && SEPFORALL(0, bsl::strlen(pathName), i, pathName + i ↦ _)`
+    - `true`
+  - ensures:
+    - `(__out >= pathName) && (__out == pathName || (*(__out - 1) == '/' || *(__out - 1) == '\\'))`
+    - `__out == -1`
+- **groups/bal/baltzo/baltzo_datafileloader.cpp**
+  - requires:
+    - `path != nullptr`
+    - `result != nullptr && timeZoneId != nullptr`
+    - `timeZoneId && SEPFORALL(0, strlen(timeZoneId), i, (timeZoneId + i ↦ _))`
+  - ensures:
+    - `(__out == -1 ==> timeZoneId[0] == '/') && (__out == -2 ==> SEPEXISTS(0, strlen(timeZoneId), i, (timeZoneId + i ↦ sep_v && !bsl::strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890/_+-", sep_v)))) && (__out == 0 ==> !(timeZoneId[0] == '/') && SEPFORALL(0, strlen(timeZoneId), i, (timeZoneId + i ↦ sep_v && bsl::strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890/_+-", sep_v))))`
+    - `(__out == true ==> (bdls::FilesystemUtil::isDirectory(path, true) && bdls::FilesystemUtil::isRegularFile((bsl::string(path) + "/GMT").c_str(), true))) && (__out == false ==> !(bdls::FilesystemUtil::isDirectory(path, true) && bdls::FilesystemUtil::isRegularFile((bsl::string(path) + "/GMT").c_str(), true)))`
+    - `POST(
+    (__out == u::UNSUPPORTED_ID || __out == u::UNSPECIFIED_ERROR) ||
+    (result->getIdentifier() == timeZoneId)
+)
+
+This postcondition ensures that either the function returns an error code (`u::UNSUPPORTED_ID` or `u::UNSPECIFIED_ERROR`), or it successfully sets the identifier of the `result` object to `timeZoneId`.`
+    - `__out == u::loadTimeZoneFilePath_Impl(result, timeZoneId, d_rootPath) && (result ↦ _)`
+- **groups/bal/baltzo/baltzo_defaultzoneinfocache.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out != 0) && ((__out == getenv("BDE_ZONEINFO_ROOT_PATH")) || (SEPEXISTS(0, u::k_NUM_BALTZO_DATA_LOCATIONS, ii, __out == u::BALTZO_DATA_LOCATIONS[ii])) || (__out == "."))`
+    - `(u::userSingletonCachePtr != 0 ==> __out == u::userSingletonCachePtr) && (u::userSingletonCachePtr == 0 ==> (__out == u::systemSingletonCachePtr && u::systemSingletonCachePtr != 0))`
+    - `__out != 0`
+- **groups/bal/baltzo/baltzo_localdatetime.cpp**
+  - requires:
+    - `(stream.bad() ==> true) && (!stream.bad() ==> (SEPFORALL(0, object.timeZoneId().size(), i, object.timeZoneId().c_str()[i] ↦ _) ⋆ SEPFORALL(0, object.datetimeTz().size(), j, object.datetimeTz().c_str()[j] ↦ _)))`
+  - ensures:
+    - `__out == stream && (stream.bad() || (stream.good() && (SEPFORALL(0, object.timeZoneId().size(), i, stream + i ↦ object.timeZoneId().c_str()[i]) ⋆ SEPFORALL(0, object.datetimeTz().size(), j, stream + j ↦ object.datetimeTz().c_str()[j]))))`
+- **groups/bal/baltzo/baltzo_localtimedescriptor.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream && SEPFORALL(0, 3, i, (__out + i ↦ sep_v && (sep_v == object.utcOffsetInSeconds() || sep_v == object.dstInEffectFlag() || sep_v == object.description().c_str())))`
+- **groups/bal/baltzo/baltzo_localtimeoffsetutil.cpp**
+  - requires:
+    - `timezone != NULL`
+  - ensures:
+    - `__out == 0 || __out != 0`
+- **groups/bal/baltzo/baltzo_localtimeperiod.cpp**
+  - requires:
+    - `stream ↦ _ && !stream.bad()`
+  - ensures:
+    - `(__out == stream) && (stream ↦ _)`
+- **groups/bal/baltzo/baltzo_localtimevalidity.cpp**
+  - requires:
+    - `stream.good() && (value == LocalTimeValidity::Enum::VALID || value == LocalTimeValidity::Enum::INVALID)`
+  - ensures:
+    - `__out == stream && SEPFORALL(0, strlen(toAscii(value)), i, (stream + i ↦ toAscii(value)[i]))`
+- **groups/bal/baltzo/baltzo_timezoneutil.cpp**
+  - requires:
+    - `result != 0`
+  - ensures:
+    - `(result != 0) && (result->datetimeTz().utcDatetime() == (originalTime.datetimeTz().utcDatetime() + bdlt::IntervalConversionUtil::convertToDatetimeInterval(interval))) ⋆ (__out == convertUtcToLocalTime(result, originalTime.timeZoneId().c_str(), originalTime.datetimeTz().utcDatetime() + bdlt::IntervalConversionUtil::convertToDatetimeInterval(interval)))`
+- **groups/bal/baltzo/baltzo_timezoneutilimp.cpp**
+  - requires:
+    - `result != 0 && resultTimeZoneId != 0 && cache != 0`
+    - `start >= timeZone.beginTransitions() && start < timeZone.endTransitions()`
+    - `timeZone != 0 && timeZoneId != 0 && cache != 0`
+  - ensures:
+    - `(__out != timeZone.endTransitions() ==> __out->descriptor().dstInEffectFlag() == dstFlag) || (__out == timeZone.endTransitions())`
+    - `(__out == 0 ==> (result != 0)) && (__out != 0 ==> true)`
+    - `(__out == 0 ==> (timeZone != 0 && *timeZone != 0)) && (__out != 0 ==> *timeZone == 0)`
+- **groups/bal/baltzo/baltzo_windowstimezoneutil.cpp**
+  - requires:
+    - `result != 0 && windowsTimeZoneId != 0`
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> (*result ↦ ptr->d_value)) && (__out == -1 ==> true)`
+    - `(__out == true ==> bsl::strcmp(a.d_key, b.d_key) < 0) && (__out == false ==> bsl::strcmp(a.d_key, b.d_key) >= 0)`
+- **groups/bal/baltzo/baltzo_zoneinfo.cpp**
+  - requires:
+    - `!stream.bad()`
+    - `SEPFORALL(object.beginTransitions(), object.endTransitions(), it, *it ↦ _)`
+    - `true`
+  - ensures:
+    - `(__out == (lhs.utcOffsetInSeconds() < rhs.utcOffsetInSeconds())) || (lhs.utcOffsetInSeconds() == rhs.utcOffsetInSeconds() && __out == (lhs.description() < rhs.description())) || (lhs.utcOffsetInSeconds() == rhs.utcOffsetInSeconds() && lhs.description() == rhs.description() && __out == (lhs.dstInEffectFlag() < rhs.dstInEffectFlag()))`
+    - `(__out == true ==> SEPEXISTS(0, transitions.size(), i, transitions[i].descriptor() == descriptor)) && (__out == false ==> SEPFORALL(0, transitions.size(), i, transitions[i].descriptor() != descriptor))`
+    - `__out == stream && (stream ↦ _)`
+    - `__out == stream && SEPFORALL(object.beginTransitions(), object.endTransitions(), it, *it ↦ _)`
+- **groups/bal/baltzo/baltzo_zoneinfobinaryreader.cpp**
+  - requires:
+    - `address != 0 && SEPFORALL(0, 4, i, address + i ↦ _)`
+    - `buffer != 0 && 0 <= length && SEPFORALL(0, length, i, buffer + i ↦ _)`
+    - `true`
+  - ensures:
+    - `(__out == true ==> SEPFORALL(0, length, i, (buffer + i ↦ sep_v && bdlb::CharType::isPrint(sep_v)))) && (__out == false ==> SEPEXISTS(0, length, i, (buffer + i ↦ sep_v && !bdlb::CharType::isPrint(sep_v))))`
+    - `__out == BSLS_BYTEORDER_BE_U32_TO_HOST(*reinterpret_cast<const int*>(address))`
+    - `__out == readImpl(zoneinfoResult, &description, k_READ_NORMALIZED, stream)`
+- **groups/bal/baltzo/baltzo_zoneinfocache.cpp**
+  - requires:
+    - `rc != 0 && timeZoneId != 0`
+    - `timeZoneId != 0`
+  - ensures:
+    - `(__out != 0 ==> d_cache.find(timeZoneId) != d_cache.end() && __out == d_cache.find(timeZoneId)->second) && (__out == 0 ==> d_cache.find(timeZoneId) == d_cache.end())`
+    - `(__out == 0 ==> *rc != 0) && (__out != 0 ==> (*rc == 0 && (__out->identifier() ↦ timeZoneId)))`
+- **groups/bal/baltzo/baltzo_zoneinfoutil.cpp**
+  - requires:
+    - `resultTime != NULL && resultTransition != NULL && isWellFormed(timeZone) && EXISTS(0, timeZone.endTransitions(), it, it != timeZone.endTransitions())`
+  - ensures:
+    - `(__out == 0) || (__out == ErrorCode::k_OUT_OF_RANGE)`
+- **groups/bal/balxml/balxml_decoder.cpp**
+  - requires:
+    - `context != 0 && (context ↦ _ ⋆ d_reader ↦ _)`
+  - ensures:
+    - `(__out == BAEXML_SUCCESS || __out == BAEXML_FAILURE) && (context ↦ _ ⋆ d_reader ↦ _)`
+- **groups/bal/balxml/balxml_elementattribute.cpp**
+  - requires:
+    - `(d_prefix || !d_qualifiedName) || (!d_prefixStack && d_qualifiedName) || (d_prefixStack && d_qualifiedName)`
+  - ensures:
+    - `__out == d_prefix`
+- **groups/bal/balxml/balxml_encoder.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(options.encodingStyle() == balxml::EncodingStyle::COMPACT ==> __out == 0) && (options.encodingStyle() == balxml::EncodingStyle::PRETTY ==> __out == options.initialIndentLevel())`
+- **groups/bal/balxml/balxml_formatter.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(d_mode == rhs.d_mode`
+- **groups/bal/balxml/balxml_formatter_prettyimpl.cpp**
+  - requires:
+    - `state != 0`
+  - ensures:
+    - `(__out == stream) && (state->column() == 0`
+- **groups/bal/balxml/balxml_minireader.cpp**
+  - requires:
+    - `(error >= ErrorInfo::e_ERROR) ==> res_tmp == -1 && (error < ErrorInfo::e_ERROR) ==> res_tmp == 0`
+    - `d_scanPtr != nullptr && d_endPtr != nullptr && d_scanPtr <= d_endPtr`
+    - `true`
+    - `val < 0x110000U`
+  - ensures:
+    - `(__out == 0 ==> d_scanPtr == d_endPtr) && (__out != 0 ==> (*d_scanPtr ↦ __out))`
+    - `(error >= ErrorInfo::e_ERROR ==> __out == -1) && (error < ErrorInfo::e_ERROR ==> __out == 0)`
+    - `(s != nullptr ==> __out == s) && (s == nullptr ==> __out == "")`
+    - `(val >= 0x110000U ==> __out == 0) && (val < 0x110000U ==> __out > 0)`
+    - `__out == d_errorInfo`
+    - `__out == static_cast<char>(val)`
+- **groups/bal/balxml/balxml_namespaceregistry.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out != -1 ==> EXISTS(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri == predefinedNamespaces[i])) && (__out == -1 ==> FORALL(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri != predefinedNamespaces[i]))`
+- **groups/bal/balxml/balxml_prefixstack.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(EXISTS(0, d_numPrefixes, i, (d_prefixes[i].first == prefix) && (__out == d_prefixes[i].second))) || (FORALL(0, d_numPrefixes, i, (d_prefixes[i].first != prefix)) ==> (__out == lookupPredefinedPrefix(prefix).d_nsid))`
+    - `__out == nsId && (d_prefixes[d_numPrefixes - 1].first ↦ prefix ⋆ d_prefixes[d_numPrefixes - 1].second ↦ nsId) ⋆ d_numPrefixes == d_numPrefixes + 1`
+- **groups/bal/balxml/balxml_typesparserutil.cpp**
+  - requires:
+    - `input != NULL`
+    - `input != NULL && inputLength >= 0`
+    - `input != nullptr && result != nullptr && (inputLength == 1 || inputLength == 4 || inputLength == 5)`
+    - `inputLength > 0`
+    - `inputLength >= 0`
+    - `result != 0 && input != 0 && input[bsl::strlen(input)] == '\0'`
+  - ensures:
+    - `(__out == BAEXML_SUCCESS ==> ((*result == true && (input[0] == '1' || (inputLength == 4 && input[0] == 't' && input[1] == 'r' && input[2] == 'u' && input[3] == 'e'))) || (*result == false && (input[0] == '0' || (inputLength == 5 && input[0] == 'f' && input[1] == 'a' && input[2] == 'l' && input[3] == 's' && input[4] == 'e'))))) && (__out == BAEXML_FAILURE ==> *result == old_result)`
+    - `(__out == BAEXML_SUCCESS ==> (result != 0 && (result ↦ _))) && (__out == BAEXML_FAILURE ==> true)`
+    - `(__out == BAEXML_SUCCESS ==> consumed == inputLength && errno == 0) && (__out == BAEXML_FAILURE ==> consumed != inputLength || errno != 0 || inputLength == 0)`
+    - `(__out == BAEXML_SUCCESS ==> consumed == inputLength) && (__out == BAEXML_FAILURE ==> consumed != inputLength || inputLength == 0)`
+    - `(__out == BAEXML_SUCCESS) || (__out == BAEXML_FAILURE)`
+    - `(inputLength == 0 ==> __out == BAEXML_FAILURE) && (inputLength != 0 ==> (__out == BAEXML_SUCCESS || __out == BAEXML_FAILURE))`
+- **groups/bal/balxml/balxml_typesprintutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bal/balxml/balxml_utf8readerwrapper.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == 0 || __out != 0)`
+    - `(str != 0 ==> __out == str) && (str == 0 ==> __out == "")`
+    - `__out == d_errorInfo.source().get_allocator().mechanism()`
+- **groups/bal/balxml/balxml_util.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == u::extractNamespaceFromXsd_Impl(xsdSource, targetNamespace)`
+- **groups/bbl/bblb/bblb_schedulegenerationutil.cpp**
+  - requires:
+    - `(1 <= year && year <= 9999) && (1 <= month && month <= 12) && (1 <= day && day <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, month)) && (dayOfFeb == 0 || (1 <= dayOfFeb && dayOfFeb <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, 2)))`
+    - `denominator > 0`
+    - `u::k_MIN_SERIAL_MONTH <= exampleSerialMonth && exampleSerialMonth <= u::k_MAX_SERIAL_MONTH && earliestSerialMonth <= latestSerialMonth`
+  - ensures:
+    - `((numerator > 0 && numerator % denominator != 0) ==> __out == (numerator / denominator + 1)) && ((numerator <= 0 || numerator % denominator == 0) ==> __out == (numerator / denominator))`
+    - `(__out == bdlt::Date(year, month, __out.day())) && (1 <= __out.day() && __out.day() <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, month))`
+    - `(__out == e_OUT_OF_RANGE) ==> (startSerialMonthCandidate > u::k_MAX_SERIAL_MONTH || endSerialMonthCandidate < u::k_MIN_SERIAL_MONTH)`
+    - `(__out == e_VALID_RANGE ==> ((*startSerialMonth ↦ startSerialMonthCandidate) ⋆ (*endSerialMonth ↦ endSerialMonthCandidate))) && (__out == e_OUT_OF_RANGE ==> ((*startSerialMonth ↦ old_startSerialMonth) ⋆ (*endSerialMonth ↦ old_endSerialMonth)))`
+    - `(numerator < 0 && numerator % denominator != 0) ==> (__out == (numerator / denominator - 1)) && (!(numerator < 0 && numerator % denominator != 0)) ==> (__out == (numerator / denominator))`
+- **groups/bbl/bbldc/bbldc_basicactual360.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == (endDate - beginDate) / 360.0`
+- **groups/bbl/bbldc/bbldc_basicactual36525.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == (endDate - beginDate) / 365.25`
+- **groups/bbl/bbldc/bbldc_basicactual365fixed.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == (endDate - beginDate) / 365.0`
+- **groups/bbl/bbldc/bbldc_basicdaycountutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(convention == DayCountConvention::e_ACTUAL_360 || convention == DayCountConvention::e_ACTUAL_365_25 || convention == DayCountConvention::e_ACTUAL_365_FIXED || convention == DayCountConvention::e_ISDA_1_1 || convention == DayCountConvention::e_ISDA_30_360_EOM || convention == DayCountConvention::e_ISDA_ACTUAL_ACTUAL || convention == DayCountConvention::e_ISMA_30_360 || convention == DayCountConvention::e_NL_365 || convention == DayCountConvention::e_PSA_30_360_EOM || convention == DayCountConvention::e_SIA_30_360_EOM || convention == DayCountConvention::e_SIA_30_360_NEOM) ==> __out == numDays`
+- **groups/bbl/bbldc/bbldc_basicisdaactualactual.cpp**
+  - requires:
+    - `beginDate <= endDate`
+  - ensures:
+    - `__out == (yDiff * daysInBeginYear * daysInEndYear + beginYearDayDiff * daysInEndYear + endYearDayDiff * daysInBeginYear) / static_cast<double>(daysInBeginYear * daysInEndYear)`
+- **groups/bbl/bbldc/bbldc_basicisma30360.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == ((yEnd - yBegin) * 360 + (mEnd - mBegin) * 30 + (dEnd == 31 ? 30 : dEnd) - (dBegin == 31 ? 30 : dBegin))`
+    - `__out == computeDaysDiff(beginDate, endDate)`
+- **groups/bbl/bbldc/bbldc_basicnl365.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == ((y2 - y1) * 365 + (m2 - m1) * 31 - (s_daysInMonthCorrection[m2] - s_daysInMonthCorrection[m1]) + d2 - d1)`
+- **groups/bbl/bbldc/bbldc_basicpsa30360eom.cpp**
+  - requires:
+    - `bdlt::Date::isValidYearMonthDay(year, month, day)`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year))))) && (__out == false ==> !(month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year)))))`
+    - `(beginDate <= endDate ==> __out >= 0) && (beginDate > endDate ==> __out <= 0)`
+    - `__out == computeDaysDiff(beginDate, endDate)`
+    - `__out == lhs ==> lhs > rhs && __out == rhs ==> lhs <= rhs`
+- **groups/bbl/bbldc/bbldc_basicsia30360eom.cpp**
+  - requires:
+    - `bdlt::Date::isValidYearMonthDay(year, month, day)`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year))))) && (__out == false ==> !(month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year)))))`
+    - `(beginDate > endDate ==> __out <= 0) && (beginDate < endDate ==> __out >= 0) && (beginDate == endDate ==> __out == 0)`
+    - `__out == computeDaysDiff(beginDate, endDate)`
+- **groups/bbl/bbldc/bbldc_basicsia30360neom.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(beginDate > endDate ==> __out <= 0) && (beginDate < endDate ==> __out >= 0) && (beginDate == endDate ==> __out == 0)`
+    - `__out == computeDaysDiff(beginDate, endDate)`
+- **groups/bbl/bbldc/bbldc_calendardaycountutil.cpp**
+  - requires:
+    - `calendar.isInRange(beginDate) && calendar.isInRange(endDate)`
+  - ensures:
+    - `(convention == DayCountConvention::e_CALENDAR_BUS_252 ==> __out == bbldc::CalendarBus252::daysDiff(beginDate, endDate, calendar)) && (convention != DayCountConvention::e_CALENDAR_BUS_252 ==> __out == 0)`
+- **groups/bbl/bbldc/bbldc_daycountconvention.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == stream) && SEPFORALL(0, sizeof(toAscii(value)), i, stream + i ↦ toAscii(value)[i])`
+- **groups/bbl/bbldc/bbldc_perioddaycountutil.cpp**
+  - requires:
+    - `2 <= (periodDateEnd - periodDateBegin) && *periodDateBegin <= beginDate && beginDate <= *(periodDateEnd - 1) && *periodDateBegin <= endDate && endDate <= *(periodDateEnd - 1) && FORALL(periodDateBegin, periodDateEnd, i, *(i) <= *(i + 1))`
+    - `true`
+  - ensures:
+    - `(convention == DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == bbldc::PeriodIcmaActualActual::daysDiff(beginDate, endDate)) && (convention != DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == 0)`
+    - `(convention == DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == bbldc::PeriodIcmaActualActual::yearsDiff(beginDate, endDate, periodDateBegin, periodDateEnd, periodYearDiff)) && (convention != DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == 0.0)`
+- **groups/bbl/bbldc/bbldc_periodicmaactualactual.cpp**
+  - requires:
+    - `...`
+  - ensures:
+    - `(beginDate == endDate ==> __out == 0.0) && (beginDate != endDate ==> __out != 0.0)`
+- **groups/bbl/bbldc/bbldc_terminateddaycountutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(convention == DayCountConvention::e_ISDA_30_360_EOM ==> __out == bbldc::TerminatedIsda30360Eom::daysDiff(beginDate, endDate, terminationDate)) && (convention != DayCountConvention::e_ISDA_30_360_EOM ==> __out == 0)`
+- **groups/bbl/bbldc/bbldc_terminatedisda30360eom.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == ((beginDate <= endDate ? 1 : -1) * (((y2 - y1) * 360 + (m2 - m1) * 30 + d2) - d1))`
+- **groups/bdl/bdlat/bdlat_enumeratorinfo.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdlat/bdlat_selectioninfo.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdlb/bdlb_bigendian.cpp**
+  - requires:
+    - `!stream.bad()`
+  - ensures:
+    - `(__out == stream) && (!stream.bad()) && (stream ↦ _)`
+    - `__out == stream`
+- **groups/bdl/bdlb/bdlb_bitstringutil.cpp**
+  - requires:
+    - `0 <= numBits && numBits < 64`
+    - `level >= 0 && spacesPerLevel >= 0`
+    - `numBits + pos1 <= k_BITS_PER_UINT64 && numBits + pos2 <= k_BITS_PER_UINT64`
+    - `true`
+  - ensures:
+    - `(__out == (~0ULL << numBits)) && (0 <= numBits) && (numBits < 64)`
+    - `(__out == stream) && (spacesPerLevel >= 0) && SEPFORALL(0, level * spacesPerLevel, i, (stream + i ↦ ' '))`
+    - `(__out == true ==> (((word1 >> pos1) ^ (word2 >> pos2)) & BitMaskUtil::lt64(numBits)) != 0) && (__out == false ==> (((word1 >> pos1) ^ (word2 >> pos2)) & BitMaskUtil::lt64(numBits)) == 0)`
+    - `(__out == true ==> (lhs.d_hi > rhs.d_hi || (lhs.d_hi == rhs.d_hi && lhs.d_lo > rhs.d_lo))) && (__out == false ==> !(lhs.d_hi > rhs.d_hi || (lhs.d_hi == rhs.d_hi && lhs.d_lo > rhs.d_lo)))`
+    - `(__out.d_hi == (~d_hi + (d_lo & k_UNUSED_LO_MASK ? 1 : 0))`
+    - `(__out.d_hi == lhs.d_hi - rhs.d_hi - (lhs.d_lo < rhs.d_lo ? 1 : 0)) && (__out.d_lo == lhs.d_lo - rhs.d_lo + (lhs.d_lo < rhs.d_lo ? k_BITS_PER_UINT64 : 0))`
+    - `__out == ((1ULL << numBits) - 1)`
+    - `__out == static_cast<unsigned int>(value)`
+- **groups/bdl/bdlb/bdlb_caselessstringviewhash.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `true`
+- **groups/bdl/bdlb/bdlb_doublecompareutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(input >= 0.0 ==> __out == input) && (input < 0.0 ==> __out == -input)`
+- **groups/bdl/bdlb/bdlb_float.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(numberExp == 0 && (number & doubleManMask) != 0 ==> __out == bdlb::Float::k_SUBNORMAL) && (numberExp == 0 && (number & doubleManMask) == 0 ==> __out == bdlb::Float::k_ZERO) && (numberExp == doubleExpMask && (number & doubleManMask) != 0 ==> __out == bdlb::Float::k_NAN) && (numberExp == doubleExpMask && (number & doubleManMask) == 0 ==> __out == bdlb::Float::k_INFINITE) && (numberExp != 0 && numberExp != doubleExpMask ==> __out == bdlb::Float::k_NORMAL)`
+    - `(numberExp == 0 && (number & floatManMask) != 0 ==> __out == bdlb::Float::k_SUBNORMAL) && (numberExp == 0 && (number & floatManMask) == 0 ==> __out == bdlb::Float::k_ZERO) && (numberExp == floatExpMask && (number & floatManMask) != 0 ==> __out == bdlb::Float::k_NAN) && (numberExp == floatExpMask && (number & floatManMask) == 0 ==> __out == bdlb::Float::k_INFINITE) && (numberExp != 0 && numberExp != floatExpMask ==> __out == bdlb::Float::k_NORMAL)`
+    - `__out == *reinterpret_cast<DoubleRep_t*>(&number)`
+    - `__out == *reinterpret_cast<FloatRep_t*>(&number)`
+- **groups/bdl/bdlb/bdlb_guid.cpp**
+  - requires:
+    - `true`
+    - `x >= 0 && x <= 15`
+  - ensures:
+    - `__out == "0123456789abcdef"[x]`
+    - `__out == (bsl::memcmp(&lhs[0], &rhs[0], bdlb::Guid::k_GUID_NUM_BYTES) < 0)`
+- **groups/bdl/bdlb/bdlb_guidutil.cpp**
+  - requires:
+    - `hex != 0 && (c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F')`
+    - `true`
+  - ensures:
+    - `(__out == 0 && ((c >= '0' && c <= '9' && (hex ↦ c - '0')) || (c >= 'a' && c <= 'f' && (hex ↦ c - 'a' + 10)) || (c >= 'A' && c <= 'F' && (hex ↦ c - 'A' + 10)))) || (__out == -1 && (hex ↦ old_hex))`
+    - `true`
+- **groups/bdl/bdlb/bdlb_hashutil.cpp**
+  - requires:
+    - `(length >= 0) && (length == 0 || data != NULL)`
+  - ensures:
+    - `__out >= 0`
+- **groups/bdl/bdlb/bdlb_numericparseutil.cpp**
+  - requires:
+    - `!positiveNum.empty()`
+    - `(2 <= base && base <= 36) && (Ct::isDigit(character) || (Ct::isAlpha(character) && (Ct::toLower(character) - aShift < base)))`
+    - `stdlibInput.size() >= 2`
+    - `true`
+  - ensures:
+    - `(0 <= __out && __out < base) || __out == -1`
+    - `(__out == true ==> (stdlibInput.substr(0, 2) == "0x" || stdlibInput.substr(0, 2) == "0X")) && (__out == false ==> (stdlibInput.substr(0, 2) != "0x" && stdlibInput.substr(0, 2) != "0X"))`
+    - `(__out == true ==> bsl::isinf(number)) && (__out == false ==> !bsl::isinf(number))`
+    - `(positiveNum[0] == '+' ==> __out == positiveNum.substr(1)) && (positiveNum[0] != '+' ==> __out == positiveNum)`
+- **groups/bdl/bdlb/bdlb_print.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdlb/bdlb_randomdevice.cpp**
+  - requires:
+    - `(numBytes == 0) || (buffer != 0 && SEPFORALL(0, numBytes, i, (buffer + i ↦ _)))`
+  - ensures:
+    - `(numBytes == 0 ==> __out == 0) && (numBytes > 0 ==> SEPFORALL(0, numBytes, i, (buffer + i ↦ _)))`
+- **groups/bdl/bdlb/bdlb_string.cpp**
+  - requires:
+    - `lhsString != nullptr && rhsString != nullptr && SEPFORALL(0, strlen(lhsString), i, (lhsString + i ↦ _)) && SEPFORALL(0, strlen(rhsString), i, (rhsString + i ↦ _))`
+  - ensures:
+    - `(__out == true ==> SEPFORALL(0, strlen(lhsString), i, (bdlb::CharType::toLower(lhsString[i]) == bdlb::CharType::toLower(rhsString[i])))) && (__out == false ==> SEPEXISTS(0, strlen(lhsString), i, (bdlb::CharType::toLower(lhsString[i]) != bdlb::CharType::toLower(rhsString[i]))) || strlen(lhsString) != strlen(rhsString))`
+- **groups/bdl/bdlb/bdlb_stringrefutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(('A' <= ch && ch <= 'Z') ==> __out == (ch | 0x20)) && (!(('A' <= ch && ch <= 'Z')) ==> __out == ch)`
+    - `(('a' <= ch && ch <= 'z') ==> __out == (ch & ~0x20)) && (!(('a' <= ch && ch <= 'z')) ==> __out == ch)`
+- **groups/bdl/bdlb/bdlb_tokenizer.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `&__out == this`
+    - `(__out == true ==> SEPEXISTS(0, d_token_p - d_prevDelim_p, i, (d_prevDelim_p + i) ↦ sep_v && d_sharedData.inputType(sep_v) == SFT)) && (__out == false ==> SEPFORALL(0, d_token_p - d_prevDelim_p, i, (d_prevDelim_p + i) ↦ sep_v && d_sharedData.inputType(sep_v) != SFT))`
+    - `(this != &rhs ==> (d_sharedData_p == rhs.d_sharedData_p ⋆ d_cursor_p == rhs.d_cursor_p ⋆ d_token_p == rhs.d_token_p ⋆ d_postDelim_p == rhs.d_postDelim_p ⋆ d_end_p == rhs.d_end_p ⋆ d_endFlag == rhs.d_endFlag)) && (__out == *this)`
+- **groups/bdl/bdlbb/bdlbb_blob.cpp**
+  - requires:
+    - `rhs.d_buffer ↦ _ ⋆ rhs.d_size ↦ _`
+    - `stream ↦ _`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (lhs.d_buffers == rhs.d_buffers && lhs.d_totalSize == rhs.d_totalSize && lhs.d_dataLength == rhs.d_dataLength && lhs.d_dataIndex == rhs.d_dataIndex && lhs.d_preDataIndexLength == rhs.d_preDataIndexLength)) && (__out == false ==> !(lhs.d_buffers == rhs.d_buffers && lhs.d_totalSize == rhs.d_totalSize && lhs.d_dataLength == rhs.d_dataLength && lhs.d_dataIndex == rhs.d_dataIndex && lhs.d_preDataIndexLength == rhs.d_preDataIndexLength))`
+    - `(this->d_buffer ↦ rhs.d_buffer) ⋆ (this->d_size ↦ rhs.d_size)`
+    - `__out == 0`
+    - `__out == buffer.print(stream, 0, -1)`
+    - `__out == stream && (stream ↦ _)`
+- **groups/bdl/bdlbb/bdlbb_blobstreambuf.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(c == EOF ==> __out == traits_type::not_eof(c)) && (c != EOF ==> __out == c)`
+    - `__out == 0`
+    - `__out == traits_type::eof()`
+- **groups/bdl/bdlbb/bdlbb_blobutil.cpp**
+  - requires:
+    - `0 <= bufferIndex && bufferIndex < source.numDataBuffers() && 0 <= numBytes && numBytes <= source.totalSize() - source.sizeUpToBuffer(bufferIndex)`
+  - ensures:
+    - `SEPFORALL(0, numBytes, i, stream + i ↦ source.buffer(bufferIndex + i / source.buffer(bufferIndex).size()).data()[i % source.buffer(bufferIndex).size()])`
+- **groups/bdl/bdlbb/bdlbb_simpleblobbufferfactory.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == d_size`
+- **groups/bdl/bdlc/bdlc_bitarray.cpp**
+  - requires:
+    - `0 <= numBits && numBits < BitArray::k_BITS_PER_UINT64`
+  - ensures:
+    - `__out == ((static_cast<uint64_t>(1) << numBits) - 1)`
+- **groups/bdl/bdlc/bdlc_hashtable.cpp**
+  - requires:
+    - `hint != 0`
+  - ensures:
+    - `__out != 0 && (__out == *bsl::lower_bound(PRIME_NUMBERS, PRIME_NUMBERS + NUM_PRIME_NUMBERS, (0 < hint) ? hint : -hint) || __out == *(bsl::lower_bound(PRIME_NUMBERS, PRIME_NUMBERS + NUM_PRIME_NUMBERS, (0 < hint) ? hint : -hint) - 1))`
+- **groups/bdl/bdlc/bdlc_indexclerk.cpp**
+  - requires:
+    - `(unsigned int)index < (unsigned int)d_nextNewIndex`
+    - `true`
+  - ensures:
+    - `(__out == false ==> EXISTS(0, d_unusedStack.size(), i, d_unusedStack[i] == index)) && (__out == true ==> FORALL(0, d_unusedStack.size(), i, d_unusedStack[i] != index))`
+    - `(__out == false) ==> (indicesInvalid != 0 || indicesNotUnique & 0x2)`
+- **groups/bdl/bdlcc/bdlcc_fixedqueueindexmanager.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out >= 0) && (__out <= d_capacity)`
+    - `__out == ((encodedPushIndex & k_DISABLED_STATE_MASK) != 0)`
+    - `__out == ((generation << k_GENERATION_COUNT_SHIFT) | indexState)`
+    - `__out == (encodedPushIndex & ~k_DISABLED_STATE_MASK)`
+    - `__out == (encodedState >> k_GENERATION_COUNT_SHIFT)`
+    - `__out == ElementState(encodedState & k_ELEMENT_STATE_MASK)`
+- **groups/bdl/bdld/bdld_datum.cpp**
+  - requires:
+    - `stream.good()`
+    - `stream.good() && (stream ↦ _)`
+    - `true`
+  - ensures:
+    - `(__out != 0 ==> findElementBinary(key, *this) == __out || findElementLinear(key, *this) == __out) && (__out == 0 ==> findElementBinary(key, *this) == nullptr && findElementLinear(key, *this) == nullptr)`
+    - `(__out == stream) && (__out ↦ _)`
+    - `(stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == stream && (__out << bsl::flush)))`
+    - `POST(
+    (__out == true) == 
+    (lhs.type() == rhs.type() && 
+     (
+         (lhs.type() == Datum::e_DOUBLE && lhs.theDouble() == rhs.theDouble()) ||
+         (lhs.type() == Datum::e_STRING && lhs.theString() == rhs.theString()) ||
+         (lhs.type() == Datum::e_INTEGER && lhs.theInteger() == rhs.theInteger()) ||
+         (lhs.type() == Datum::e_BOOLEAN && lhs.theBoolean() == rhs.theBoolean()) ||
+         (lhs.type() == Datum::e_NIL) ||
+         (lhs.type() == Datum::e_ERROR && lhs.theError() == rhs.theError()) ||
+         (lhs.type() == Datum::e_DATE && lhs.theDate() == rhs.theDate()) ||
+         (lhs.type() == Datum::e_TIME && lhs.theTime() == rhs.theTime()) ||
+         (lhs.type() == Datum::e_DATETIME && lhs.theDatetime() == rhs.theDatetime()) ||
+         (lhs.type() == Datum::e_DATETIME_INTERVAL && lhs.theDatetimeInterval() == rhs.theDatetimeInterval()) ||
+         (lhs.type() == Datum::e_INTEGER64 && lhs.theInteger64() == rhs.theInteger64()) ||
+         (lhs.type() == Datum::e_BINARY && lhs.theBinary() == rhs.theBinary()) ||
+         (lhs.type() == Datum::e_DECIMAL64 && lhs.theDecimal64() == rhs.theDecimal64()) ||
+         (lhs.type() == Datum::e_ARRAY && lhs.theArray() == rhs.theArray()) ||`
+    - `__out == stream && (stream ↦ _)`
+    - `true`
+- **groups/bdl/bdld/bdld_datumarraybuilder.cpp**
+  - requires:
+    - `length >= 0 && length < bsl::numeric_limits<DatumArrayBuilder::SizeType>::max() / 2 && capacity >= 0`
+  - ensures:
+    - `__out >= length && (capacity == 0 ? __out == 1 : __out >= capacity && __out % capacity == 0)`
+- **groups/bdl/bdld/bdld_datumbinaryref.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == (stream << bsl::flush) ⋆ stream ↦ _))`
+- **groups/bdl/bdld/bdld_datumerror.cpp**
+  - requires:
+    - `stream ↦ _ && !stream.bad()`
+  - ensures:
+    - `(__out == stream) && (stream ↦ _)`
+- **groups/bdl/bdld/bdld_datumintmapbuilder.cpp**
+  - requires:
+    - `size >= 0 && (capacity == 0 || (capacity > 0 && size < bsl::numeric_limits<DatumIntMapBuilder::SizeType>::max() / 2))`
+    - `true`
+  - ensures:
+    - `(__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())`
+    - `__out >= size && (capacity == 0 ? __out == 1 : __out >= capacity && __out % capacity == 0)`
+- **groups/bdl/bdld/bdld_datummaker.cpp**
+  - requires:
+    - `size >= 0 && (size == 0 || FORALL(0, size, i, elements[i].isValid()))`
+  - ensures:
+    - `true`
+- **groups/bdl/bdld/bdld_datummapbuilder.cpp**
+  - requires:
+    - `size < bsl::numeric_limits<DatumMapBuilder::SizeType>::max() / 2 && capacity >= 0`
+    - `true`
+  - ensures:
+    - `(__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())`
+    - `__out >= size && (capacity == 0 ? __out == 1 : __out >= capacity && __out % capacity == 0)`
+- **groups/bdl/bdld/bdld_datummapowningkeysbuilder.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())`
+    - `__out >= size && (capacity == 0 ==> EXISTS(0, 31, k, __out == (1 << k))) && (capacity != 0 ==> EXISTS(0, 31, k, __out == (capacity << k)))`
+- **groups/bdl/bdld/bdld_datumudt.cpp**
+  - requires:
+    - `!stream.bad() && stream.rdbuf()->in_sync()`
+  - ensures:
+    - `__out == &stream && !stream.bad() && stream.rdbuf()->in_sync()`
+- **groups/bdl/bdlde/bdlde_base64alphabet.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdlde/bdlde_base64decoderoptions.cpp**
+  - requires:
+    - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (lhs.ignoreMode() == rhs.ignoreMode() && lhs.alphabet() == rhs.alphabet() && lhs.isPadded() == rhs.isPadded())) && (__out == false ==> !(lhs.ignoreMode() == rhs.ignoreMode() && lhs.alphabet() == rhs.alphabet() && lhs.isPadded() == rhs.isPadded()))`
+    - `__out == stream && (__out ↦ _)`
+- **groups/bdl/bdlde/bdlde_base64encoderoptions.cpp**
+  - requires:
+    - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
+    - `true`
+  - ensures:
+    - `(__out == true) ==> (lhs.alphabet() == rhs.alphabet() && lhs.maxLineLength() == rhs.maxLineLength() && lhs.isPadded() == rhs.isPadded()) && (__out == false) ==> !(lhs.alphabet() == rhs.alphabet() && lhs.maxLineLength() == rhs.maxLineLength() && lhs.isPadded() == rhs.isPadded())`
+    - `__out == stream && (__out ↦ _)`
+- **groups/bdl/bdlde/bdlde_base64ignoremode.cpp**
+  - requires:
+    - `stream ↦ _ && !stream.bad()`
+    - `true`
+  - ensures:
+    - `__out == stream`
+    - `__out == stream && (stream ↦ _)`
+- **groups/bdl/bdlde/bdlde_byteorder.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == stream ⋆ SEPFORALL(0, sizeof(ByteOrder::toAscii(value)), i, stream + i ↦ ByteOrder::toAscii(value)[i])))`
+- **groups/bdl/bdlde/bdlde_charconvertstatus.cpp**
+  - requires:
+    - `stream.bad() ==> true && !stream.bad() ==> (stream ↦ _)`
+  - ensures:
+    - `(stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == stream && (stream ↦ _)))`
+- **groups/bdl/bdlde/bdlde_charconvertutf32.cpp**
+  - requires:
+    - `SEPFORALL(0, 3, i, octBuf + i ↦ _)`
+    - `SEPFORALL(0, 4, i, octBuf + i ↦ _)`
+    - `SEPFORALL(0, n, i, (octBuf + i ↦ sep_v))`
+    - `octBuf ↦ _ ⋆ (octBuf + 1) ↦ _`
+    - `position != nullptr`
+    - `position <= d_end`
+    - `true`
+  - ensures:
+    - `(__out == ((uc & (~ (unsigned int) 0 << (k_THREE_OCT_CONT_WID + 2 * k_CONTINUE_CONT_WID))) == 0))`
+    - `(__out == 0 ==> !isContinuation(octBuf[0])) && (__out > 0 ==> (SEPFORALL(0, __out, i, (octBuf + i ↦ sep_v) && isContinuation(sep_v)) && (__out == n || !isContinuation(octBuf[__out]))))`
+    - `(__out == false ==> position < d_end) && (__out == true ==> position == d_end)`
+    - `(__out == false ==> position < d_end_p) && (__out == true ==> position >= d_end_p)`
+    - `(__out == true ==> (*position ↦ 0)) && (__out == false ==> (*position ↦ sep_v && sep_v != 0))`
+    - `(__out == true ==> (oct & k_CONTINUE_MASK) == k_CONTINUE_TAG) && (__out == false ==> (oct & k_CONTINUE_MASK) != k_CONTINUE_TAG)`
+    - `(__out == true ==> (oct & k_THREE_OCTET_MASK) == k_THREE_OCTET_TAG) && (__out == false ==> (oct & k_THREE_OCTET_MASK) != k_THREE_OCTET_TAG)`
+    - `(__out == true ==> (oct & k_TWO_OCTET_MASK) == k_TWO_OCTET_TAG) && (__out == false ==> (oct & k_TWO_OCTET_MASK) != k_TWO_OCTET_TAG)`
+    - `(__out == true ==> (uc >= 0xd800 && uc < 0xe000)) && (__out == false ==> !(uc >= 0xd800 && uc < 0xe000))`
+    - `(__out == true ==> d_capacity < rhs) && (__out == false ==> d_capacity >= rhs)`
+    - `(__out == true ==> d_capacity >= rhs) && (__out == false ==> d_capacity < rhs)`
+    - `(__out == true ==> uc > 0x10ffff) && (__out == false ==> uc <= 0x10ffff)`
+    - `(__out == true) ==> ((oct & k_FOUR_OCTET_MASK) == k_FOUR_OCTET_TAG) && (__out == false) ==> ((oct & k_FOUR_OCTET_MASK) != k_FOUR_OCTET_TAG)`
+    - `(__out == true) || (__out == false)`
+    - `(__out ==> (uc & (~0 << (k_TWO_OCT_CONT_WID + k_CONTINUE_CONT_WID))) == 0) && (!__out ==> (uc & (~0 << (k_TWO_OCT_CONT_WID + k_CONTINUE_CONT_WID))) != 0)`
+    - `__out == !(oct & k_ONE_OCTET_MASK)`
+    - `__out == ((octBuf[1] & ~k_CONTINUE_MASK) | ((octBuf[0] & ~k_TWO_OCTET_MASK) << k_CONTINUE_CONT_WID))`
+    - `__out == ((octBuf[2] & ~k_CONTINUE_MASK) | ((octBuf[1] & ~k_CONTINUE_MASK) << k_CONTINUE_CONT_WID) | ((octBuf[0] & ~k_THREE_OCTET_MASK) << 2 * k_CONTINUE_CONT_WID))`
+    - `__out == ((octBuf[3] & ~k_CONTINUE_MASK) | ((octBuf[2] & ~k_CONTINUE_MASK) << k_CONTINUE_CONT_WID) | ((octBuf[1] & ~k_CONTINUE_MASK) << 2 * k_CONTINUE_CONT_WID) | ((octBuf[0] & ~k_FOUR_OCTET_MASK) << 3 * k_CONTINUE_CONT_WID))`
+    - `__out == ((uc & (~ (unsigned int) 0 << k_ONE_OCT_CONT_WID)) == 0)`
+    - `__out == false`
+    - `__out == reinterpret_cast<OctetType*>(ptr)`
+    - `__out == reinterpret_cast<const OctetType*>(ptr)`
+    - `__out == true`
+    - `__out >= input`
+- **groups/bdl/bdlde/bdlde_crc32.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `SEPFORALL(0, 11, i, stream + i ↦ array[i])`
+- **groups/bdl/bdlde/bdlde_crc32c.cpp**
+  - requires:
+    - `(data == 0 && length == 0) || (data != 0 && SEPFORALL(0, length, i, data + i ↦ _)) && length >= 0 && crc >= 0`
+    - `length == 0 || data != NULL`
+  - ensures:
+    - `__out == ~crc`
+    - `true`
+- **groups/bdl/bdlde/bdlde_crc64.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `SEPFORALL(0, 18, i, (stream + i ↦ out[i]))`
+- **groups/bdl/bdlde/bdlde_hexdecoder.cpp**
+  - requires:
+    - `(d_state == e_ERROR_STATE || d_firstDigit) ==> res_tmp == -1 && (!d_firstDigit) ==> res_tmp == 0`
+  - ensures:
+    - `(__out == -1 ==> (d_state == e_ERROR_STATE || d_firstDigit)) && (__out == 0 ==> (d_state == e_DONE_STATE && !d_firstDigit))`
+- **groups/bdl/bdlde/bdlde_md5.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == (lhs.d_length == rhs.d_length && 0 == bsl::memcmp(lhs.d_state, rhs.d_state, sizeof lhs.d_state) && 0 == bsl::memcmp(lhs.d_buffer, rhs.d_buffer, (sizeof *lhs.d_buffer) * getLengthInUse(lhs.d_length))))`
+    - `__out == (length & 0x3f)`
+- **groups/bdl/bdlde/bdlde_quotedprintabledecoder.cpp**
+  - requires:
+    - `out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL && maxNumOut >= 0`
+  - ensures:
+    - `(__out == -1 || __out == 0) && (__out == -1 ==> (d_state == e_ERROR_STATE || d_state == e_DONE_STATE)) && (__out == 0 ==> (d_state == e_INPUT_STATE || d_state == e_SAW_WS_STATE || d_state == e_SAW_EQUAL_STATE || d_state == e_NEED_HEX_STATE || d_state == e_NEED_SOFT_LF_STATE || d_state == e_NEED_HARD_LF_STATE))`
+- **groups/bdl/bdlde/bdlde_quotedprintableencoder.cpp**
+  - requires:
+    - `out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL && maxNumOut >= 0`
+  - ensures:
+    - `(maxNumOut == 0 ==> __out == numOutputPending()) && (*numOut >= 0) && (*numIn >= 0)`
+- **groups/bdl/bdlde/bdlde_sha1.cpp**
+  - requires:
+    - `0 <= shift && shift < (sizeof(value) * CHAR_BIT)`
+    - ````cpp
+PRE(lhs.d_totalSize >= 0 && rhs.d_totalSize >= 0 &&
+    lhs.d_bufferSize >= 0 && rhs.d_bufferSize >= 0 &&
+    lhs.d_bufferSize == rhs.d_bufferSize &&
+    SEPFORALL(0, lhs.d_bufferSize, i, lhs.d_buffer + i ↦ _ ⋆ rhs.d_buffer + i ↦ _) &&
+    SEPFORALL(0, 5, i, bsl::begin(lhs.d_state) + i ↦ _ ⋆ bsl::begin(rhs.d_state) + i ↦ _))
+```
+
+This precondition ensures that:
+- The `d_totalSize` and `d_bufferSize` fields are non-negative.
+- The `d_bufferSize` fields of `lhs` and `rhs` are equal.
+- The `d_buffer` arrays of `lhs` and `rhs` are properly allocated and of the same size.
+- The `d_state` arrays of `lhs` and `rhs` are properly allocated and of the same size (assuming `d_state` is an array of`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && bsl::equal(lhs.d_buffer, lhs.d_buffer + lhs.d_bufferSize, rhs.d_buffer) && bsl::equal(bsl::begin(lhs.d_state), bsl::end(lhs.d_state), bsl::begin(rhs.d_state)))) && (__out == false ==> !(lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && bsl::equal(lhs.d_buffer, lhs.d_buffer + lhs.d_bufferSize, rhs.d_buffer) && bsl::equal(bsl::begin(lhs.d_state), bsl::end(lhs.d_state), bsl::begin(rhs.d_state))))`
+    - `(index <= 19 ==> __out == bitwiseConditional(x, y, z)) && (index >= 40 && index <= 59 ==> __out == bitwiseMajority(x, y, z)) && ((index > 19 && index < 40) || (index > 59) ==> __out == (x ^ y ^ z))`
+    - `__out == ((condition & (x ^ y)) ^ y)`
+    - `__out == ((value << shift) | (value >> ((sizeof(value) * CHAR_BIT) - shift)))`
+    - `__out == ((x & y) | ((x | y) & z))`
+    - `true`
+- **groups/bdl/bdlde/bdlde_sha2.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == true ==> (lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && SEPFORALL(0, lhs.d_bufferSize, i, (lhs.d_buffer + i ↦ sep_v) && (rhs.d_buffer + i ↦ sep_v)) && SEPFORALL(0, 8, i, (lhs.d_state + i ↦ sep_v) && (rhs.d_state + i ↦ sep_v)))) && (__out == false ==> (lhs.d_totalSize != rhs.d_totalSize || lhs.d_bufferSize != rhs.d_bufferSize || SEPEXISTS(0, lhs.d_bufferSize, i, (lhs.d_buffer + i ↦ sep_v1) && (rhs.d_buffer + i ↦ sep_v2) && sep_v1 != sep_v2) || SEPEXISTS(0, 8, i, (lhs.d_state + i ↦ sep_v1) && (rhs.d_state + i ↦ sep_v2) && sep_v1 != sep_v2)))`
+    - `__out == (rotateRight(value, 1) ^ rotateRight(value, 8) ^ (value >> 7))`
+    - `__out == (rotateRight(value, 14) ^ rotateRight(value, 18) ^ rotateRight(value, 41))`
+    - `__out == (rotateRight(value, 17) ^ rotateRight(value, 19) ^ (value >> 10))`
+    - `__out == (rotateRight(value, 19) ^ rotateRight(value, 61) ^ (value >> 6))`
+    - `__out == (rotateRight(value, 2) ^ rotateRight(value, 13) ^ rotateRight(value, 22))`
+    - `__out == (rotateRight(value, 28) ^ rotateRight(value, 34) ^ rotateRight(value, 39))`
+    - `__out == (rotateRight(value, 6) ^ rotateRight(value, 11) ^ rotateRight(value, 25))`
+    - `__out == (rotateRight(value, 7) ^ rotateRight(value, 18) ^ (value >> 3))`
+- **groups/bdl/bdlde/bdlde_utf8checkinginstreambufwrapper.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(errorStatus == 0 ==> __out == "NO_ERROR") && (errorStatus == k_SEEK_FAIL ==> __out == "SEEK_FAIL") && (errorStatus != 0 && errorStatus != k_SEEK_FAIL ==> __out == Utf8Util::toAscii(errorStatus))`
+    - `__out == -1 && d_offset == 0 && d_errorStatus == k_SEEK_FAIL && d_bufEndStatus == 0 && d_putBackMode == false`
+    - `__out == traits_type::eof()`
+- **groups/bdl/bdlde/bdlde_utf8util.cpp**
+  - requires:
+    - `(pc ↦ _ ⋆ (pc + 1) ↦ _)`
+    - `SEPFORALL(0, 4, i, (pc + i) ↦ _)`
+    - `input.length() >= 1`
+    - `invalidString != nullptr && (string != nullptr || length == 0) && length >= 0`
+    - `invalidString != nullptr && string != nullptr`
+    - `pc ↦ _ ⋆ (pc + 1) ↦ _ ⋆ (pc + 2) ↦ _`
+    - `true`
+  - ensures:
+    - `(__out >= 0 ==> __out == count) && (__out < 0 ==> (*invalidString != 0 && *invalidString == string))`
+    - `(__out >= 0) || (__out < 0 && *invalidString != nullptr)`
+    - `(__out >= 1) && (__out <= input.length())`
+    - `(character & k_ONEBYTEHEAD_TEST == k_ONEBYTEHEAD_RES ==> __out == 1) && (character & k_TWOBYTEHEAD_TEST == k_TWOBYTEHEAD_RES ==> __out == 2) && (character & k_THREEBYTEHEAD_TEST == k_THREEBYTEHEAD_RES ==> __out == 3) && ((character & k_ONEBYTEHEAD_TEST != k_ONEBYTEHEAD_RES && character & k_TWOBYTEHEAD_TEST != k_TWOBYTEHEAD_RES && character & k_THREEBYTEHEAD_TEST != k_THREEBYTEHEAD_RES) ==> __out == 4)`
+    - `__out == (((k_SURROGATE_MASK & value) == k_MIN_SURROGATE))`
+    - `__out == ((*pc & 0x1f) << 6) | (pc[1] & k_CONT_VALUE_MASK)`
+    - `__out == ((*pc & 0x7) << 18) | ((pc[1] & k_CONT_VALUE_MASK) << 12) | ((pc[2] & k_CONT_VALUE_MASK) << 6) | (pc[3] & k_CONT_VALUE_MASK)`
+    - `__out == ((*pc & 0xf) << 12) | ((pc[1] & k_CONT_VALUE_MASK) << 6) | (pc[2] & k_CONT_VALUE_MASK)`
+    - `__out == (0x80 != (value & 0xc0))`
+- **groups/bdl/bdldfp/bdldfp_decimal.cpp**
+  - requires:
+    - `!stream.bad()`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (x.value().d_raw & k_SIGN_MASK != 0)) && (__out == false ==> (x.value().d_raw & k_SIGN_MASK == 0))`
+    - `(__out == true ==> (x.value().d_raw.w[PlatformIndex()] & k_SIGN_MASK != 0)) && (__out == false ==> (x.value().d_raw.w[PlatformIndex()] & k_SIGN_MASK == 0))`
+    - `__out == stream`
+- **groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp**
+  - requires:
+    - `low <= high`
+    - `true`
+  - ensures:
+    - `(value < 1 ==> __out == low) && (value > high ==> __out == high) && ((value >= 1 && value <= high) ==> __out == value)`
+    - `__out == static_cast<unsigned char*>(buffer) + count`
+- **groups/bdl/bdldfp/bdldfp_decimalimputil.cpp**
+  - requires:
+    - `classification == static_cast<int>(class_types::signalingNaN) || classification == static_cast<int>(class_types::quietNaN)`
+    - `true`
+  - ensures:
+    - `(classification == static_cast<int>(class_types::signalingNaN) || classification == static_cast<int>(class_types::quietNaN)`
+    - `__out >= 0 && __out < 10`
+- **groups/bdl/bdljsn/bdljsn_error.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdljsn/bdljsn_jsontestsuiteutil.cpp**
+  - requires:
+    - `index < s_numData`
+    - `true`
+  - ensures:
+    - `__out != 0 && (__out == &s_data[index] && (index == 68 ==> (__out->d_JSON_p ↦ u::leftBrackets100000 ⋆ __out->d_length ↦ u::lenLeftBrackets100000)))`
+    - `__out != 0 && SEPFORALL(0, 100000, i, (__out + i ↦ '['))`
+    - `__out != 0 && SEPFORALL(0, 50000 * lenOpenArrayObjectSubsequence + 1, i, (__out + i ↦ openArrayObject50000[i]))`
+- **groups/bdl/bdljsn/bdljsn_jsonutil.cpp**
+  - requires:
+    - `d_it != d_end`
+    - `d_it != nullptr && *d_it != nullptr`
+    - `lhs->first ↦ _ ⋆ rhs->first ↦ _`
+    - `result != 0 && error != 0 && tokenizer != 0`
+    - `tokenizer != 0 && tokenizer->tokenType() == Tokenizer::e_START_ARRAY && result != 0 && error != 0 && maxNestedDepth >= 0`
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> (result != 0 && tokenizer->tokenType() == Tokenizer::e_END_ARRAY)) && (__out != 0 ==> error != 0)`
+    - `(__out == 0 ==> (result != 0)) && (__out != 0 ==> (error != 0 && (error->message() ↦ _)))`
+    - `(__out == true ==> d_it != d_end) && (__out == false ==> d_it == d_end)`
+    - `(__out == true ==> d_it == d_begin) && (__out == false ==> d_it != d_begin)`
+    - `(__out == true ==> d_it == d_sortedMembers.begin()) && (__out == false ==> d_it != d_sortedMembers.begin())`
+    - `(__out == true ==> lhs->first < rhs->first) && (__out == false ==> lhs->first >= rhs->first)`
+    - `__out == (d_it != d_end)`
+    - `__out == (d_it != d_sortedMembers.end())`
+    - `__out == **d_it`
+    - `__out == *d_it`
+    - `__out == 0 || __out != 0`
+    - `true`
+- **groups/bdl/bdljsn/bdljsn_location.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdljsn/bdljsn_numberutil.cpp**
+  - requires:
+    - `begin <= end`
+    - `true`
+  - ensures:
+    - `(__out == end) || (!bdlb::CharType::isDigit(*__out))`
+    - `(lhs.d_isExpNegative == rhs.d_isExpNegative && lhs.d_significantDigits == rhs.d_significantDigits && lhs.d_exponent == rhs.d_exponent) ==> __out == true && (!(lhs.d_isExpNegative == rhs.d_isExpNegative && lhs.d_significantDigits == rhs.d_significantDigits) || lhs.d_exponent != rhs.d_exponent) ==> __out == false`
+- **groups/bdl/bdljsn/bdljsn_readoptions.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `d_allowTrailingText ↦ s_DEFAULT_INITIALIZER_ALLOW_TRAILING_TEXT ⋆ d_maxNestedDepth ↦ s_DEFAULT_INITIALIZER_MAX_NESTED_DEPTH`
+- **groups/bdl/bdljsn/bdljsn_stringutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == u::readUnquotedStringImp(value, string, flags)`
+- **groups/bdl/bdljsn/bdljsn_tokenizer.cpp**
+  - requires:
+    - `d_streambuf_p != nullptr && d_tokenType != e_ERROR`
+    - `true`
+  - ensures:
+    - `(__out == -1 ==> d_tokenType == e_ERROR) && (__out == 0 ==> d_tokenType != e_ERROR)`
+    - `(__out == 0 ==> (d_tokenType == e_ELEMENT_NAME || d_tokenType == e_ELEMENT_VALUE) && (d_valueBegin != d_valueEnd) && (*data ↦ bsl::string_view(d_stringBuffer).substr(d_valueBegin, d_valueEnd - d_valueBegin))) && (__out == -1 ==> !(d_tokenType == e_ELEMENT_NAME || d_tokenType == e_ELEMENT_VALUE) || (d_valueBegin == d_valueEnd))`
+    - `(__out == 0 ==> numRead != 0) && (__out == -1 ==> numRead == 0)`
+- **groups/bdl/bdljsn/bdljsn_writeoptions.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `d_initialIndentLevel ↦ s_DEFAULT_INITIALIZER_INITIAL_INDENT_LEVEL ⋆ d_sortMembers ↦ s_DEFAULT_INITIALIZER_SORT_MEMBERS ⋆ d_escapeForwardSlash ↦ s_DEFAULT_INITIALIZER_ESCAPE_FORWARD_SLASH ⋆ d_spacesPerLevel ↦ s_DEFAULT_INITIALIZER_SPACES_PER_LEVEL ⋆ d_style ↦ s_DEFAULT_INITIALIZER_STYLE`
+- **groups/bdl/bdlma/bdlma_aligningallocator.cpp**
+  - requires:
+    - `size >= 0`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 && (reinterpret_cast<bsls::Types::size_type>(__out) & d_mask) == 0 && (__out ↦ _)))`
+- **groups/bdl/bdlma/bdlma_blocklist.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)`
+    - `__out == ((size + sizeOfBlock - 1) & ~(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))`
+- **groups/bdl/bdlma/bdlma_buffermanager.cpp**
+  - requires:
+    - `address != NULL && size > 0`
+  - ensures:
+    - `__out == size || __out > size`
+- **groups/bdl/bdlma/bdlma_concurrentallocatoradapter.cpp**
+  - requires:
+    - `numBytes >= 0`
+  - ensures:
+    - `__out == 0 || (__out != 0 && (__out ↦ _))`
+- **groups/bdl/bdlma/bdlma_concurrentfixedpool.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == 0) || (__out != 0)`
+- **groups/bdl/bdlma/bdlma_concurrentmultipool.cpp**
+  - requires:
+    - `size >= 0`
+    - `true`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ ((__out - 1) ↦ sep_v ⋆ (sep_v.d_header.d_poolIdx == findPool(size) || sep_v.d_header.d_poolIdx == -1))))`
+    - `__out == 31 - bdlb::BitUtil::numLeadingUnsetBits(static_cast<bsl::uint32_t>(((size + k_MIN_BLOCK_SIZE - 1) >> 3) * 2 - 1))`
+- **groups/bdl/bdlma/bdlma_concurrentmultipoolallocator.cpp**
+  - requires:
+    - `size >= 0`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))`
+- **groups/bdl/bdlma/bdlma_concurrentpool.cpp**
+  - requires:
+    - `d_freeList != 0`
+    - `true`
+    - `y > 0`
+  - ensures:
+    - `(__out % y == 0) && (__out >= x)`
+    - `__out != 0`
+    - `__out == roundUp(bsl::max(blockSize + HEADER_LENGTH, MINIMUM_LENGTH), bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT)`
+    - `__out == static_cast<LLink *>(static_cast<void *>(address))`
+- **groups/bdl/bdlma/bdlma_concurrentpoolallocator.cpp**
+  - requires:
+    - `size >= 0`
+    - `true`
+  - ensures:
+    - `(__out % BloombergLP::bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT) == 0`
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)`
+- **groups/bdl/bdlma/bdlma_countingallocator.cpp**
+  - requires:
+    - `size >= 0`
+    - `true`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)`
+    - `__out == stream`
+- **groups/bdl/bdlma/bdlma_guardingallocator.cpp**
+  - requires:
+    - `address != 0 && pageSize == getSystemPageSize()`
+    - `size > 0`
+    - `size >= 0`
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> (address ↦ _)) && (__out != 0 ==> (address ↦ _))`
+    - `(__out == 0 ==> size <= 0) && (__out != 0 ==> SEPFORALL(0, size, i, (__out + i) ↦ _))`
+    - `(__out == 0 ==> size == 0) && (__out != 0 ==> (__out ↦ _ ⋆ (__out + size) ↦ _))`
+    - `__out == pageSize.loadRelaxed()`
+    - `__out == static_cast<AfterUserBlockDeallocationData*>(static_cast<void*>(static_cast<char*>(address) - OFFSET * 2))`
+    - `true`
+- **groups/bdl/bdlma/bdlma_infrequentdeleteblocklist.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ d_head_p->d_next_p ↦ old_d_head_p ⋆ d_head_p ↦ _))`
+    - `__out == ((size + sizeOfBlock - 1) & ~static_cast<bsls::Types::size_type>(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))`
+- **groups/bdl/bdlma/bdlma_multipool.cpp**
+  - requires:
+    - `size <= d_maxBlockSize`
+    - `size >= 0`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)`
+    - `__out == (31 - bdlb::BitUtil::numLeadingUnsetBits(static_cast<bsl::uint32_t>(((size + k_MIN_BLOCK_SIZE - 1) >> 3) * 2 - 1)))`
+- **groups/bdl/bdlma/bdlma_pool.cpp**
+  - requires:
+    - `1 <= y`
+  - ensures:
+    - `(__out % y == 0) && (__out >= x) && (__out - y < x || __out - y % y != 0)`
+- **groups/bdl/bdlma/bdlma_sequentialpool.cpp**
+  - requires:
+    - `size >= 0`
+    - `true`
+  - ensures:
+    - `(__out != 0 ==> (__out ↦ _)) && (__out == 0 ==> size == 0)`
+    - `__out == ((size + sizeOfBlock - 1) & ~(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))`
+    - `__out == ((static_cast<uint64_t>(-1) << k_NUM_GEOMETRIC_BIN) | (bdlb::BitUtil::roundUpToBinaryPower(static_cast<uint64_t>(initialSize)) - 1))`
+- **groups/bdl/bdlmt/bdlmt_eventscheduler.cpp**
+  - requires:
+    - `amount > 0`
+    - `handle != nullptr && ((*handle == 0) || ((*handle != 0) && (*(const Event **)handle != 0)))`
+    - `true`
+  - ensures:
+    - `((*handle == 0) ==> (__out == EventQueue::e_INVALID)) && ((*handle != 0) ==> (__out != EventQueue::e_INVALID))`
+    - `__out == 0`
+    - `__out == d_currentTime`
+    - `__out == d_currentTime && d_currentTime == amount + old_d_currentTime`
+    - `__out == d_data_p->currentTime()`
+    - `__out == d_running`
+    - `true`
+- **groups/bdl/bdlmt/bdlmt_fixedthreadpool.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == 0) || (__out == -1)`
+- **groups/bdl/bdlmt/bdlmt_multiprioritythreadpool.cpp**
+  - requires:
+    - `(unsigned) priority < (unsigned) d_queue.numPriorities()`
+    - `true`
+  - ensures:
+    - `__out == d_queue.isEnabled()`
+    - `__out == d_queue.pushBack(job, priority)`
+- **groups/bdl/bdlmt/bdlmt_multiqueuethreadpool.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == d_nextId - 1 ⋆ d_queueRegistry[__out] ↦ _`
+- **groups/bdl/bdlmt/bdlmt_threadpool.cpp**
+  - requires:
+    - `aThis != 0`
+    - `true`
+  - ensures:
+    - `__out == 0`
+    - `__out == d_numActiveThreads`
+- **groups/bdl/bdlmt/bdlmt_throttle.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(numActions <= 0 || d_maxSimultaneousActions < numActions || d_nanosecondsPerAction == k_ALLOW_NONE) ==> __out == -1 && (numActions > 0 && d_maxSimultaneousActions >= numActions && d_nanosecondsPerAction != k_ALLOW_NONE) ==> __out == 0`
+- **groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp**
+  - requires:
+    - `amount > 0`
+    - `true`
+  - ensures:
+    - `__out == d_currentTime`
+    - `__out == d_currentTime && d_currentTime == old_d_currentTime + amount`
+    - `__out == d_data_p->advanceTime(amount)`
+    - `__out == d_data_p->currentTime()`
+    - `__out.totalMicroseconds() == minTime`
+    - `true`
+- **groups/bdl/bdlpcre/bdlpcre_regex.cpp**
+  - requires:
+    - `errorMessage != NULL && errorOffset != NULL && pattern != NULL && (flags & ~VALID_FLAGS) == 0`
+    - `matchContextData != 0`
+    - `matchContextData != NULL`
+    - `pcre2Context != 0 && patternCode != 0`
+    - `subject.data() != nullptr && subject.length() >= 0 && subjectOffset <= subject.length()`
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> (matchContextData->d_matchData_p != 0 ⋆ matchContextData->d_matchContext_p != 0 ⋆ (matchContextData->d_jitStack_p != 0 || d_jitStackSize == 0))) && (__out == k_INTERNAL_ERROR ==> (matchContextData->d_matchData_p == 0 ⋆ matchContextData->d_matchContext_p == 0 ⋆ matchContextData->d_jitStack_p == 0))`
+    - `(__out == k_STATUS_SUCCESS) || (__out == k_INTERNAL_ERROR)`
+    - `(matchContextData != nullptr ==> __out == RegEx::k_STATUS_SUCCESS) || (matchContextData == nullptr ==> __out == allocateMatchContext(matchContextData))`
+    - `__out == k_IS_JIT_SUPPORTED`
+    - `__out == match(subject.data(), subject.length(), subjectOffset)`
+    - `d_pcre2Context_p ↦ pcre2Context ⋆ d_pcre2PatternCode_p ↦ patternCode ⋆ d_depthLimit ↦ depthLimit ⋆ d_jitStackSize ↦ jitStackSize ⋆ __out == allocateMatchContext(&d_mainThreadMatchData)`
+- **groups/bdl/bdls/bdls_fdstreambuf.cpp**
+  - requires:
+    - `(buffer == 0 && numBytes == 0) ==> (d_mode == e_NULL_MODE && (d_buf_p ↦ sep_v && sep_v != 0)) && (buffer != 0 && numBytes > 0) ==> (d_buf_p ↦ buffer)`
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> (d_fileId == -1 || (buf.st_size <= 0))) && (__out != 0 ==> (d_fileId != -1 && __out == buf.st_size))`
+    - `(__out == 0 ==> d_mode == e_INPUT_MODE) && (__out == -1 ==> d_mode != e_INPUT_MODE)`
+    - `(__out == traits_type::to_int_type(*gptr()) ==> (d_mode == e_INPUT_PUTBACK_MODE || (d_mmapBase_p != 0 && d_mmapLen > 0))) && (__out == traits_type::eof() ==> (d_mode != e_INPUT_MODE && switchToInputMode() != 0)) && (__out == underflowRead() ==> (d_mmapBase_p == 0 || d_mmapLen == 0))`
+    - `(buffer == 0 && numBytes == 0 ==> (d_mode == e_NULL_MODE && (d_buf_p ↦ sep_v && sep_v != 0))) && (buffer != 0 && numBytes > 0 ==> (d_buf_p ↦ buffer)) && (__out == this)`
+    - `true`
+- **groups/bdl/bdls/bdls_filesystemutil.cpp**
+  - requires:
+    - `(0 <= idx && idx <= str.size()) && (len == bsl::string::npos || (idx + len <= str.size()))`
+    - `dirFD >= 0`
+    - `path != NULL`
+    - `path != nullptr`
+    - `true`
+  - ensures:
+    - `(__out == 0) || (__out != 0)`
+    - `(__out == 0) || (__out == bdls::FilesystemUtil::k_ERROR_ALREADY_EXISTS) || (__out == bdls::FilesystemUtil::k_ERROR_PATH_NOT_FOUND) || (__out == -1)`
+    - `(__out == true ==> (*path == '.' && (!path[1] || ('.' == path[1] && !path[2])))) && (__out == false ==> !(*path == '.' && (!path[1] || ('.' == path[1] && !path[2]))))`
+    - `(__out == true ==> (path[0] == '.' && strlen(path) == 1) || (path[strlen(path) - 1] == '.' && path[strlen(path) - 2] == '.' && (strlen(path) == 2 || path[strlen(path) - 3] == '/'))) && (__out == false ==> !(path[0] == '.' && strlen(path) == 1) && !(path[strlen(path) - 1] == '.' && path[strlen(path) - 2] == '.' && (strlen(path) == 2 || path[strlen(path) - 3] == '/')))`
+    - `__out == bsl::string_view(str).substr(idx, len)`
+    - `true`
+- **groups/bdl/bdls/bdls_pathutil.cpp**
+  - requires:
+    - `path != nullptr`
+    - `path != nullptr && rootEnd >= 0 && rootEnd <= bsl::strlen(path) && (length == -1 || (length >= 0 && length <= bsl::strlen(path)))`
+  - ensures:
+    - `(__out >= path + rootEnd && __out <= path + length) && (__out == path + rootEnd || isSeparator(*__out)) && (__out > path + rootEnd ==> SEPFORALL(__out - path + 1, length, i, !isSeparator(path[i])))`
+    - `__out == u_appendIfValid(path, filename)`
+- **groups/bdl/bdls/bdls_pipeutil.cpp**
+  - requires:
+    - `pipeName != 0`
+  - ensures:
+    - `__out == u_makeCanonicalName(pipeName, baseName)`
+- **groups/bdl/bdls/bdls_processutil.cpp**
+  - requires:
+    - `path != nullptr`
+    - `true`
+  - ensures:
+    - `(__out == "" || __out == "\"/proc\" exists." || __out == "\"/proc\" does not exist.")`
+    - `(__out == true ==> (0 == rc && !(s.st_mode & S_IFDIR) && (s.st_mode & executableBits))) && (__out == false ==> !(0 == rc && !(s.st_mode & S_IFDIR) && (s.st_mode & executableBits)))`
+    - `__out > 0`
+    - `true`
+- **groups/bdl/bdls/bdls_tempdirectoryguard.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == d_dirName`
+- **groups/bdl/bdlsb/bdlsb_fixedmeminput.cpp**
+  - requires:
+    - `(!(which & bsl::ios_base::in) || (position >= 0 && position <= d_bufferSize)) && (which & bsl::ios_base::in) ==> position >= 0`
+  - ensures:
+    - `(__out == -1 ==> (!(which & bsl::ios_base::in) || position < 0 || position > d_bufferSize)) && (__out != -1 ==> __out == position)`
+- **groups/bdl/bdlsb/bdlsb_fixedmeminstreambuf.cpp**
+  - requires:
+    - `(!(which & bsl::ios_base::in) || (way == bsl::ios_base::beg || way == bsl::ios_base::cur || way == bsl::ios_base::end)) && (way == bsl::ios_base::beg ==> offset >= 0) && (way == bsl::ios_base::end ==> offset <= 0)`
+  - ensures:
+    - `(__out == -1 ==> (!(which & bsl::ios_base::in) || __out < 0 || static_cast<bsl::size_t>(__out) > d_bufferSize)) && (__out != -1 ==> __out >= 0 && static_cast<bsl::size_t>(__out) <= d_bufferSize)`
+- **groups/bdl/bdlsb/bdlsb_memoutstreambuf.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(insertionChar == traits_type::eof() ==> __out == traits_type::not_eof(insertionChar)) && (insertionChar != traits_type::eof() ==> __out == sputc(static_cast<char_type>(insertionChar)))`
+- **groups/bdl/bdlsb/bdlsb_overflowmemoutput.cpp**
+  - requires: _none_
+  - ensures:
+    - `(!(which & bsl::ios_base::out) || way != bsl::ios_base::beg && way != bsl::ios_base::cur && way != bsl::ios_base::end || __out < 0 ==> __out == -1) && (!(which & bsl::ios_base::out) && way == bsl::ios_base::beg && way == bsl::ios_base::cur && way == bsl::ios_base::end && __out >= 0 ==> __out != -1)`
+- **groups/bdl/bdlsb/bdlsb_overflowmemoutstreambuf.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(c == EOF ==> __out == traits_type::not_eof(c)) && (c != EOF ==> __out == c)`
+- **groups/bdl/bdlt/bdlt_calendar.cpp**
+  - requires:
+    - `nextBusinessDay != 0 && date < Date(9999, 12, 31) && nth > 0 && (nextBusinessDay ↦ _)`
+    - `true`
+  - ensures:
+    - `(__out == e_SUCCESS ==> (*nextBusinessDay == firstDate() + offset)) && (__out == e_FAILURE ==> (*nextBusinessDay == old_nextBusinessDay))`
+    - `__out > initialDate`
+- **groups/bdl/bdlt/bdlt_calendarcache.cpp**
+  - requires:
+    - `calendarName != 0`
+    - `calendarName != NULL`
+    - `true`
+  - ensures:
+    - `(__out != nullptr) || (__out == nullptr)`
+    - `(__out.use_count() > 0) || (__out == bsl::shared_ptr<const Calendar>())`
+    - `(this->d_ptr ↦ rhs.d_ptr) ⋆ (this->d_loadTime ↦ rhs.d_loadTime)`
+    - `__out == d_ptr && (d_ptr ↦ _)`
+- **groups/bdl/bdlt/bdlt_currenttime.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(-1440 < __out.offset()) && (__out.offset() < 1440)`
+- **groups/bdl/bdlt/bdlt_date.cpp**
+  - requires:
+    - `!stream.bad()`
+    - `true`
+  - ensures:
+    - `__out == 0 || __out == -1`
+    - `__out == stream`
+- **groups/bdl/bdlt/bdlt_datetime.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+    - `__out == stream && SEPFORALL(0, 25, i, (stream + i ↦ buffer[i]))`
+- **groups/bdl/bdlt/bdlt_datetimeimputil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out != 0`
+- **groups/bdl/bdlt/bdlt_datetimeinterval.cpp**
+  - requires:
+    - `To ensure the function behaves correctly, the input parameters should be within the specified bounds. The function checks:
+- `u::k_HOURS_FLOOR <= hours <= u::k_HOURS_CEILING`
+- `u::k_MINUTES_FLOOR <= minutes <= u::k_MINUTES_CEILING`
+- `u::k_SECONDS_FLOOR <= seconds <= u::k_SECONDS_CEILING`
+- `u::k_MILLISECONDS_FLOOR <= milliseconds <= u::k_MILLISECONDS_CEILING`
+
+Additionally, the total duration should not exceed the maximum allowed duration.
+
+###`
+    - `result != nullptr && numBytes > 0`
+    - `true`
+  - ensures:
+    - `__out == stream`
+    - `__out >= 0`
+- **groups/bdl/bdlt/bdlt_datetimetz.cpp**
+  - requires:
+    - `!stream.bad()`
+  - ensures:
+    - `(__out == stream) && (!stream.bad())`
+- **groups/bdl/bdlt/bdlt_datetz.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(stream.bad() == true ==> __out == stream) && (stream.bad() == false ==> __out == stream)`
+- **groups/bdl/bdlt/bdlt_dateutil.cpp**
+  - requires:
+    - `(original.month() == 2) && (original.day() == 28 || original.day() == 29)`
+    - `original.year() >= 1 && original.year() <= 9999 && original.month() >= 1 && original.month() <= 12 && original.day() >= 1 && original.day() <= 31`
+    - `true`
+  - ensures:
+    - `(__out.month() == 2) && (__out.year() == original.year() + numYears) && (__out.day() == 28 || __out.day() == 29)`
+    - `(__out.year() == ((original.year() * 12 + original.month() + numMonths - 1) / 12)) && (__out.month() == (((original.year() * 12 + original.month() + numMonths - 1) % 12) + 1)) && (__out.day() <= 31) && (__out.day() == original.day() || __out.day() == SerialDateImpUtil::lastDayOfMonth(__out.year(), __out.month()))`
+    - `(day1 > day2 ==> __out == 7 - day1 + day2) && (day1 <= day2 ==> __out == day2 - day1) && (0 <= __out && __out <= 6)`
+- **groups/bdl/bdlt/bdlt_dayofweek.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream && SEPFORALL(0, strlen(toAscii(value)), i, (stream + i ↦ toAscii(value)[i]))`
+- **groups/bdl/bdlt/bdlt_dayofweekset.cpp**
+  - requires:
+    - `!stream.bad() && (stream ↦ _)`
+    - `true`
+  - ensures:
+    - `(d_index < 8 ==> ((1 << d_index) & d_data) != 0) && (d_index >= 8 || ((1 << d_index) & d_data) != 0) && (__out == *this)`
+    - `__out == stream && (stream ↦ _)`
+- **groups/bdl/bdlt/bdlt_defaultcalendarcache.cpp**
+  - requires:
+    - `loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)`
+    - `true`
+  - ensures:
+    - `(__out == 0 || __out == 1) && (__out == 0 ==> bsls::AtomicOperations::getPtrAcquire(&g_cachePtr) != NULL)`
+    - `__out != 0 && (__out != 0 ==> true)`
+- **groups/bdl/bdlt/bdlt_defaulttimetablecache.cpp**
+  - requires:
+    - `loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)`
+    - `true`
+  - ensures:
+    - `(__out == 0 || __out == 1) && (__out == 0 ==> bsls::AtomicOperations::getPtrAcquire(&g_cachePtr) != NULL)`
+    - `__out != 0 && (__out != 0 ==> true)`
+- **groups/bdl/bdlt/bdlt_fixutil.cpp**
+  - requires:
+    - `buffer != NULL && -(24 * 60) < tzOffset && tzOffset < 24 * 60`
+    - `buffer != NULL && 0 <= value && 0 <= paddedLen`
+    - `buffer != NULL && bufferLength >= 0`
+    - `buffer != nullptr && paddedLen >= 0`
+    - `nextPos != 0 && result != 0 && begin != 0 && end != 0 && begin < end && SEPFORALL(begin, end, i, (begin + i ↦ sep_v) && (sep_v >= '0' && sep_v <= '9'))`
+    - `nextPos != NULL && date != NULL && begin != NULL && end != NULL && begin <= end && (end - begin >= sizeof "YYYYMMDD" - 1)`
+    - `nextPos != nullptr && minuteOffset != nullptr && begin <= end && begin != end`
+  - ensures:
+    - `(0 == tzOffset && configuration.useZAbbreviationForUtc() ==> __out == 1) && (0 != tzOffset || !configuration.useZAbbreviationForUtc() ==> __out >= 4)`
+    - `(__out == -1) || (__out == 0 && (*nextPos == p) && (*minuteOffset == (sign == '-' ? -(hour * 60 + minute) : (hour * 60 + minute))))`
+    - `(__out == 0 ==> (*result ↦ tmp ⋆ *nextPos ↦ end)) && (__out == -1 ==> SEPEXISTS(0, end - begin, i, (begin + i ↦ sep_v) && !(sep_v >= '0' && sep_v <= '9')))`
+    - `__out == 0 || __out == -1`
+    - `__out == k_DATE_STRLEN`
+    - `__out == paddedLen`
+    - `__out == paddedLen + 1`
+- **groups/bdl/bdlt/bdlt_fixutilconfiguration.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == stream) && (SEPFORALL(0, 2, i, (stream + i ↦ sep_v) && ((i == 0 && sep_v == object.fractionalSecondPrecision()) || (i == 1 && sep_v == object.useZAbbreviationForUtc()))))`
+- **groups/bdl/bdlt/bdlt_fuzzutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `true`
+- **groups/bdl/bdlt/bdlt_iso8601utilconfiguration.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdlt/bdlt_iso8601utilparseconfiguration.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == stream`
+- **groups/bdl/bdlt/bdlt_monthofyear.cpp**
+  - requires:
+    - `stream ↦ _`
+  - ensures:
+    - `__out == stream && (stream ↦ _)`
+- **groups/bdl/bdlt/bdlt_packedcalendar.cpp**
+  - requires:
+    - `0 <= offset`
+    - `isHoliday(date)`
+    - `level >= 0 && spacesPerLevel != 0`
+    - `true`
+  - ensures:
+    - `(__out == d_holidayCodes.begin() + iterIndex) && (iterIndex == d_holidayCodes.length() || (iterIndex == d_holidayCodesIndex[i - offsetBegin] && i != offsetEnd && *i == offset))`
+    - `SEPFORALL(0, level * spacesPerLevel, i, (stream + i ↦ ' '))`
+    - `__out == ((firstDate <= lastDate ? (lastDate - firstDate + 1) : 0) / 7) * weekendDays.length() + (s_partialWeeks[static_cast<int>(firstDate.dayOfWeek())][(firstDate <= lastDate ? (lastDate - firstDate + 1) : 0) % 7] & weekendDays).length()`
+    - `__out == (lhs.d_firstDate == rhs.d_firstDate && lhs.d_lastDate == rhs.d_lastDate && lhs.d_weekendDaysTransitions == rhs.d_weekendDaysTransitions && lhs.d_holidayOffsets == rhs.d_holidayOffsets && lhs.d_holidayCodesIndex == rhs.d_holidayCodesIndex && lhs.d_holidayCodes == rhs.d_holidayCodes)`
+    - `__out == *this && (*this == rhs)`
+    - `__out >= 0 && __out < d_holidayOffsets.length() && d_holidayOffsets[__out] == offset`
+    - `__out.d_offsetIter == rhs.d_offsetIter ⋆ __out.d_calendar_p == rhs.d_calendar_p ⋆ __out.d_currentOffset == rhs.d_currentOffset ⋆ __out.d_endFlag == rhs.d_endFlag`
+- **groups/bdl/bdlt/bdlt_posixdateimputil.cpp**
+  - requires:
+    - `0 <= year`
+    - `k_MIN_YEAR <= year && year <= k_MAX_YEAR`
+    - `k_MIN_YEAR <= year && year <= k_MAX_YEAR && k_MIN_MONTH <= month && month <= k_MAX_MONTH`
+  - ensures:
+    - `(bdlt::PosixDateImpUtil::isLeapYear(year) && year == k_YEAR_1752 ==> __out == y1752DaysThroughMonth) && (bdlt::PosixDateImpUtil::isLeapYear(year) && year != k_YEAR_1752 ==> __out == leapDaysThroughMonth) && (!bdlt::PosixDateImpUtil::isLeapYear(year) ==> __out == normDaysThroughMonth)`
+    - `(month == k_FEBRUARY && isLeapYear(year) ==> __out == normDaysPerMonth[month] + 1) && (month != k_FEBRUARY || !isLeapYear(year) ==> __out == normDaysPerMonth[month])`
+    - `(year >= k_YEAR_2000 ==> __out == k_NUM_LEAP_YEARS_UNTIL_YEAR_2000 + (year - k_YEAR_2000) / 4 - (year - k_YEAR_2000) / 100 + (year - k_YEAR_2000) / 400) && (year >= k_YEAR_1800 && year < k_YEAR_2000 ==> __out == k_NUM_LEAP_YEARS_UNTIL_YEAR_1800 + (year - k_YEAR_1800) / 4 - (year - k_YEAR_1800) / 100) && (year < k_YEAR_1800 ==> __out == year / 4)`
+    - `__out == (year - 1) * k_DAYS_IN_NON_LEAP_YEAR + (year - 1) / 4 - (year > k_YEAR_1752 ? k_YEAR_1752_NUM_MISSING_DAYS + (year > k_YEAR_1800 ? (year - k_YEAR_1701) / 100 - (year - k_YEAR_1601) / 400 : 0) : 0)`
+- **groups/bdl/bdlt/bdlt_prolepticdateimputil.cpp**
+  - requires:
+    - `(k_MIN_YEAR <= year && year <= k_MAX_YEAR) && (k_MIN_MONTH <= month && month <= k_MAX_MONTH)`
+    - `k_MIN_YEAR <= year && year <= k_MAX_YEAR`
+    - `k_MIN_YEAR <= year && year <= k_MAX_YEAR && 0 <= month && month <= k_MAX_MONTH`
+  - ensures:
+    - `(month == k_FEB && isLeapYear(year) ==> __out == normDaysPerMonth[month] + 1) && (month != k_FEB || !isLeapYear(year) ==> __out == normDaysPerMonth[month])`
+    - `__out == (year - 1) * k_DAYS_IN_NON_LEAP_YEAR + numLeapYearsSoFar(year - 1)`
+    - `__out == getArrayDaysThroughMonth(year)[month]`
+- **groups/bdl/bdlt/bdlt_time.cpp**
+  - requires:
+    - `base > 0 && number ↦ _`
+    - `number ↦ _ && base >= 1`
+    - `true`
+  - ensures:
+    - `(__out == old_initial / base) && (number ↦ old_initial % base) && (old_initial == *number + __out * base)`
+    - `(__out == old_number / base) && (number ↦ old_number % base) && (0 <= *number) && (*number < base)`
+    - `(__out == old_number / base) && (number ↦ old_number % base) && (old_number == *number + __out * base)`
+    - `__out == (BSLS_PLATFORM_IS_LITTLE_ENDIAN ? d_value * TimeUnitRatio::k_US_PER_MS : (d_value >> 32) * TimeUnitRatio::k_US_PER_MS)`
+    - `__out == static_cast<int>(wholeDays)`
+- **groups/bdl/bdlt/bdlt_timetable.cpp**
+  - requires:
+    - `24 > time.hour() && (0 <= code || code == Timetable::k_UNSET_TRANSITION_CODE)`
+    - `true`
+  - ensures:
+    - `(__out == true ==> finalTransitionCode() != old_finalTransitionCode) && (__out == false ==> finalTransitionCode() == old_finalTransitionCode)`
+    - `(time.hour() < 24) ==> (__out == finalTransitionCode() || __out == d_initialTransitionCode || __out == iter->d_code)`
+    - `__out == *this`
+    - `__out == Timetable_ConstIterator(*this, dayIndex, 0)`
+- **groups/bdl/bdlt/bdlt_timetablecache.cpp**
+  - requires:
+    - `timetableName != NULL`
+    - `true`
+  - ensures:
+    - `(__out != nullptr) ==> (__out.use_count() > 0)`
+    - `(__out.get() != nullptr) ==> (__out.use_count() > 0)`
+    - `__out == d_ptr && (d_ptr ↦ _)`
+    - `d_ptr ↦ rhs.d_ptr ⋆ d_loadTime ↦ rhs.d_loadTime`
+- **groups/bdl/bdlt/bdlt_timetz.cpp**
+  - requires:
+    - `!stream.bad()`
+  - ensures:
+    - `(__out == stream) && (!stream.bad() || stream.bad()) && (__out != 0) && (__out->str() ↦ oss.str())`
+- **groups/bsl/bslalg/bslalg_hashutil.cpp**
+  - requires:
+    - `0 <= length && (length == 0 || data != 0)`
+  - ensures:
+    - `true`
+- **groups/bsl/bslalg/bslalg_rbtreeutil.cpp**
+  - requires:
+    - `subtree != 0 && FORALL(subtree, nullptr, node, node->leftChild() != 0 || node == subtree)`
+    - `true`
+  - ensures:
+    - `(__out == true ==> (node == 0 || node->isBlack())) && (__out == false ==> (node != 0 && !node->isBlack()))`
+    - `__out != 0 && __out->leftChild() == 0`
+- **groups/bsl/bslfmt/bslfmt_unicodecodepoint.cpp**
+  - requires:
+    - `(pc ↦ _ ⋆ (pc + 1) ↦ _ ⋆ (pc + 2) ↦ _)`
+    - `(pc ↦ _ ⋆ (pc + 1) ↦ _)`
+    - `maxBytes >= 2`
+    - `pc != NULL && pc + 3 < (unsigned char*)-1`
+    - `true`
+  - ensures:
+    - `(__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTBOTH & value) == k_UTF16_HIGH_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTBOTH & value) != k_UTF16_HIGH_SURROGATE_START))`
+    - `(__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) == k_UTF16_HIGH_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) != k_UTF16_HIGH_SURROGATE_START))`
+    - `(__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) == k_UTF16_LOW_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) != k_UTF16_LOW_SURROGATE_START))`
+    - `(__out == true ==> (value & 0xc0) != 0x80) && (__out == false ==> (value & 0xc0) == 0x80)`
+    - `__out == ((*pc & 0x1f) << 6) | ((pc[1] & k_UTF8_CONT_VALUE_MASK))`
+    - `__out == ((*pc & 0xf) << 12) | ((pc[1] & k_UTF8_CONT_VALUE_MASK) << 6) | (pc[2] & k_UTF8_CONT_VALUE_MASK)`
+    - `__out == 1 || __out == 2`
+    - `true`
+- **groups/bsl/bslh/bslh_siphashalgorithm.cpp**
+  - requires:
+    - `p ↦ _ ⋆ (p + 1) ↦ _ ⋆ (p + 2) ↦ _ ⋆ (p + 3) ↦ _ ⋆ (p + 4) ↦ _ ⋆ (p + 5) ↦ _ ⋆ (p + 6) ↦ _ ⋆ (p + 7) ↦ _`
+    - `true`
+  - ensures:
+    - `__out == ((x << b) | (x >> (64 - b)))`
+    - `__out == BSLS_BYTEORDER_LE_U64_TO_HOST(*((u64*)p))`
+- **groups/bsl/bslim/bslim_printer.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == d_level`
+- **groups/bsl/bslma/bslma_allocator.cpp**
+  - requires:
+    - `bytes >= 0 && align > 0`
+  - ensures:
+    - `(bytes == 0 ==> __out != nullptr) && (bytes != 0 ==> __out != nullptr)`
+- **groups/bsl/bslma/bslma_bufferallocator.cpp**
+  - requires: _none_
+  - ensures:
+    - `(__out == nullptr ==> *cursor + bsls::AlignmentUtil::calculateAlignmentOffset(buffer + *cursor, alignment) + size > bufSize) && (__out != nullptr ==> __out >= buffer && __out < buffer + bufSize)`
+- **groups/bsl/bslma/bslma_infrequentdeleteblocklist.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == 0 ==> numBytes == 0) && (__out != 0 ==> (d_head_p->d_next_p ↦ old_d_head_p ⋆ d_head_p->d_memory ↦ _ ⋆ (d_head_p ↦ _ && (d_head_p->d_next_p ↦ old_d_head_p))))`
+- **groups/bsl/bslma/bslma_mallocfreeallocator.cpp**
+  - requires:
+    - `p != 0`
+    - `true`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))`
+    - `__out == &p->object()`
+    - `true`
+- **groups/bsl/bslma/bslma_newdeleteallocator.cpp**
+  - requires:
+    - `address != 0`
+    - `true`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))`
+    - `__out != 0 && (__out == &address->object())`
+    - `true`
+- **groups/bsl/bslma/bslma_sequentialpool.cpp**
+  - requires:
+    - `(size == 0 ==> true) && (size != 0 ==> 0 < size)`
+  - ensures:
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))`
+- **groups/bsl/bslma/bslma_testallocator.cpp**
+  - requires:
+    - `output != NULL && blockList != NULL`
+    - `true`
+  - ensures:
+    - `(__out == true ==> bsls::AlignmentUtil::calculateAlignmentOffset(address, int(alignment)) == 0) && (__out == false ==> bsls::AlignmentUtil::calculateAlignmentOffset(address, int(alignment)) != 0)`
+    - `(size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)`
+    - `0 < __out && __out < k_BLOCKID_LINE_SZ`
+- **groups/bsl/bslmt/bslmt_configuration.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(1 <= __out) && (__out <= INT_MAX)`
+- **groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp**
+  - requires:
+    - `argument != nullptr`
+  - ensures:
+    - `__out == 0`
+- **groups/bsl/bslmt/bslmt_latch.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == d_sigCount`
+- **groups/bsl/bslmt/bslmt_qlock.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == key) || (__out == reinterpret_cast<TlsKey *>(oldKey))`
+    - `__out != 0`
+    - `__out != 0 && (__out != 0 ==> true)`
+    - `__out == bslma::NewDeleteAllocator::singleton()`
+- **groups/bsl/bslmt/bslmt_sluice.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out != NULL`
+- **groups/bsl/bslmt/bslmt_testutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `&__out == mutex_p && (true ==> &__out == mutex_p)`
+    - `__out == ptr`
+- **groups/bsl/bslmt/bslmt_threadattributes.cpp**
+  - requires:
+    - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
+    - `true`
+  - ensures:
+    - `__out == (lhs.detachedState() == rhs.detachedState() && lhs.guardSize() == rhs.guardSize() && lhs.inheritSchedule() == rhs.inheritSchedule() && lhs.schedulingPolicy() == rhs.schedulingPolicy() && lhs.schedulingPriority() == rhs.schedulingPriority() && lhs.stackSize() == rhs.stackSize() && lhs.threadName() == rhs.threadName())`
+    - `__out == stream && (__out ↦ _)`
+    - `d_detachedState ↦ rhs.d_detachedState ⋆ d_guardSize ↦ rhs.d_guardSize ⋆ d_inheritScheduleFlag ↦ rhs.d_inheritScheduleFlag ⋆ d_schedulingPolicy ↦ rhs.d_schedulingPolicy ⋆ d_schedulingPriority ↦ rhs.d_schedulingPriority ⋆ d_stackSize ↦ rhs.d_stackSize ⋆ d_threadName ↦ rhs.d_threadName`
+- **groups/bsl/bslmt/bslmt_threadutil.cpp**
+  - requires:
+    - `((int) policy >= ThreadAttributes::e_SCHED_MIN && (int) policy <= ThreadAttributes::e_SCHED_MAX) && (normalizedSchedulingPriority >= 0.0 && normalizedSchedulingPriority <= 1.0)`
+    - `true`
+  - ensures:
+    - `(minPri == ThreadAttributes::e_UNSET_PRIORITY || maxPri == ThreadAttributes::e_UNSET_PRIORITY) ==> __out == ThreadAttributes::e_UNSET_PRIORITY`
+    - `true`
+- **groups/bsl/bslmt/bslmt_throughputbenchmark.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == s_antiOptimization`
+    - `true`
+- **groups/bsl/bslmt/bslmt_turnstile.cpp**
+  - requires:
+    - `timestamp != 0`
+    - `true`
+  - ensures:
+    - `(__out == *timestamp) && (*timestamp ↦ __out)`
+    - `__out == (nowUSecs - d_nextTurn > 0 ? nowUSecs - d_nextTurn : 0)`
+- **groups/bsl/bsls/bsls_alignment.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(value == Alignment::BSLS_MAXIMUM ==> __out == "MAXIMUM") && (value == Alignment::BSLS_NATURAL ==> __out == "NATURAL") && (value == Alignment::BSLS_BYTEALIGNED ==> __out == "BYTEALIGNED") && (value != Alignment::BSLS_MAXIMUM && value != Alignment::BSLS_NATURAL && value != Alignment::BSLS_BYTEALIGNED ==> __out == "(* UNKNOWN *)")`
+- **groups/bsl/bsls/bsls_asserttest.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(__out == (lhs.length() == rhs.length() && 0 == memcmp(lhs.str(), rhs.str(), lhs.length())))`
+    - `__out == (d_str_p == 0 && d_length == 0)`
+    - `__out == (testName.isEmpty() || throwName.isEmpty() || throwName == testName)`
+- **groups/bsl/bsls/bsls_blockgrowth.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(value == BlockGrowth::BSLS_GEOMETRIC ==> __out == "GEOMETRIC") && (value == BlockGrowth::BSLS_CONSTANT ==> __out == "CONSTANT") && (value != BlockGrowth::BSLS_GEOMETRIC && value != BlockGrowth::BSLS_CONSTANT ==> __out == "(* UNKNOWN *)")`
+- **groups/bsl/bsls/bsls_bslonce.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == true || __out == false`
+- **groups/bsl/bsls/bsls_bslsourcenameparserutil.cpp**
+  - requires:
+    - `begin <= end && SEPFORALL(0, end - begin, i, (begin + i ↦ _))`
+    - `componentNamePtr != NULL && componentNameLength != NULL && sourceName != NULL && type_p != NULL`
+    - `filename != nullptr && EXISTS(0, strlen(filename), i, SEPEXISTS(0, sizeof(pathSeparators) - 1, j, filename[i] == pathSeparators[j]))`
+    - `true`
+  - ensures:
+    - `(__out == 0) || (__out == -1) || (__out == -2) || (__out == -3)`
+    - `(__out == begin) || (__out != begin ==> SEPEXISTS(0, end - begin, i, (begin + i ↦ ch) && __out == (begin + i + 1)))`
+    - `(__out == filename) || (FORALL(0, __out - filename, i, SEPEXISTS(0, sizeof(pathSeparators), j, filename + i == pathSeparators[j])))`
+    - `(__out == true ==> (sourceType & BslSourceNameParserUtil::k_MASK_TEST) != 0) && (__out == false ==> (sourceType & BslSourceNameParserUtil::k_MASK_TEST) == 0)`
+    - `(__out == true ==> (tag == 't' || tag == 'g')) && (__out == false ==> (tag != 't' && tag != 'g'))`
+    - `(__out == true ==> (tag >= 'a' && tag <= 'z')) && (__out == false ==> !(tag >= 'a' && tag <= 'z'))`
+- **groups/bsl/bsls/bsls_bsltestutil.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == ptr`
+- **groups/bsl/bsls/bsls_log.cpp**
+  - requires:
+    - `numBytes >= 0`
+    - `size > 0 && buffer != NULL && format != NULL`
+  - ensures:
+    - `(__out == d_buffer_p) && ((numBytes == 0 ==> __out == 0) && (numBytes > 0 ==> (__out != 0 ⋆ SEPFORALL(0, numBytes, i, (__out + i) ↦ _))))`
+    - `(size > 0 && buffer != NULL && format != NULL) ==> __out >= 0`
+- **groups/bsl/bsls/bsls_logseverity.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(value == LogSeverity::e_FATAL ==> __out == "FATAL") && (value == LogSeverity::e_ERROR ==> __out == "ERROR") && (value == LogSeverity::e_WARN ==> __out == "WARN") && (value == LogSeverity::e_DEBUG ==> __out == "DEBUG") && (value == LogSeverity::e_INFO ==> __out == "INFO") && (value == LogSeverity::e_TRACE ==> __out == "TRACE") && (value != LogSeverity::e_FATAL && value != LogSeverity::e_ERROR && value != LogSeverity::e_WARN && value != LogSeverity::e_DEBUG && value != LogSeverity::e_INFO && value != LogSeverity::e_TRACE ==> __out == "(* UNKNOWN *)")`
+- **groups/bsl/bsls/bsls_nameof.cpp**
+  - requires:
+    - `buffer != nullptr && functionName != nullptr && std::strlen(functionName) > 0`
+  - ensures:
+    - `(__out == functionName ==> std::strncmp(uselessPreamble, functionName, k_USELESS_PREAMBLE_LEN) != 0) && (__out == buffer ==> std::strncmp(uselessPreamble, functionName, k_USELESS_PREAMBLE_LEN) == 0)`
+- **groups/bsl/bsls/bsls_outputredirector.cpp**
+  - requires:
+    - `expected != 0`
+  - ensures:
+    - `__out == compare(expected, strlen(expected))`
+- **groups/bsl/bsls/bsls_stackaddressutil.cpp**
+  - requires:
+    - `tag != NULL && strlen(tag) > 0`
+  - ensures:
+    - `__out == 0 || *__out != '\0'`
+- **groups/bsl/bsls/bsls_systemclocktype.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out != 0 && ((value == SystemClockType::Enum::e_REALTIME ==> __out == "REALTIME") || (value == SystemClockType::Enum::e_MONOTONIC ==> __out == "MONOTONIC") || (value != SystemClockType::Enum::e_REALTIME && value != SystemClockType::Enum::e_MONOTONIC ==> __out == "(* UNKNOWN *)"))`
+- **groups/bsl/bsls/bsls_systemtime.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `true`
+- **groups/bsl/bsls/bsls_timeinterval.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == *this`
+- **groups/bsl/bslstl/bslstl_error.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == error_category::message(value)`
+    - `true`
+- **groups/bsl/bslstl/bslstl_sharedptr.cpp**
+  - requires:
+    - `bufferSize > 0 && basicAllocator != nullptr`
+  - ensures:
+    - `__out != nullptr && (__out.get() ↦ _ ⋆ SEPFORALL(0, bufferSize, i, (__out.get() + i) ↦ _))`
+- **groups/bsl/bslstl/bslstl_stopstate.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out != 0`
+    - `true`
+- **groups/bsl/bsltf/bsltf_allocemplacabletesttype.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == s_numDeletes`
+- **groups/bsl/bsltf/bsltf_alloctesttype.cpp**
+  - requires:
+    - `rhs.d_data_p ↦ _`
+  - ensures:
+    - `(__out == *this) && (d_data_p ↦ *rhs.d_data_p)`
+- **groups/bsl/bsltf/bsltf_copymovestate.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out != 0`
+- **groups/bsl/bsltf/bsltf_emplacabletesttype.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `__out == *this ⋆ d_arg01 ↦ rhs.d_arg01 ⋆ d_arg02 ↦ rhs.d_arg02 ⋆ d_arg03 ↦ rhs.d_arg03 ⋆ d_arg04 ↦ rhs.d_arg04 ⋆ d_arg05 ↦ rhs.d_arg05 ⋆ d_arg06 ↦ rhs.d_arg06 ⋆ d_arg07 ↦ rhs.d_arg07 ⋆ d_arg08 ↦ rhs.d_arg08 ⋆ d_arg09 ↦ rhs.d_arg09 ⋆ d_arg10 ↦ rhs.d_arg10 ⋆ d_arg11 ↦ rhs.d_arg11 ⋆ d_arg12 ↦ rhs.d_arg12 ⋆ d_arg13 ↦ rhs.d_arg13 ⋆ d_arg14 ↦ rhs.d_arg14`
+    - `__out == s_numDeletes`
+- **groups/bsl/bsltf/bsltf_movestate.cpp**
+  - requires:
+    - `(value == MoveState::e_NOT_MOVED) || (value == MoveState::e_MOVED) || (value == MoveState::e_UNKNOWN)`
+  - ensures:
+    - `(value == MoveState::e_NOT_MOVED ==> __out == "NOT_MOVED") && (value == MoveState::e_MOVED ==> __out == "MOVED") && (value == MoveState::e_UNKNOWN ==> __out == "UNKNOWN") && (value != MoveState::e_NOT_MOVED && value != MoveState::e_MOVED && value != MoveState::e_UNKNOWN ==> __out == "(* UNKNOWN *)")`
+- **groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.cpp**
+  - requires:
+    - `(rhs.d_data_p ↦ _) && (d_data_p ↦ _)`
+  - ensures:
+    - `(__out == *this) && ((&rhs != this) ==> (d_data_p ↦ *rhs.d_data_p))`
+- **groups/bsl/bsltf/bsltf_stdtestallocator.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(s_StdTestAllocatorConfiguration_allocator_p != 0 ==> __out == s_StdTestAllocatorConfiguration_allocator_p) && (s_StdTestAllocatorConfiguration_allocator_p == 0 ==> __out == &bslma::NewDeleteAllocator::singleton())`
+- **groups/bsl/bslx/bslx_byteinstream.cpp**
+  - requires:
+    - `object.length() >= 0 && stream.good()`
+  - ensures:
+    - `__out == stream && stream.flags() == old_flags`
+- **groups/bsl/bslx/bslx_byteoutstream.cpp**
+  - requires:
+    - `stream.good()`
+  - ensures:
+    - `(__out == stream) && (stream.flags() == old_flags)`
+- **groups/bsl/bslx/bslx_testinstream.cpp**
+  - requires:
+    - `(object.length() >= 0) && SEPFORALL(0, object.length(), i, (object.data() + i ↦ _))`
+    - `true`
+  - ensures:
+    - `(__out == *this) && (isValid() ==> variable >= 0)`
+    - `__out == stream && (stream.flags() == old_stream.flags())`
+- **groups/bsl/bslx/bslx_testoutstream.cpp**
+  - requires:
+    - `0 <= length`
+    - `true`
+  - ensures:
+    - `&__out == this`
+    - `__out == stream`
+- **groups/bsl/bslx/bslx_typecode.cpp**
+  - requires:
+    - `true`
+  - ensures:
+    - `(stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == (stream << TypeCode::toAscii(value) << bsl::flush)))`

--- a/groups/bal/balb/balb_controlmanager.cpp
+++ b/groups/bal/balb/balb_controlmanager.cpp
@@ -55,6 +55,8 @@ ControlManager::~ControlManager()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_defaultHandler.has_value()
 bool ControlManager::hasDefaultHandler() const
 {
     bslmt::ReadLockGuard<bslmt::RWMutex> registryGuard(&d_registryMutex);
@@ -62,6 +64,8 @@ bool ControlManager::hasDefaultHandler() const
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == 0 || __out == 1
 int ControlManager::registerHandler(const bsl::string_view& prefix,
                                     const bsl::string_view& arguments,
                                     const bsl::string_view& description,

--- a/groups/bal/balb/balb_leakybucket.cpp
+++ b/groups/bal/balb/balb_leakybucket.cpp
@@ -22,6 +22,7 @@ namespace {
 /// `timeInterval.seconds() * drainRate <= ULLONG_MAX`.  Note that
 /// `fractionalUnitDrainedInNanoUnits` is represented in nano-units to avoid
 /// using a floating point representation.
+// ensures: __out >= 0 && *fractionalUnitDrainedInNanoUnits < 1000000000
 bsls::Types::Uint64 calculateNumberOfUnitsToDrain(
                     bsls::Types::Uint64*      fractionalUnitDrainedInNanoUnits,
                     bsls::Types::Uint64       drainRate,
@@ -161,6 +162,8 @@ LeakyBucket::LeakyBucket(bsls::Types::Uint64       drainRate,
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == bsls::TimeInterval(0, 0) ==> (d_unitsInBucket + d_unitsReserved < d_capacity)) && (__out != bsls::TimeInterval(0, 0) ==> (d_unitsInBucket + d_unitsReserved >= d_capacity))
 bsls::TimeInterval LeakyBucket::calculateTimeToSubmit(
                                          const bsls::TimeInterval& currentTime)
 {

--- a/groups/bal/balb/balb_performancemonitor.cpp
+++ b/groups/bal/balb/balb_performancemonitor.cpp
@@ -122,6 +122,8 @@ MeasureData s_measureData[PM::e_NUM_MEASURES] = {
 /// Return `true` if the absolute value of the difference between the
 /// specified `lhs` and `rhs` is less than
 /// `bsl::numeric_limits<double>::episilon`.
+// requires: true
+// ensures: __out == (bsl::fabs(lhs - rhs) < bsl::numeric_limits<double>::epsilon())
 bool nearlyEqual(double lhs, double rhs)
 {
     return bsl::fabs(lhs - rhs) < bsl::numeric_limits<double>::epsilon();

--- a/groups/bal/balb/balb_pipetaskmanager.cpp
+++ b/groups/bal/balb/balb_pipetaskmanager.cpp
@@ -25,6 +25,8 @@ namespace u {
 /// `basicAllocator`, of a `balb::PipeControlChannel` object configured to
 /// invoke the `dispatchMethod` function of the specified `controlManager`
 /// and that uses `basicAllocator` to supply memory.
+// requires: controlManager != 0 && basicAllocator != 0
+// ensures: __out != 0
 static
 PipeControlChannel *makeControlChannel(ControlManager   *controlManager,
                                        bslma::Allocator *basicAllocator)

--- a/groups/bal/balb/balb_ratelimiter.cpp
+++ b/groups/bal/balb/balb_ratelimiter.cpp
@@ -51,6 +51,8 @@ namespace {
 /// with which to initialize a `balb::LeakyBucket` object, and if so,
 /// whether a `balb::LeakyBucket` object so initialized would preserve the
 /// value of `window`.
+// requires: limit > 0 && window > bsls::TimeInterval()
+// ensures: (__out == true ==> (limit > 0 && window > bsls::TimeInterval() && (limit == 1 || window <= LeakyBucket::calculateDrainTime(ULLONG_MAX, limit, true)) && window == LeakyBucket::calculateTimeWindow(limit, LeakyBucket::calculateCapacity(limit, window)))) && (__out == false ==> !(limit > 0 && window > bsls::TimeInterval() && (limit == 1 || window <= LeakyBucket::calculateDrainTime(ULLONG_MAX, limit, true)) && window == LeakyBucket::calculateTimeWindow(limit, LeakyBucket::calculateCapacity(limit, window))))
 bool supportsExactly(bsls::Types::Uint64       limit,
                      const bsls::TimeInterval& window)
 {
@@ -79,6 +81,8 @@ bool RateLimiter::supportsRateLimitsExactly(
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == bsl::max(d_peakRateBucket.calculateTimeToSubmit(currentTime), d_sustainedRateBucket.calculateTimeToSubmit(currentTime))
 bsls::TimeInterval RateLimiter::calculateTimeToSubmit(
                                          const bsls::TimeInterval& currentTime)
 {

--- a/groups/bal/balber/balber_berdecoder.cpp
+++ b/groups/bal/balber/balber_berdecoder.cpp
@@ -74,6 +74,8 @@ BerDecoder::ErrorSeverity BerDecoder::logMsg(const char *prefix,
                        // -----------------------------
 
 // ACCESSORS
+// requires: FORALL(0, d_parent_count, i, d_parent[i] != 0 && d_parent[i]->d_consumedHeaderBytes ↦ _ && d_parent[i]->d_consumedBodyBytes ↦ _)
+// ensures: __out == (d_parent == 0 ? 0 : d_parent->d_consumedHeaderBytes + d_parent->d_consumedBodyBytes + d_parent->startPos())
 int BerDecoder_Node::startPos() const
 {
     int ret = 0;
@@ -179,6 +181,8 @@ void BerDecoder_Node::print(bsl::ostream&  out,
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == d_decoder->logError(msg)
 int BerDecoder_Node::logError(const char *msg)
 {
     BerDecoder::ErrorSeverity rc = d_decoder->logError(msg);

--- a/groups/bal/balber/balber_berdecoderoptions.cpp
+++ b/groups/bal/balber/balber_berdecoderoptions.cpp
@@ -74,6 +74,8 @@ const bdlat_AttributeInfo balber::BerDecoderOptions::ATTRIBUTE_INFO_ARRAY[] = {
 namespace balber {
 
 // CLASS METHODS
+// requires: nameLength >= 0 && SEPFORALL(0, nameLength, i, name[i] ↦ _)
+// ensures: (__out == 0) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_MAX_DEPTH] && nameLength == 8) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_TRACE_LEVEL] && nameLength == 10) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_MAX_SEQUENCE_SIZE] && nameLength == 15) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_SKIP_UNKNOWN_ELEMENTS] && nameLength == 19) || (__out == &ATTRIBUTE_INFO_ARRAY[e_ATTRIBUTE_INDEX_DEFAULT_EMPTY_STRINGS] && nameLength == 19)
 const bdlat_AttributeInfo *BerDecoderOptions::lookupAttributeInfo(
                                                         const char *name,
                                                         int         nameLength)

--- a/groups/bal/balber/balber_berencoder.cpp
+++ b/groups/bal/balber/balber_berencoder.cpp
@@ -46,6 +46,8 @@ BerEncoder::~BerEncoder()
 }
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: (static_cast<int>(d_severity) >= static_cast<int>(e_BER_ERROR)) && (__out == logMsg("ERROR", tagClass, tagNumber, name, index))
 BerEncoder::ErrorSeverity
 BerEncoder::logError(BerConstants::TagClass  tagClass,
                      int                     tagNumber,

--- a/groups/bal/balber/balber_beruniversaltagnumber.cpp
+++ b/groups/bal/balber/balber_beruniversaltagnumber.cpp
@@ -14,6 +14,8 @@ namespace balber {
                         // ----------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (value == e_BER_BOOL ==> __out == "BOOL") && (value == e_BER_INT ==> __out == "INT") && (value == e_BER_OCTET_STRING ==> __out == "OCTET_STRING") && (value == e_BER_REAL ==> __out == "REAL") && (value == e_BER_ENUMERATION ==> __out == "ENUMERATION") && (value == e_BER_UTF8_STRING ==> __out == "UTF8_STRING") && (value == e_BER_SEQUENCE ==> __out == "SEQUENCE") && (value == e_BER_VISIBLE_STRING ==> __out == "VISIBLE_STRING") && (value != e_BER_BOOL && value != e_BER_INT && value != e_BER_OCTET_STRING && value != e_BER_REAL && value != e_BER_ENUMERATION && value != e_BER_UTF8_STRING && value != e_BER_SEQUENCE && value != e_BER_VISIBLE_STRING ==> __out == "(* UNKNOWN *)")
 const char *BerUniversalTagNumber::toString(BerUniversalTagNumber::Value value)
 {
 #ifdef CASE

--- a/groups/bal/balber/balber_berutil.cpp
+++ b/groups/bal/balber/balber_berutil.cpp
@@ -100,6 +100,8 @@ ReadRestFunctor::ReadRestFunctor(bsl::streambuf *streamBuf, int oldSize)
 }
 
 // MODIFIERS
+// requires: newSize >= d_oldSize
+// ensures: __out == d_oldSize + nRead
 size_t ReadRestFunctor::operator()(char *buf, size_t newSize)
 {
     bsl::streamsize nRead = d_streamBuf->sgetn(
@@ -134,6 +136,8 @@ namespace balber {
                                // --------------
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 int BerUtil::getIdentifierOctets(bsl::streambuf         *streamBuf,
                                  BerConstants::TagClass *tagClass,
                                  BerConstants::TagType  *tagType,
@@ -158,6 +162,8 @@ int BerUtil::putIdentifierOctets(bsl::streambuf         *streamBuf,
                       // --------------------------------
 
 // CLASS METHODS
+// requires: tagClass != NULL && tagType != NULL && tagNumber != NULL && accumNumBytesConsumed != NULL && streamBuf != NULL
+// ensures: __out == SUCCESS || __out == FAILURE
 int BerUtil_IdentifierImpUtil::getIdentifierOctets(
                                  BerConstants::TagClass *tagClass,
                                  BerConstants::TagType  *tagType,
@@ -209,6 +215,8 @@ int BerUtil_IdentifierImpUtil::getIdentifierOctets(
 }
 
 /// Write the specified `tag*` to the specified `streamBuf`.
+// requires: tagNumber >= 0 && streamBuf != NULL
+// ensures: (__out == SUCCESS || __out == FAILURE)
 int BerUtil_IdentifierImpUtil::putIdentifierOctets(
                                              bsl::streambuf         *streamBuf,
                                              BerConstants::TagClass  tagClass,
@@ -432,6 +440,8 @@ int BerUtil_LengthImpUtil::putEndOfContentOctets(bsl::streambuf *streamBuf)
                        // -----------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == (value == 0 ? 1 : ((31 - bdlb::BitUtil::numLeadingUnsetBits(static_cast<bsl::uint32_t>(value > 0 ? value : ~value)) + 2 + Constants::k_NUM_BITS_PER_OCTET - 1) / Constants::k_NUM_BITS_PER_OCTET))
 int BerUtil_IntegerImpUtil::getNumOctetsToStream(short value)
 {
     // This overload of 'numBytesToStream' is optimized for a 16-bit 'value'.
@@ -1238,6 +1248,8 @@ int BerUtil_Iso8601ImpUtil::putTimeTzValue(bsl::streambuf          *streamBuf,
                     // ------------------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (__out == true ==> (k_MIN_OFFSET <= value && k_MAX_OFFSET >= value)) && (__out == false ==> !(k_MIN_OFFSET <= value && k_MAX_OFFSET >= value))
 bool BerUtil_TimezoneOffsetImpUtil::isValidTimezoneOffsetInMinutes(int value)
 {
     return (k_MIN_OFFSET <= value) && (k_MAX_OFFSET >= value);

--- a/groups/bal/balcl/balcl_commandline.cpp
+++ b/groups/bal/balcl/balcl_commandline.cpp
@@ -100,6 +100,8 @@ EnvironmentVariableAccessor::EnvironmentVariableAccessor(
 #endif
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_returnValue
 inline
 const char *EnvironmentVariableAccessor::value() const
 {
@@ -215,6 +217,8 @@ Ordinal::Ordinal(bsl::size_t n)
 }  // close namespace u
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& u::operator<<(bsl::ostream& stream, Ordinal position)
 {
     // ranks start at 0, but are displayed as 1st, 2nd, etc.
@@ -370,6 +374,8 @@ bool isValidEnvironmentVariableName(
 /// documentation.  Return 0 if `options` are valid, and a non-zero value
 /// otherwise.  If `options` is invalid, a descriptive message is written to
 /// the specified `errorStream`.
+// requires: true
+// ensures: __out == 0 || __out == 1 || __out == 2 || __out == 3 || __out == 4 || __out == 5 || __out == 6 || __out == 7 || __out == 8 || __out == 9 || __out == 10 || __out == 11 || __out == 12 || __out == 14 || __out == -1 || __out == -2 || __out == -3
 int validate(const bsl::vector<Option>& options,
              bsl::ostream&              errorStream)
 {
@@ -1186,6 +1192,8 @@ void CommandLine::validateAndInitialize(bsl::ostream& errorStream)
 }
 
 // PRIVATE ACCESSORS
+// requires: true
+// ensures: (__out != -1 ==> d_options[__out].name() == name) && (__out == -1 ==> FORALL(0, d_options.size(), i, d_options[i].name() != name))
 int CommandLine::findName(const bsl::string_view& name) const
 {
     for (unsigned int i = 0; i < d_options.size(); ++i) {
@@ -1284,6 +1292,8 @@ int CommandLine::missing(bool checkAlsoNonOptions) const
 }
 
 // CLASS METHODS
+// requires: specTable != 0 && length >= 0
+// ensures: __out == (status == 0)
 bool CommandLine::isValidOptionSpecificationTable(
                                                  const OptionInfo *specTable,
                                                  int               length,
@@ -1393,6 +1403,8 @@ CommandLine::~CommandLine()
 }
 
 // MANIPULATORS
+// requires: rhs.d_state != e_INVALID
+// ensures: (__out == *this) && (d_options == rhs.d_options) && (d_state == e_NOT_PARSED || (d_state == e_PARSED && d_arguments == rhs.d_arguments))
 CommandLine& CommandLine::operator=(const CommandLine& rhs)
 {
     BSLS_ASSERT(d_state != e_INVALID);
@@ -1438,6 +1450,8 @@ int CommandLine::parse(int                argc,
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == (0 <= findName(name))
 bool CommandLine::hasOption(const bsl::string_view& name) const
 {
     return 0 <= findName(name);
@@ -1566,6 +1580,8 @@ OptionType::Enum CommandLine::type(const bsl::string_view& name) const
 }
 
 // BDE_VERIFY pragma: -FABC01  // not in alphabetic order
+// requires: true
+// ensures: true
 bool CommandLine::theBool(const bsl::string_view& name) const
 {
     const int index = findName(name);
@@ -2011,6 +2027,8 @@ bsl::ostream& CommandLine::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == (lhs.isParsed() && rhs.isParsed() && lhs.options() == rhs.options())
 bool balcl::operator==(const CommandLine& lhs, const CommandLine& rhs)
 {
     return lhs.isParsed() && rhs.isParsed() && lhs.options() == rhs.options();
@@ -2042,6 +2060,8 @@ namespace balcl {
                           // ------------------------------
 
 // ACCESSORS
+// requires: true
+// ensures: (__out != -1 ==> EXISTS(d_schema_p->cbegin(), d_schema_p->cend(), itr, (itr->d_name_p == name))) && (__out == -1 ==> FORALL(d_schema_p->cbegin(), d_schema_p->cend(), itr, (itr->d_name_p != name)))
 int CommandLineOptionsHandle::index(const bsl::string_view& name) const
 {
     for (CommandLine_Schema::const_iterator itr  = d_schema_p->cbegin(),

--- a/groups/bal/balcl/balcl_occurrenceinfo.cpp
+++ b/groups/bal/balcl/balcl_occurrenceinfo.cpp
@@ -197,6 +197,8 @@ OccurrenceInfo::~OccurrenceInfo()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == *this) && ((&rhs != this) ==> (d_defaultValue ↦ rhs.d_defaultValue ⋆ d_isRequired ↦ rhs.d_isRequired ⋆ d_isHidden ↦ rhs.d_isHidden))
 OccurrenceInfo& OccurrenceInfo::operator=(const OccurrenceInfo& rhs)
 {
     if (&rhs != this) {
@@ -225,6 +227,8 @@ void OccurrenceInfo::setHidden()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_defaultValue
 const OptionValue& OccurrenceInfo::defaultValue() const
 {
     return d_defaultValue;
@@ -309,6 +313,8 @@ bsl::ostream& OccurrenceInfo::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == true ==> (lhs.occurrenceType() == rhs.occurrenceType() && lhs.hasDefaultValue() == rhs.hasDefaultValue() && (!lhs.hasDefaultValue() || lhs.defaultValue() == rhs.defaultValue()))) && (__out == false ==> !(lhs.occurrenceType() == rhs.occurrenceType() && lhs.hasDefaultValue() == rhs.hasDefaultValue() && (!lhs.hasDefaultValue() || lhs.defaultValue() == rhs.defaultValue())))
 bool balcl::operator==(const OccurrenceInfo& lhs, const OccurrenceInfo& rhs)
 {
     return lhs.occurrenceType()  == rhs.occurrenceType()

--- a/groups/bal/balcl/balcl_option.cpp
+++ b/groups/bal/balcl/balcl_option.cpp
@@ -159,6 +159,8 @@ Option::~Option()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this ⋆ (*this == rhs)
 Option& Option::operator=(const Option& rhs)
 {
     const OptionInfo& optionInfo = rhs;
@@ -417,6 +419,8 @@ bsl::ostream& Option::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == (static_cast<const OptionInfo&>(lhs) == static_cast<const OptionInfo&>(rhs))
 bool balcl::operator==(const Option& lhs, const Option& rhs)
 {
     return static_cast<const OptionInfo&>(lhs)

--- a/groups/bal/balcl/balcl_optioninfo.cpp
+++ b/groups/bal/balcl/balcl_optioninfo.cpp
@@ -13,6 +13,8 @@ namespace BloombergLP {
                      // -----------------
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& balcl::operator<<(bsl::ostream& stream, const OptionInfo& rhs)
 {
     static const char NL = '\n';

--- a/groups/bal/balcl/balcl_optiontype.cpp
+++ b/groups/bal/balcl/balcl_optiontype.cpp
@@ -65,6 +65,8 @@ const Ot::Enum Ot::TypeToEnum<Ot::DateArray>    ::value = Ot::e_DATE_ARRAY;
 const Ot::Enum Ot::TypeToEnum<Ot::TimeArray>    ::value = Ot::e_TIME_ARRAY;
 
 // CLASS METHODS
+// requires: stream ↦ _
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& OptionType::print(bsl::ostream&    stream,
                                 OptionType::Enum value,
                                 int              level,

--- a/groups/bal/balcl/balcl_optionvalue.cpp
+++ b/groups/bal/balcl/balcl_optionvalue.cpp
@@ -58,6 +58,8 @@ void OptionValue::init(OptionType::Enum type)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == (d_value.is<OptionValue_NullOf>() ? d_value.the<OptionValue_NullOf>().type() : static_cast<OptionType::Enum>(d_value.typeIndex()))
 OptionType::Enum OptionValue::type() const
 {
     if (d_value.is<OptionValue_NullOf>()) {

--- a/groups/bal/balcl/balcl_typeinfo.cpp
+++ b/groups/bal/balcl/balcl_typeinfo.cpp
@@ -187,6 +187,8 @@ bsl::ostream& u::operator<<(bsl::ostream& stream, Ordinal position)
 /// for values of the specified `type`.  Return `true` if the parse
 /// succeeds, and `false` otherwise.  Note that on success `value` can be
 /// legitimately cast to a pointer of the type associated with `type`.
+// requires: value != NULL && input.size() >= 0
+// ensures: (type == OptionType::e_STRING ==> __out == true) && (type != OptionType::e_STRING ==> (__out == true || __out == false))
 bool parseValue(void                    *value,
                 const bsl::string_view&  input,
                 OptionType::Enum         type)
@@ -378,6 +380,8 @@ BoolConstraint::~BoolConstraint()
 // BDE_VERIFY pragma: -FABC01  // not in alphabetic order
 
 // ACCESSORS
+// requires: true
+// ensures: __out == OptionType::e_BOOL
 OptionType::Enum BoolConstraint::type() const
 {
     return OptionType::e_BOOL;
@@ -1594,6 +1598,8 @@ TypeInfo::~TypeInfo()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (this != &rhs ==> (d_elemType == rhs.d_elemType && d_linkedVariable_p == rhs.d_linkedVariable_p && d_isOptionalLinkedVariable == rhs.d_isOptionalLinkedVariable && d_constraint_p == rhs.d_constraint_p)) && (__out == *this)
 TypeInfo& TypeInfo::operator=(const TypeInfo& rhs)
 {
     if (this != &rhs) {
@@ -2107,6 +2113,8 @@ void TypeInfo::setLinkedVariable(bsl::optional<bdlt::Time> *variable)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_constraint_p
 bsl::shared_ptr<TypeInfoConstraint> TypeInfo::constraint() const
 {
     return d_constraint_p;
@@ -2171,6 +2179,8 @@ bsl::ostream& TypeInfo::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == (lhs.type() == rhs.type() && lhs.linkedVariable() == rhs.linkedVariable() && lhs.constraint() == rhs.constraint())
 bool balcl::operator==(const TypeInfo& lhs, const TypeInfo& rhs)
 {
     return lhs.type()           == rhs.type()

--- a/groups/bal/baljsn/baljsn_datumutil.cpp
+++ b/groups/bal/baljsn/baljsn_datumutil.cpp
@@ -63,6 +63,8 @@ int encodeValue(baljsn::SimpleFormatter    *formatter,
 /// Decode into the specified `*result` the JSON object in the specified
 /// `*tokenizer`, updating the specified `*errorStream` if any errors are
 /// detected, including if the specified `maxNestedDepth` is exceeded.
+// requires: result != NULL && tokenizer != NULL
+// ensures: __out == -4 || __out == -1 || __out == -2 || __out == -3 || __out == 0
 int decodeObject(bdld::ManagedDatum *result,
                  bsl::ostream       *errorStream,
                  baljsn::Tokenizer  *tokenizer,
@@ -142,6 +144,8 @@ int decodeObject(bdld::ManagedDatum *result,
 /// Decode into the specified `*result` the JSON array in the specified
 /// `*tokenizer`, updating the specified `*errorStream` if any errors are
 /// detected, including if the specified `maxNestedDepth` is exceeded.
+// requires: maxNestedDepth >= 0
+// ensures: __out == -4 || __out == -1 || __out == -2 || __out == 0
 int decodeArray(bdld::ManagedDatum *result,
                 bsl::ostream       *errorStream,
                 baljsn::Tokenizer  *tokenizer,
@@ -214,6 +218,8 @@ int encodeImp(STRING                             *result,
 
 /// Extract into the specified `*result` the current value in the specified
 /// `*tokenizer`.
+// requires: result != NULL && tokenizer != NULL
+// ensures: (__out == 0 || __out == -1)
 int extractValue(bdld::ManagedDatum *result,
                  baljsn::Tokenizer  *tokenizer)
 {
@@ -305,6 +311,8 @@ int decodeValue(bdld::ManagedDatum *result,
 /// unsupported types or values are encountered.  Optionally specify the
 /// `name` to be used for this array.  Return 0 on success, and a negative
 /// value if `datum` cannot be encoded, which should stop further encoding.
+// requires: formatter != 0 && strictTypesCheckStatus != 0 && datum.length() >= 0 && (name == 0 || name != 0)
+// ensures: (__out == 0) ==> (FORALL(0, datum.length(), i, u::encodeValue(formatter, datum[i], strictTypesCheckStatus) == 0)) && (__out != 0) ==> EXISTS(0, datum.length(), i, u::encodeValue(formatter, datum[i], strictTypesCheckStatus) == __out)
 int encodeArray(baljsn::SimpleFormatter    *formatter,
                 const bdld::DatumArrayRef&  datum,
                 int                        *strictTypesCheckStatus,
@@ -340,6 +348,8 @@ int encodeArray(baljsn::SimpleFormatter    *formatter,
 /// unsupported types or values are encountered.Optionally specify the
 /// `name` to be used for this object.  Return 0 on success, and a negative
 /// value if `datum` cannot be encoded, which should stop further encoding.
+// requires: formatter != nullptr && strictTypesCheckStatus != nullptr && (name == nullptr || (*name == bsl::string_view() && formatter->canAddMemberName())) && datum.size() >= 0
+// ensures: __out == result
 int encodeObject(baljsn::SimpleFormatter  *formatter,
                  const bdld::DatumMapRef&  datum,
                  int                      *strictTypesCheckStatus,
@@ -475,6 +485,8 @@ namespace baljsn {
                               // ----------------
 
 // CLASS METHODS
+// requires: result != NULL && jsonBuffer != NULL
+// ensures: __out == 0 || __out == -1 || __out == -2 || __out == -3
 int DatumUtil::decode(bdld::ManagedDatum         *result,
                       bsl::ostream               *errorStream,
                       bsl::streambuf             *jsonBuffer,

--- a/groups/bal/baljsn/baljsn_decoder.cpp
+++ b/groups/bal/baljsn/baljsn_decoder.cpp
@@ -18,6 +18,8 @@ namespace baljsn {
                                // -------------
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: __out == d_logStream
 bsl::ostream& Decoder::logTokenizerError(const char *alternateString)
 {
     const int sts = d_tokenizer.readStatus();

--- a/groups/bal/baljsn/baljsn_encoder.cpp
+++ b/groups/bal/baljsn/baljsn_encoder.cpp
@@ -14,6 +14,8 @@ namespace baljsn {
                         // -----------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == encodeSimpleValue(formatter, base64String, encoderOptions) || __out < 0
 int Encoder_EncodeImplUtil::encodeCharArray(
                                       Formatter                *formatter,
                                       const bsl::vector<char>& value,

--- a/groups/bal/baljsn/baljsn_encoder_testtypes.cpp
+++ b/groups/bal/baljsn/baljsn_encoder_testtypes.cpp
@@ -134,6 +134,8 @@ EncoderTestAddress::~EncoderTestAddress()
 
 // MANIPULATORS
 
+// requires: true
+// ensures: (this != &rhs ==> (d_street ↦ rhs.d_street ⋆ d_city ↦ rhs.d_city ⋆ d_state ↦ rhs.d_state)) && __out == *this
 EncoderTestAddress&
 EncoderTestAddress::operator=(const EncoderTestAddress& rhs)
 {
@@ -266,6 +268,8 @@ EncoderTestChoiceWithAllCategoriesChoice::EncoderTestChoiceWithAllCategoriesChoi
 
 // MANIPULATORS
 
+// requires: true
+// ensures: &__out == this
 EncoderTestChoiceWithAllCategoriesChoice&
 EncoderTestChoiceWithAllCategoriesChoice::operator=(const EncoderTestChoiceWithAllCategoriesChoice& rhs)
 {
@@ -331,6 +335,8 @@ int EncoderTestChoiceWithAllCategoriesChoice::makeSelection(int selectionId)
     return 0;
 }
 
+// requires: name != nullptr && nameLength >= 0 && name[nameLength - 1] == '\0'
+// ensures: (__out == -1 ==> selectionInfo == 0) && (__out != -1 ==> __out == makeSelection(selectionInfo->d_id))
 int EncoderTestChoiceWithAllCategoriesChoice::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -357,6 +363,8 @@ int& EncoderTestChoiceWithAllCategoriesChoice::makeSelection0()
     return d_selection0.object();
 }
 
+// requires: true
+// ensures: (d_selectionId == SELECTION_ID_SELECTION0 ==> (d_selection0.object() ↦ value)) && (d_selectionId != SELECTION_ID_SELECTION0 ==> (d_selectionId == SELECTION_ID_SELECTION0 ⋆ d_selection0.object() ↦ value))
 int& EncoderTestChoiceWithAllCategoriesChoice::makeSelection0(int value)
 {
     if (SELECTION_ID_SELECTION0 == d_selectionId) {
@@ -393,6 +401,8 @@ bsl::ostream& EncoderTestChoiceWithAllCategoriesChoice::print(
 }
 
 
+// requires: true
+// ensures: (d_selectionId == SELECTION_ID_SELECTION0 ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SELECTION0].name()) && (d_selectionId != SELECTION_ID_SELECTION0 ==> __out == "(* UNDEFINED *)")
 const char *EncoderTestChoiceWithAllCategoriesChoice::selectionName() const
 {
     switch (d_selectionId) {
@@ -462,6 +472,8 @@ const bdlat_EnumeratorInfo EncoderTestChoiceWithAllCategoriesEnumeration::ENUMER
 
 // CLASS METHODS
 
+// requires: (number == EncoderTestChoiceWithAllCategoriesEnumeration::A || number == EncoderTestChoiceWithAllCategoriesEnumeration::B) && result != 0
+// ensures: (__out == 0 ==> ((*result ↦ static_cast<EncoderTestChoiceWithAllCategoriesEnumeration::Value>(number)) && (number == EncoderTestChoiceWithAllCategoriesEnumeration::A || number == EncoderTestChoiceWithAllCategoriesEnumeration::B))) && (__out == -1 ==> true)
 int EncoderTestChoiceWithAllCategoriesEnumeration::fromInt(EncoderTestChoiceWithAllCategoriesEnumeration::Value *result, int number)
 {
     switch (number) {
@@ -474,6 +486,8 @@ int EncoderTestChoiceWithAllCategoriesEnumeration::fromInt(EncoderTestChoiceWith
     }
 }
 
+// requires: EXISTS(0, 2, i, (stringLength == EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength && 0 == bsl::memcmp(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength))) || (FORALL(0, 2, i, stringLength != EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength || 0 != bsl::memcmp(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength)) && *result == old_result)
+// ensures: (__out == 0 ==> EXISTS(0, 2, i, (stringLength == EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength && 0 == bsl::memcmp(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength) && (*result == static_cast<EncoderTestChoiceWithAllCategoriesEnumeration::Value>(EncoderTestChoiceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_value))))) && (__out == -1 ==> *result == old_result)
 int EncoderTestChoiceWithAllCategoriesEnumeration::fromString(
         EncoderTestChoiceWithAllCategoriesEnumeration::Value *result,
         const char         *string,
@@ -494,6 +508,8 @@ int EncoderTestChoiceWithAllCategoriesEnumeration::fromString(
     return -1;
 }
 
+// requires: (value == EncoderTestChoiceWithAllCategoriesEnumeration::A) || (value == EncoderTestChoiceWithAllCategoriesEnumeration::B)
+// ensures: (value == A ==> __out == "A") && (value == B ==> __out == "B") && (value != A && value != B ==> __out == 0)
 const char *EncoderTestChoiceWithAllCategoriesEnumeration::toString(EncoderTestChoiceWithAllCategoriesEnumeration::Value value)
 {
     switch (value) {
@@ -717,6 +733,8 @@ EncoderTestSequenceWithAllCategoriesChoice::EncoderTestSequenceWithAllCategories
 
 // MANIPULATORS
 
+// requires: true
+// ensures: (this != &rhs ==> (d_selectionId == rhs.d_selectionId && (d_selectionId == SELECTION_ID_SELECTION0 ==> (d_selection0.object() == rhs.d_selection0.object())))) && (this == &rhs ==> true)
 EncoderTestSequenceWithAllCategoriesChoice&
 EncoderTestSequenceWithAllCategoriesChoice::operator=(const EncoderTestSequenceWithAllCategoriesChoice& rhs)
 {
@@ -767,6 +785,8 @@ void EncoderTestSequenceWithAllCategoriesChoice::reset()
     d_selectionId = SELECTION_ID_UNDEFINED;
 }
 
+// requires: true
+// ensures: (selectionId == SELECTION_ID_SELECTION0 || selectionId == SELECTION_ID_UNDEFINED) ==> __out == 0 && (selectionId != SELECTION_ID_SELECTION0 && selectionId != SELECTION_ID_UNDEFINED) ==> __out == -1
 int EncoderTestSequenceWithAllCategoriesChoice::makeSelection(int selectionId)
 {
     switch (selectionId) {
@@ -782,6 +802,8 @@ int EncoderTestSequenceWithAllCategoriesChoice::makeSelection(int selectionId)
     return 0;
 }
 
+// requires: name != nullptr && nameLength >= 0 && FORALL(0, nameLength, i, name[i] != 0) && name[nameLength] == 0
+// ensures: (__out == -1 ==> lookupSelectionInfo(name, nameLength) == nullptr) && (__out != -1 ==> __out == makeSelection(lookupSelectionInfo(name, nameLength)->d_id))
 int EncoderTestSequenceWithAllCategoriesChoice::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -808,6 +830,8 @@ int& EncoderTestSequenceWithAllCategoriesChoice::makeSelection0()
     return d_selection0.object();
 }
 
+// requires: true
+// ensures: (d_selectionId == SELECTION_ID_SELECTION0 ==> (d_selection0.object() ↦ value)) && (d_selectionId != SELECTION_ID_SELECTION0 ==> (d_selection0.buffer() ↦ value ⋆ d_selectionId == SELECTION_ID_SELECTION0)) && (__out ↦ value)
 int& EncoderTestSequenceWithAllCategoriesChoice::makeSelection0(int value)
 {
     if (SELECTION_ID_SELECTION0 == d_selectionId) {
@@ -844,6 +868,8 @@ bsl::ostream& EncoderTestSequenceWithAllCategoriesChoice::print(
 }
 
 
+// requires: true
+// ensures: (d_selectionId == SELECTION_ID_SELECTION0 ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SELECTION0].name()) && (d_selectionId != SELECTION_ID_SELECTION0 ==> __out == "(* UNDEFINED *)")
 const char *EncoderTestSequenceWithAllCategoriesChoice::selectionName() const
 {
     switch (d_selectionId) {
@@ -913,6 +939,8 @@ const bdlat_EnumeratorInfo EncoderTestSequenceWithAllCategoriesEnumeration::ENUM
 
 // CLASS METHODS
 
+// requires: result != 0 && (number == EncoderTestSequenceWithAllCategoriesEnumeration::A || number == EncoderTestSequenceWithAllCategoriesEnumeration::B)
+// ensures: (__out == 0 ==> ((*result ↦ static_cast<EncoderTestSequenceWithAllCategoriesEnumeration::Value>(number)) && (number == EncoderTestSequenceWithAllCategoriesEnumeration::A || number == EncoderTestSequenceWithAllCategoriesEnumeration::B))) && (__out == -1 ==> (number != EncoderTestSequenceWithAllCategoriesEnumeration::A && number != EncoderTestSequenceWithAllCategoriesEnumeration::B))
 int EncoderTestSequenceWithAllCategoriesEnumeration::fromInt(EncoderTestSequenceWithAllCategoriesEnumeration::Value *result, int number)
 {
     switch (number) {
@@ -925,6 +953,8 @@ int EncoderTestSequenceWithAllCategoriesEnumeration::fromInt(EncoderTestSequence
     }
 }
 
+// requires: true
+// ensures: (__out == 0 ==> EXISTS(0, 2, i, (stringLength == EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_nameLength && 0 == bsl::memcmp(EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_name_p, string, stringLength) && (*result ↦ EncoderTestSequenceWithAllCategoriesEnumeration::ENUMERATOR_INFO_ARRAY[i].d_value)))) && (__out == -1 ==> *result ↦ old_result)
 int EncoderTestSequenceWithAllCategoriesEnumeration::fromString(
         EncoderTestSequenceWithAllCategoriesEnumeration::Value *result,
         const char         *string,
@@ -945,6 +975,8 @@ int EncoderTestSequenceWithAllCategoriesEnumeration::fromString(
     return -1;
 }
 
+// requires: (value == EncoderTestSequenceWithAllCategoriesEnumeration::A) || (value == EncoderTestSequenceWithAllCategoriesEnumeration::B)
+// ensures: (value == EncoderTestSequenceWithAllCategoriesEnumeration::A ==> __out == "A") && (value == EncoderTestSequenceWithAllCategoriesEnumeration::B ==> __out == "B") && (value != EncoderTestSequenceWithAllCategoriesEnumeration::A && value != EncoderTestSequenceWithAllCategoriesEnumeration::B ==> __out == 0)
 const char *EncoderTestSequenceWithAllCategoriesEnumeration::toString(EncoderTestSequenceWithAllCategoriesEnumeration::Value value)
 {
     switch (value) {
@@ -2385,6 +2417,8 @@ EncoderTestChoiceWithAllCategories::EncoderTestChoiceWithAllCategories(
 
 // MANIPULATORS
 
+// requires: true
+// ensures: &__out == this
 EncoderTestChoiceWithAllCategories&
 EncoderTestChoiceWithAllCategories::operator=(const EncoderTestChoiceWithAllCategories& rhs)
 {
@@ -2512,6 +2546,8 @@ int EncoderTestChoiceWithAllCategories::makeSelection(int selectionId)
     return 0;
 }
 
+// requires: name != nullptr && nameLength >= 0 && FORALL(0, nameLength, i, name[i] != 0) && name[nameLength] == 0
+// ensures: (__out == -1 ==> lookupSelectionInfo(name, nameLength) == 0) && (__out != -1 ==> __out == makeSelection(lookupSelectionInfo(name, nameLength)->d_id))
 int EncoderTestChoiceWithAllCategories::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -2682,6 +2718,8 @@ EncoderTestChoiceWithAllCategoriesEnumeration::Value& EncoderTestChoiceWithAllCa
     return d_enumeration.object();
 }
 
+// requires: true
+// ensures: (d_selectionId == SELECTION_ID_ENUMERATION && d_enumeration.object() == value) && (__out == d_enumeration.object())
 EncoderTestChoiceWithAllCategoriesEnumeration::Value& EncoderTestChoiceWithAllCategories::makeEnumeration(EncoderTestChoiceWithAllCategoriesEnumeration::Value value)
 {
     if (SELECTION_ID_ENUMERATION == d_selectionId) {
@@ -2760,6 +2798,8 @@ int& EncoderTestChoiceWithAllCategories::makeSimple()
     return d_simple.object();
 }
 
+// requires: true
+// ensures: (SELECTION_ID_SIMPLE == d_selectionId) ==> (__out == value) && (SELECTION_ID_SIMPLE != d_selectionId) ==> (__out ↦ value)
 int& EncoderTestChoiceWithAllCategories::makeSimple(int value)
 {
     if (SELECTION_ID_SIMPLE == d_selectionId) {
@@ -2817,6 +2857,8 @@ bsl::ostream& EncoderTestChoiceWithAllCategories::print(
 }
 
 
+// requires: true
+// ensures: (__out == SELECTION_INFO_ARRAY[SELECTION_INDEX_CHAR_ARRAY].name(
 const char *EncoderTestChoiceWithAllCategories::selectionName() const
 {
     switch (d_selectionId) {
@@ -2985,6 +3027,8 @@ int EncoderTestDegenerateChoice1::makeSelection(int selectionId)
     return 0;
 }
 
+// requires: true
+// ensures: (__out == -1 ==> lookupSelectionInfo(name, nameLength) == 0) && (__out != -1 ==> __out == makeSelection(lookupSelectionInfo(name, nameLength)->d_id))
 int EncoderTestDegenerateChoice1::makeSelection(const char *name, int nameLength)
 {
     const bdlat_SelectionInfo *selectionInfo =
@@ -3065,6 +3109,8 @@ bsl::ostream& EncoderTestDegenerateChoice1::print(
 }
 
 
+// requires: true
+// ensures: (d_selectionId == SELECTION_ID_SEQUENCE ==> __out == SELECTION_INFO_ARRAY[SELECTION_INDEX_SEQUENCE].name()) && (d_selectionId != SELECTION_ID_SEQUENCE ==> __out == "(* UNDEFINED *)")
 const char *EncoderTestDegenerateChoice1::selectionName() const
 {
     switch (d_selectionId) {
@@ -3183,6 +3229,8 @@ EncoderTestEmployee::~EncoderTestEmployee()
 
 // MANIPULATORS
 
+// requires: true
+// ensures: (this != &rhs ==> (d_name ↦ rhs.d_name ⋆ d_homeAddress ↦ rhs.d_homeAddress ⋆ d_age ↦ rhs.d_age)) && (__out == *this)
 EncoderTestEmployee&
 EncoderTestEmployee::operator=(const EncoderTestEmployee& rhs)
 {
@@ -3421,6 +3469,8 @@ EncoderTestSequenceWithAllCategories::~EncoderTestSequenceWithAllCategories()
 
 // MANIPULATORS
 
+// requires: true
+// ensures: __out == *this && (this != &rhs ==> (d_charArray == rhs.d_charArray ⋆ d_aString == rhs.d_aString ⋆ d_array == rhs.d_array ⋆ d_choice == rhs.d_choice ⋆ d_customizedType == rhs.d_customizedType ⋆ d_enumeration == rhs.d_enumeration ⋆ d_nullableValue == rhs.d_nullableValue ⋆ d_sequence == rhs.d_sequence ⋆ d_simple == rhs.d_simple))
 EncoderTestSequenceWithAllCategories&
 EncoderTestSequenceWithAllCategories::operator=(const EncoderTestSequenceWithAllCategories& rhs)
 {

--- a/groups/bal/baljsn/baljsn_parserutil.cpp
+++ b/groups/bal/baljsn/baljsn_parserutil.cpp
@@ -147,6 +147,8 @@ namespace baljsn {
                              // -----------------
 
 // CLASS METHODS
+// requires: value != nullptr && data.size() >= 0
+// ensures: __out == bdljsn::StringUtil::readUnquotedString(value, data, bdljsn::StringUtil::e_ACCEPT_CAPITAL_UNICODE_ESCAPE)
 int ParserUtil::getUnquotedString(bsl::string             *value,
                                   const bsl::string_view&  data)
 {

--- a/groups/bal/ball/ball_administration.cpp
+++ b/groups/bal/ball/ball_administration.cpp
@@ -18,6 +18,8 @@ namespace ball {
                       // ---------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (__out == 0) || (__out == 1)
 int Administration::addCategory(const char *categoryName,
                                 int         recordLevel,
                                 int         passLevel,

--- a/groups/bal/ball/ball_asyncfileobserver.cpp
+++ b/groups/bal/ball/ball_asyncfileobserver.cpp
@@ -135,6 +135,8 @@ void setPublicationThreadAttributes(bslmt::ThreadAttributes *attributes)
 /// `stopThread` to signal to the publication thread to stop.  Note also that
 /// this is not simply a constant because such a constant would require a
 /// constructor be called before `main` in C++03.
+// requires: true
+// ensures: true
 AsyncFileObserver_Record createStopRecord()
 {
     AsyncFileObserver_Record record;
@@ -144,6 +146,8 @@ AsyncFileObserver_Record createStopRecord()
 /// Return `true` if the specified `record` was created by
 /// `createStopRecord` and `false` otherwise.  Note that this record is used
 /// by `stopThread` to signal to the publication thread to stop.
+// requires: true
+// ensures: (__out == true ==> record.d_record.get() == 0) && (__out == false ==> record.d_record.get() != 0)
 bool isStopRecord(const AsyncFileObserver_Record& record)
 {
     return 0 == record.d_record.get();

--- a/groups/bal/ball/ball_attribute.cpp
+++ b/groups/bal/ball/ball_attribute.cpp
@@ -53,6 +53,8 @@ namespace ball {
                         // ---------------
 
 // CLASS METHODS
+// requires: size > 0
+// ensures: (attribute.d_hashValue == __out) && (0 <= __out && __out < size)
 int Attribute::hash(const Attribute& attribute, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -71,6 +73,8 @@ int Attribute::hash(const Attribute& attribute, int size)
 }
 
 // ACCESSORS
+// requires: stream ↦ _
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& Attribute::print(bsl::ostream& stream,
                                int           level,
                                int           spacesPerLevel) const
@@ -107,6 +111,8 @@ bsl::ostream& Attribute::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == output
 bsl::ostream& ball::operator<<(bsl::ostream&    output,
                                const Attribute& attribute)
 {

--- a/groups/bal/ball/ball_attributecollectorregistry.cpp
+++ b/groups/bal/ball/ball_attributecollectorregistry.cpp
@@ -15,6 +15,8 @@ namespace ball {
                          // --------------------------------
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == 0 || __out == 1)
 int AttributeCollectorRegistry::addCollector(const Collector&        collector,
                                              const bsl::string_view& name)
 {

--- a/groups/bal/ball/ball_attributecontainerlist.cpp
+++ b/groups/bal/ball/ball_attributecontainerlist.cpp
@@ -44,6 +44,8 @@ AttributeContainerList::AttributeContainerList(
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this
 AttributeContainerList& AttributeContainerList::operator=(
                                              const AttributeContainerList& rhs)
 {
@@ -154,6 +156,8 @@ void AttributeContainerList::removeAllAndRelease()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == true || __out == false
 bool AttributeContainerList::hasValue(const Attribute& value) const
 {
     Node *node = d_head_p;

--- a/groups/bal/ball/ball_attributecontext.cpp
+++ b/groups/bal/ball/ball_attributecontext.cpp
@@ -65,6 +65,8 @@ namespace ball {
                // ------------------------------------------
 
 // MANIPULATORS
+// requires: FORALL(0, RuleSet::e_MAX_NUM_RULES, i, (relevantRulesMask & (1 << i)) != 0 ==> rules.getRuleById(i) != nullptr)
+// ensures: __out == d_resultMask
 RuleSet::MaskType
 AttributeContext_RuleEvaluationCache::update(
                                bsls::Types::Int64            sequenceNumber,
@@ -106,6 +108,8 @@ AttributeContext_RuleEvaluationCache::update(
 }
 
 // ACCESSORS
+// requires: stream ↦ _
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream&
 AttributeContext_RuleEvaluationCache::print(bsl::ostream& stream,
                                             int           level,
@@ -183,6 +187,8 @@ AttributeContext::~AttributeContext()
 }
 
 // PRIVATE CLASS METHODS
+// requires: true
+// ensures: __out == &s_contextKey
 const bslmt::ThreadUtil::Key& AttributeContext::contextKey()
 {
     static bslmt::ThreadUtil::Key s_contextKey;
@@ -213,6 +219,8 @@ void AttributeContext::removeContext(void *arg)
 }
 
 // CLASS METHODS
+// requires: true
+// ensures: __out != 0
 AttributeContext *AttributeContext::getContext()
 {
 #ifdef BSLMT_THREAD_LOCAL_VARIABLE
@@ -308,6 +316,8 @@ void AttributeContext::visitAttributes(
 }
 
 // ACCESSORS
+// requires: category != nullptr
+// ensures: (__out == false ==> category->relevantRuleMask() == 0) && (__out == true ==> (category->relevantRuleMask() & d_ruleCache_p.knownActiveRules()) != 0 || (category->relevantRuleMask() & d_ruleCache_p.update(s_categoryManager_p->ruleSetSequenceNumber(), category->relevantRuleMask(), s_categoryManager_p->ruleSet(), d_containerList)) != 0)
 bool AttributeContext::hasRelevantActiveRules(const Category *category) const
 {
     BSLS_ASSERT(category);
@@ -422,6 +432,8 @@ AttributeContext::determineThresholdLevels(ThresholdAggregate *levels,
 }
 
 // ACCESSORS
+// requires: stream ↦ _
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& AttributeContext::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const

--- a/groups/bal/ball/ball_broadcastobserver.cpp
+++ b/groups/bal/ball/ball_broadcastobserver.cpp
@@ -26,6 +26,8 @@ BroadcastObserver::~BroadcastObserver()
 }
 
 // MANIPULATORS
+// requires: !observerName.empty()
+// ensures: (__out == 1 ==> d_observers.find(observerName) == d_observers.end()) && (__out == 0 ==> d_observers.find(observerName) == d_observers.end())
 int BroadcastObserver::deregisterObserver(const bsl::string_view& observerName)
 {
     bslmt::WriteLockGuard<bslmt::ReaderWriterMutex> guard(&d_rwMutex);
@@ -109,6 +111,8 @@ void BroadcastObserver::releaseRecords()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (d_observers.find(observerName) == d_observers.end() ==> __out.use_count() == 0) && (d_observers.find(observerName) != d_observers.end() ==> __out.use_count() > 0)
 bsl::shared_ptr<const Observer>
 BroadcastObserver::findObserver(const bsl::string_view& observerName) const
 {

--- a/groups/bal/ball/ball_category.cpp
+++ b/groups/bal/ball/ball_category.cpp
@@ -105,6 +105,8 @@ void Category::updateThresholdForHolders()
 }
 
 // MANIPULATORS
+// requires: Category::areValidThresholdLevels(recordLevel, passLevel, triggerLevel, triggerAllLevel)
+// ensures: (__out == 0 ==> (d_thresholdLevels ↦ ThresholdAggregateUtil::pack(ThresholdAggregate(recordLevel, passLevel, triggerLevel, triggerAllLevel)) ⋆ d_threshold ↦ ThresholdAggregate::maxLevel(recordLevel, passLevel, triggerLevel, triggerAllLevel))) && (__out == -1 ==> true)
 int Category::setLevels(int recordLevel,
                         int passLevel,
                         int triggerLevel,

--- a/groups/bal/ball/ball_categorymanager.cpp
+++ b/groups/bal/ball/ball_categorymanager.cpp
@@ -147,6 +147,8 @@ void CategoryProctor::release()
                     // ---------------------
 
 // PRIVATE MANIPULATORS
+// requires: categoryName != NULL
+// ensures: __out != NULL
 Category *CategoryManager::addNewCategory(const char *categoryName,
                                           int         recordLevel,
                                           int         passLevel,
@@ -491,6 +493,8 @@ void CategoryManager::removeAllRules()
 // BDE_VERIFY pragma: pop
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == 0 ==> d_registry.find(categoryName) == d_registry.end()) && (__out != 0 ==> (d_registry.find(categoryName) != d_registry.end() && __out == d_categories[d_registry.find(categoryName)->second]))
 const Category *CategoryManager::lookupCategory(const char *categoryName) const
 {
     bslmt::ReadLockGuard<bslmt::ReaderWriterLock> registryGuard(

--- a/groups/bal/ball/ball_context.cpp
+++ b/groups/bal/ball/ball_context.cpp
@@ -42,6 +42,8 @@ bool Context::isValid(Transmission::Cause transmissionCause,
 }
 
 // ACCESSORS
+// requires: stream.good() && (stream ↦ _)
+// ensures: __out == stream && (__out.good() && (__out ↦ _))
 bsl::ostream& Context::print(bsl::ostream& stream,
                              int           level,
                              int           spacesPerLevel) const

--- a/groups/bal/ball/ball_defaultattributecontainer.cpp
+++ b/groups/bal/ball/ball_defaultattributecontainer.cpp
@@ -21,6 +21,8 @@ int DefaultAttributeContainer::AttributeHash::s_hashtableSize = INT_MAX;
 int DefaultAttributeContainer::s_initialSize = 8;
 
 // MANIPULATORS
+// requires: true
+// ensures: (this != &rhs ==> (__out == *this && __out == rhs)) && (this == &rhs ==> __out == *this)
 DefaultAttributeContainer&
 DefaultAttributeContainer::operator=(const DefaultAttributeContainer& rhs)
 {
@@ -36,6 +38,8 @@ DefaultAttributeContainer::operator=(const DefaultAttributeContainer& rhs)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == true ==> d_attributeSet.find(value) != d_attributeSet.end()) && (__out == false ==> d_attributeSet.find(value) == d_attributeSet.end())
 bool DefaultAttributeContainer::hasValue(const Attribute& value) const
 {
     return d_attributeSet.find(value) != d_attributeSet.end();
@@ -66,6 +70,8 @@ void DefaultAttributeContainer::visitAttributes(
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: lhs.numAttributes() == rhs.numAttributes() && FORALL(lhs.begin(), lhs.end(), attr, rhs.hasValue(attr))
+// ensures: (lhs.numAttributes() == rhs.numAttributes() && lhs.begin() == lhs.end()) || (lhs.numAttributes() == rhs.numAttributes() && std::all_of(lhs.begin(), lhs.end(), [&rhs](const auto& attr) { return rhs.hasValue(attr); })) == __out
 bool ball::operator==(const DefaultAttributeContainer& lhs,
                       const DefaultAttributeContainer& rhs)
 {

--- a/groups/bal/ball/ball_fileobserver.cpp
+++ b/groups/bal/ball/ball_fileobserver.cpp
@@ -257,6 +257,8 @@ void FileObserver::setStdoutThreshold(Severity::Level stdoutThreshold)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out != 0
 bslma::Allocator *FileObserver::allocator() const
 {
     return d_stdoutLongFormat.get_allocator().mechanism();

--- a/groups/bal/ball/ball_fileobserver2.cpp
+++ b/groups/bal/ball/ball_fileobserver2.cpp
@@ -110,6 +110,8 @@ enum {
 };
 
 /// Return the system-specific error code.
+// requires: true
+// ensures: __out >= 0
 static int getErrorCode(void)
 {
 #ifdef BSLS_PLATFORM_OS_WINDOWS
@@ -248,6 +250,7 @@ static bool hasEscapePattern(const char *logFilePattern)
 /// Open a file stream referred to by the specified `stream` for the file
 /// with the specified `filename` in append mode.  Return 0 on success, and
 /// a non-zero value otherwise.
+// ensures: (__out == 0 ==> (stream->rdbuf() != nullptr && FileUtil::exists(filename))) && (__out == -1 ==> (stream->rdbuf() == nullptr || FileUtil::exists(filename) == false))
 static int openLogFile(bsl::ostream *stream, const char *filename)
 {
     BSLS_ASSERT(stream);
@@ -312,6 +315,8 @@ static int openLogFile(bsl::ostream *stream, const char *filename)
 /// Return `true` if the specified `a` and `b` times are within 10% of the
 /// specified `interval` from each other, and `false` otherwise.  The
 /// behavior is undefined unless `0 <= interval.totalMilliseconds()`.
+// requires: 0 <= interval.totalMilliseconds()
+// ensures: (__out == true ==> abs((a - b).totalMilliseconds()) < (interval.totalMilliseconds() / 10)) && (__out == false ==> abs((a - b).totalMilliseconds()) >= (interval.totalMilliseconds() / 10))
 bool fuzzyEqual(const bdlt::Datetime&         a,
                 const bdlt::Datetime&         b,
                 const bdlt::DatetimeInterval& interval)
@@ -337,6 +342,8 @@ bool fuzzyEqual(const bdlt::Datetime&         a,
 /// interpreted as local time value, and as UTC time value otherwise.
 /// `fileCreationTimeUtc` must be a UTC time value.  The behavior is
 /// undefined unless `0 <= interval.totalMilliseconds()`.
+// requires: 0 < interval.totalMilliseconds()
+// ensures: __out == fileCreationTimeUtc + interval || __out > fileCreationTimeUtc
 static bdlt::Datetime computeNextRotationTime(
                    const bdlt::Datetime&         referenceStartTime,
                    bool                          referenceStartTimeInLocalTime,
@@ -847,6 +854,8 @@ void FileObserver2::setOnFileRotationCallback(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_logStreamBuf.isOpened()
 bool FileObserver2::isFileLoggingEnabled() const
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);

--- a/groups/bal/ball/ball_log.cpp
+++ b/groups/bal/ball/ball_log.cpp
@@ -37,6 +37,8 @@ namespace ball {
                          // ----------
 
 // CLASS METHODS
+// requires: buffer != NULL && numBytes > 0
+// ensures: (__out == -1) || (__out >= 0 && __out < (signed)numBytes)
 int Log::format(char *buffer, bsl::size_t numBytes, const char *format, ...)
 {
     bsl::va_list args;

--- a/groups/bal/ball/ball_loggercategoryutil.cpp
+++ b/groups/bal/ball/ball_loggercategoryutil.cpp
@@ -71,6 +71,8 @@ static void accumulateLongerPrefixCategory(const Category **result,
                             // -------------------------
 
 // CLASS METHODS
+// requires: loggerManager != 0 && categoryName != 0
+// ensures: (__out == 0 ==> (loggerManager->lookupCategory(categoryName) != 0 || loggerManager->thresholdLevelsForNewCategory(nullptr, categoryName) != 0)) && (__out != 0 ==> true)
 Category *LoggerCategoryUtil::addCategoryHierarchically(
                                                   LoggerManager *loggerManager,
                                                   const char    *categoryName)

--- a/groups/bal/ball/ball_loggermanager.cpp
+++ b/groups/bal/ball/ball_loggermanager.cpp
@@ -234,6 +234,8 @@ void bufferPoolDeleter(void *buffer, void *pool)
 /// result in the specified `filteredNameBuffer`, and return the address of
 /// the non-modifiable data of `filteredNameBuffer`; return `originalName`
 /// otherwise (i.e., if `nameFilter` is null).
+// requires: filteredNameBuffer != nullptr && originalName != nullptr
+// ensures: (nameFilter != nullptr ==> __out == filteredNameBuffer->c_str()) && (nameFilter == nullptr ==> __out == originalName)
 const char *filterName(
    bsl::string                                             *filteredNameBuffer,
    const char                                              *originalName,
@@ -434,6 +436,8 @@ Logger::~Logger()
 }
 
 // PRIVATE MANIPULATORS
+// requires: fileName != nullptr && lineNumber >= 0
+// ensures: __out != nullptr
 bsl::shared_ptr<Record> Logger::getRecordPtr(const char *fileName,
                                              int         lineNumber)
 {
@@ -602,6 +606,8 @@ void Logger::publish(const bsl::shared_ptr<Record>& record,
 }
 
 // MANIPULATORS
+// requires: fileName != nullptr && fileName[0] != '\0' && lineNumber >= 0
+// ensures: __out != 0
 Record *Logger::getRecord(const char *fileName, int lineNumber)
 {
    // The shared pointer returned by 'getRecordPtr' is reconstituted in the
@@ -1605,6 +1611,8 @@ void LoggerManager::setDefaultThresholdLevelsCallback(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == true ==> (category->relevantRuleMask() && ThresholdAggregate::maxLevel(levels) >= severity) || (!category->relevantRuleMask() && category->maxLevel() >= severity)) && (__out == false ==> (category->relevantRuleMask() && ThresholdAggregate::maxLevel(levels) < severity) || (!category->relevantRuleMask() && category->maxLevel() < severity))
 bool LoggerManager::isCategoryEnabled(const Category *category,
                                       int             severity) const
 {

--- a/groups/bal/ball/ball_loggermanagerconfiguration.cpp
+++ b/groups/bal/ball/ball_loggermanagerconfiguration.cpp
@@ -19,6 +19,8 @@ namespace ball {
                     // --------------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == LoggerManagerDefaults::isValidDefaultRecordBufferSize(numBytes)
 bool
 LoggerManagerConfiguration::isValidDefaultRecordBufferSize(int numBytes)
 {
@@ -84,6 +86,8 @@ LoggerManagerConfiguration::LoggerManagerConfiguration(
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this
 LoggerManagerConfiguration&
 LoggerManagerConfiguration::operator=(const LoggerManagerConfiguration& rhs)
 {
@@ -160,6 +164,8 @@ void LoggerManagerConfiguration::setTriggerMarkers(TriggerMarkers value)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_defaults
 const LoggerManagerDefaults& LoggerManagerConfiguration::defaults() const
 {
     return d_defaults;
@@ -281,6 +287,8 @@ LoggerManagerConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == (lhs.d_defaults == rhs.d_defaults && (bool)lhs.d_userPopulator == (bool)rhs.d_userPopulator && (bool)lhs.d_categoryNameFilter == (bool)rhs.d_categoryNameFilter && (bool)lhs.d_defaultThresholdsCb == (bool)rhs.d_defaultThresholdsCb && lhs.d_logOrder == rhs.d_logOrder && lhs.d_triggerMarkers == rhs.d_triggerMarkers))
 bool ball::operator==(const ball::LoggerManagerConfiguration& lhs,
                       const ball::LoggerManagerConfiguration& rhs)
 {   // TBD: Note that we are casting the three 'bsl::function' data members to

--- a/groups/bal/ball/ball_loggermanagerdefaults.cpp
+++ b/groups/bal/ball/ball_loggermanagerdefaults.cpp
@@ -30,6 +30,8 @@ namespace ball {
                          // ---------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (__out == true ==> numBytes > 0) && (__out == false ==> numBytes <= 0)
 bool LoggerManagerDefaults::isValidDefaultRecordBufferSize(int numBytes)
 {
     return 0 < numBytes;
@@ -119,6 +121,8 @@ LoggerManagerDefaults::~LoggerManagerDefaults()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this ⋆ d_recordBufferSize ↦ rhs.d_recordBufferSize ⋆ d_loggerBufferSize ↦ rhs.d_loggerBufferSize ⋆ d_defaultRecordLevel ↦ rhs.d_defaultRecordLevel ⋆ d_defaultPassLevel ↦ rhs.d_defaultPassLevel ⋆ d_defaultTriggerLevel ↦ rhs.d_defaultTriggerLevel ⋆ d_defaultTriggerAllLevel ↦ rhs.d_defaultTriggerAllLevel
 LoggerManagerDefaults& LoggerManagerDefaults::operator=(
                                               const LoggerManagerDefaults& rhs)
 {
@@ -182,6 +186,8 @@ int LoggerManagerDefaults::setDefaultThresholdLevelsIfValid(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_recordBufferSize
 int LoggerManagerDefaults::defaultRecordBufferSize() const
 {
     return d_recordBufferSize;
@@ -255,6 +261,8 @@ LoggerManagerDefaults::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == true) ==> (lhs.d_recordBufferSize == rhs.d_recordBufferSize && lhs.d_loggerBufferSize == rhs.d_loggerBufferSize && lhs.d_defaultRecordLevel == rhs.d_defaultRecordLevel && lhs.d_defaultPassLevel == rhs.d_defaultPassLevel && lhs.d_defaultTriggerLevel == rhs.d_defaultTriggerLevel && lhs.d_defaultTriggerAllLevel == rhs.d_defaultTriggerAllLevel) && (__out == false) ==> !(lhs.d_recordBufferSize == rhs.d_recordBufferSize && lhs.d_loggerBufferSize == rhs.d_loggerBufferSize && lhs.d_defaultRecordLevel == rhs.d_defaultRecordLevel && lhs.d_defaultPassLevel == rhs.d_defaultPassLevel && lhs.d_defaultTriggerLevel == rhs.d_defaultTriggerLevel && lhs.d_defaultTriggerAllLevel == rhs.d_defaultTriggerAllLevel)
 bool ball::operator==(const LoggerManagerDefaults& lhs,
                       const LoggerManagerDefaults& rhs)
 {

--- a/groups/bal/ball/ball_managedattribute.cpp
+++ b/groups/bal/ball/ball_managedattribute.cpp
@@ -16,6 +16,8 @@ namespace ball {
                         // ----------------------
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream && (d_attribute.print(stream, level, spacesPerLevel) == stream)
 bsl::ostream& ManagedAttribute::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const
@@ -27,6 +29,8 @@ bsl::ostream& ManagedAttribute::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == output
 bsl::ostream& ball::operator<<(bsl::ostream&                 output,
                                const ball::ManagedAttribute& attribute)
 {

--- a/groups/bal/ball/ball_managedattributeset.cpp
+++ b/groups/bal/ball/ball_managedattributeset.cpp
@@ -27,6 +27,8 @@ int ManagedAttributeSet::AttributeHash::s_hashtableSize = INT_MAX;
 int ManagedAttributeSet::s_initialSize = 8;
 
 // CLASS METHODS
+// requires: 0 < size
+// ensures: __out == (hashValue % size)
 int ManagedAttributeSet::hash(const ManagedAttributeSet& set, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -40,6 +42,8 @@ int ManagedAttributeSet::hash(const ManagedAttributeSet& set, int size)
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (this != &rhs ==> d_attributeSet == rhs.d_attributeSet) && (__out == *this)
 ManagedAttributeSet&
 ManagedAttributeSet::operator=(const ManagedAttributeSet& rhs)
 {
@@ -50,6 +54,8 @@ ManagedAttributeSet::operator=(const ManagedAttributeSet& rhs)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == true) || (__out == false)
 bool
 ManagedAttributeSet::evaluate(const AttributeContainerList& containerList)
                                                                           const
@@ -79,6 +85,8 @@ ManagedAttributeSet::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == true ==> (lhs.numAttributes() == rhs.numAttributes() && FORALL(0, lhs.numAttributes(), i, rhs.isMember(*(lhs.begin() + i))))) && (__out == false ==> (lhs.numAttributes() != rhs.numAttributes() || EXISTS(0, lhs.numAttributes(), i, !rhs.isMember(*(lhs.begin() + i)))))
 bool ball::operator==(const ManagedAttributeSet& lhs,
                       const ManagedAttributeSet& rhs)
 {

--- a/groups/bal/ball/ball_patternutil.cpp
+++ b/groups/bal/ball/ball_patternutil.cpp
@@ -41,6 +41,8 @@ namespace ball {
                         // ------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 bool PatternUtil::isValidPattern(const char *pattern)
 {
     while (*pattern) {

--- a/groups/bal/ball/ball_record.cpp
+++ b/groups/bal/ball/ball_record.cpp
@@ -23,6 +23,8 @@ namespace ball {
                            // ------------
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& Record::print(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel) const

--- a/groups/bal/ball/ball_recordattributes.cpp
+++ b/groups/bal/ball/ball_recordattributes.cpp
@@ -103,6 +103,8 @@ RecordAttributes& RecordAttributes::operator=(const RecordAttributes& rhs)
 }
 
 // ACCESSORS
+// requires: d_messageStreamBuf.data() != 0
+// ensures: __out != 0
 const char *RecordAttributes::message() const
 {
     const bsl::size_t length = d_messageStreamBuf.length();
@@ -254,6 +256,8 @@ bsl::ostream& RecordAttributes::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == (lhs.d_timestamp == rhs.d_timestamp && lhs.d_processID == rhs.d_processID && lhs.d_threadID == rhs.d_threadID && lhs.d_severity == rhs.d_severity && lhs.d_lineNumber == rhs.d_lineNumber && lhs.d_fileName == rhs.d_fileName && lhs.d_category == rhs.d_category && lhs.messageRef() == rhs.messageRef())
 bool ball::operator==(const RecordAttributes& lhs, const RecordAttributes& rhs)
 {
     return lhs.d_timestamp  == rhs.d_timestamp

--- a/groups/bal/ball/ball_recordjsonformatter.cpp
+++ b/groups/bal/ball/ball_recordjsonformatter.cpp
@@ -287,6 +287,8 @@ const char *const k_VALUE_FILE           = "file";
 const char *const k_VALUE_FULL           = "full";
 
 /// Return the default record JSON format specification.
+// requires: true
+// ensures: true
 bsl::string_view getDefaultFormat()
 {
     const  int  k_BUFFER_SIZE = 256;
@@ -1137,6 +1139,8 @@ int ThreadIdFormatter::parse(bdld::DatumMapRef v)
                    // -------------------------
 
 // MANIPULATORS
+// requires: (EXISTS(0, v.size(), i, !v[i].value().isString()) ==> res_tmp == -1) && (FORALL(0, v.size(), i, v[i].value().isString()) ==> res_tmp == 0)
+// ensures: (__out == -1 ==> EXISTS(0, v.size(), i, !v[i].value().isString())) && (__out == 0 ==> FORALL(0, v.size(), i, v[i].value().isString()))
 int FixedFieldFormatter::parse(bdld::DatumMapRef v)
 {
     for (bdld::Datum::SizeType i = 0; i < v.size(); ++ i) {
@@ -1151,6 +1155,8 @@ int FixedFieldFormatter::parse(bdld::DatumMapRef v)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out ↦ d_name
 inline
 const bsl::string& FixedFieldFormatter::name() const
 {
@@ -1354,6 +1360,8 @@ int AttributeFormatter::parse(bdld::DatumMapRef v)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out ↦ d_key
 const bsl::string& AttributeFormatter::key() const
 {
     return d_key;
@@ -1422,6 +1430,8 @@ int AttributesFormatter::parse(bdld::DatumMapRef v)
                        // -----------------
 
 // CLASS METHODS
+// requires: SEPEXISTS(0, 9, i, v == k_KEY_TIMESTAMP || v == k_KEY_PROCESS_ID || v == k_KEY_THREAD_ID || v == k_KEY_SEVERITY || v == k_KEY_FILE || v == k_KEY_LINE || v == k_KEY_CATEGORY || v == k_KEY_MESSAGE || v == k_KEY_ATTRIBUTES)
+// ensures: __out != 0 && (__out ↦ _)
 RecordJsonFormatter_FieldFormatter *
 DatumParser::make(const bslstl::StringRef& v)
 {
@@ -1614,6 +1624,8 @@ RecordJsonFormatter::~RecordJsonFormatter()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (format.empty() ==> __out == -1) && (!format.empty() ==> __out == 0 || __out != 0)
 int RecordJsonFormatter::setFormat(const bsl::string_view& format)
 {
     if (format.empty()) {

--- a/groups/bal/ball/ball_recordstringformatter.cpp
+++ b/groups/bal/ball/ball_recordstringformatter.cpp
@@ -1296,6 +1296,8 @@ void RecordStringFormatter::operator()(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == true ==> (bsl::strcmp(lhs.format(), rhs.format()) == 0 && lhs.timestampOffset() == rhs.timestampOffset())) && (__out == false ==> (bsl::strcmp(lhs.format(), rhs.format()) != 0 || lhs.timestampOffset() != rhs.timestampOffset()))
 bool ball::operator==(const RecordStringFormatter& lhs,
                       const RecordStringFormatter& rhs)
 {

--- a/groups/bal/ball/ball_rule.cpp
+++ b/groups/bal/ball/ball_rule.cpp
@@ -23,6 +23,8 @@ namespace ball {
                          // ----------
 
 // CLASS METHODS
+// requires: 0 < size && rule.d_attributeSet != nullptr && rule.d_thresholds != nullptr && rule.d_pattern != ""
+// ensures: (rule.d_hashValue < 0 || rule.d_hashSize != size) ==> (rule.d_hashValue == ((ManagedAttributeSet::hash(rule.d_attributeSet, size) + ThresholdAggregate::hash(rule.d_thresholds, size) + bdlb::HashUtil::hash0(rule.d_pattern.c_str(), size)) % size) ⋆ rule.d_hashSize == size) ⋆ __out == rule.d_hashValue
 int Rule::hash(const Rule& rule, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -42,6 +44,8 @@ int Rule::hash(const Rule& rule, int size)
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out.d_pattern ↦ rhs.d_pattern ⋆ __out.d_thresholds ↦ rhs.d_thresholds ⋆ __out.d_attributeSet ↦ rhs.d_attributeSet ⋆ __out.d_hashValue ↦ rhs.d_hashValue ⋆ __out.d_hashSize ↦ rhs.d_hashSize
 Rule& Rule::operator=(const Rule& rhs)
 {
     d_pattern      = rhs.d_pattern,
@@ -53,6 +57,8 @@ Rule& Rule::operator=(const Rule& rhs)
 }
 
 // ACCESSORS
+// requires: stream ↦ _ && level >= 0 && spacesPerLevel >= 0
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream& Rule::print(bsl::ostream& stream,
                           int           level,
                           int           spacesPerLevel) const

--- a/groups/bal/ball/ball_ruleset.cpp
+++ b/groups/bal/ball/ball_ruleset.cpp
@@ -80,6 +80,8 @@ RuleSet::RuleSet(const RuleSet& original, bslma::Allocator *basicAllocator)
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == -1 || __out == -2 || __out >= 0)
 int RuleSet::addRule(const Rule& value)
 {
     if (d_ruleHashtable.find(value) != d_ruleHashtable.end()) {
@@ -182,6 +184,8 @@ RuleSet& RuleSet::operator=(const RuleSet& rhs)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == -1 ==> d_ruleHashtable.find(value) == d_ruleHashtable.end()) && (__out != -1 ==> (0 <= __out && __out < d_ruleAddresses.size() && d_ruleAddresses[__out] == &*d_ruleHashtable.find(value)))
 int RuleSet::ruleId(const Rule& value) const
 {
     HashtableType::const_iterator iter = d_ruleHashtable.find(value);
@@ -222,6 +226,8 @@ bsl::ostream& RuleSet::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: lhs.numRules() == rhs.numRules()
+// ensures: (lhs.numRules() == rhs.numRules() && __out == true) || (lhs.numRules() != rhs.numRules() || __out == false)
 bool ball::operator==(const RuleSet& lhs, const RuleSet& rhs)
 {
     if (lhs.numRules() != rhs.numRules()) {

--- a/groups/bal/ball/ball_scopedattribute.cpp
+++ b/groups/bal/ball/ball_scopedattribute.cpp
@@ -21,6 +21,8 @@ ScopedAttribute_Container::~ScopedAttribute_Container()
 }
 
 // ACCESSORS
+// requires: stream ↦ _ && level >= 0 && spacesPerLevel >= 0
+// ensures: (__out == stream) && (stream ↦ _)
 bsl::ostream&
 ScopedAttribute_Container::print(bsl::ostream& stream,
                                  int           level,

--- a/groups/bal/ball/ball_severity.cpp
+++ b/groups/bal/ball/ball_severity.cpp
@@ -22,6 +22,8 @@ void Severity::print(bsl::ostream& stream, Severity::Level value)
 }
 
 // CLASS METHODS
+// requires: level != NULL && string != NULL
+// ensures: __out == 0 || __out == -1
 int Severity::fromAscii(Severity::Level *level,
                         const char      *string,
                         int              stringLength)

--- a/groups/bal/ball/ball_severityutil.cpp
+++ b/groups/bal/ball/ball_severityutil.cpp
@@ -18,6 +18,8 @@ namespace ball {
                         // -------------------
 
 // CLASS METHODS
+// requires: level != nullptr && name != nullptr
+// ensures: (__out == BALL_SUCCESS ==> (bdlb::String::areEqualCaseless("OFF", 3, name) || bdlb::String::areEqualCaseless("FATAL", 5, name) || bdlb::String::areEqualCaseless("ERROR", 5, name) || bdlb::String::areEqualCaseless("WARN", 4, name) || bdlb::String::areEqualCaseless("INFO", 4, name) || bdlb::String::areEqualCaseless("DEBUG", 5, name) || bdlb::String::areEqualCaseless("TRACE", 5, name))) && (__out == BALL_FAILURE ==> !(bdlb::String::areEqualCaseless("OFF", 3, name) || bdlb::String::areEqualCaseless("FATAL", 5, name) || bdlb::String::areEqualCaseless("ERROR", 5, name) || bdlb::String::areEqualCaseless("WARN", 4, name) || bdlb::String::areEqualCaseless("INFO", 4, name) || bdlb::String::areEqualCaseless("DEBUG", 5, name) || bdlb::String::areEqualCaseless("TRACE", 5, name)))
 int SeverityUtil::fromAsciiCaseless(Severity::Level *level, const char *name)
 {
     BSLS_ASSERT(level);

--- a/groups/bal/ball/ball_thresholdaggregate.cpp
+++ b/groups/bal/ball/ball_thresholdaggregate.cpp
@@ -28,6 +28,8 @@ namespace ball {
                         // ------------------------
 
 // CLASS METHODS
+// requires: 0 < size
+// ensures: __out == (bdlb::HashUtil::hash1((const char*)&value, sizeof(value)) % size)
 int ThresholdAggregate::hash(const ThresholdAggregate& aggregate, int size)
 {
     BSLS_ASSERT(0 < size);
@@ -62,6 +64,8 @@ int ThresholdAggregate::maxLevel(int recordLevel,
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out.d_recordLevel == rhs.d_recordLevel ⋆ __out.d_passLevel == rhs.d_passLevel ⋆ __out.d_triggerLevel == rhs.d_triggerLevel ⋆ __out.d_triggerAllLevel == rhs.d_triggerAllLevel
 ThresholdAggregate&
 ThresholdAggregate::operator=(const ThresholdAggregate& rhs)
 {
@@ -94,6 +98,8 @@ int ThresholdAggregate::setLevels(int recordLevel,
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream && SEPFORALL(0, n, i, stream + i ↦ sep_v)
 bsl::ostream&
 ThresholdAggregate::print(bsl::ostream& stream,
                           int           level,

--- a/groups/bal/ball/ball_userfields.cpp
+++ b/groups/bal/ball/ball_userfields.cpp
@@ -16,6 +16,8 @@ namespace ball {
                              // ----------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: __out == stream
 bsl::ostream& UserFields::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bal/ball/ball_userfieldtype.cpp
+++ b/groups/bal/ball/ball_userfieldtype.cpp
@@ -16,6 +16,8 @@ namespace ball {
                      // --------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == stream && SEPFORALL(0, sizeof(toAscii(value)), i, stream + i ↦ toAscii(value)[i])
 bsl::ostream& UserFieldType::print(bsl::ostream&       stream,
                                    UserFieldType::Enum value,
                                    int                 level,

--- a/groups/bal/ball/ball_userfieldvalue.cpp
+++ b/groups/bal/ball/ball_userfieldvalue.cpp
@@ -16,6 +16,8 @@ namespace ball {
                              // --------------------
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == ball::UserFieldType::e_VOID || __out == ball::UserFieldType::e_INT64 || __out == ball::UserFieldType::e_DOUBLE || __out == ball::UserFieldType::e_STRING || __out == ball::UserFieldType::e_DATETIMETZ || __out == ball::UserFieldType::e_CHAR_ARRAY)
 ball::UserFieldType::Enum UserFieldValue::type() const
 {
     switch (d_value.typeIndex()) {

--- a/groups/bal/balm/balm_bdlmmetricsadapter.cpp
+++ b/groups/bal/balm/balm_bdlmmetricsadapter.cpp
@@ -40,6 +40,8 @@ BdlmMetricsAdapter::~BdlmMetricsAdapter()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: true
 bdlm::MetricsAdapter::CallbackHandle
 BdlmMetricsAdapter::registerCollectionCallback(
                                 const bdlm::MetricDescriptor& metricDescriptor,

--- a/groups/bal/balm/balm_category.cpp
+++ b/groups/bal/balm/balm_category.cpp
@@ -54,6 +54,8 @@ void Category::registerCategoryHolder(CategoryHolder *holder)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream && SEPFORALL(0, sizeof(d_name_p), i, stream + i ↦ d_name_p[i])
 bsl::ostream& Category::print(bsl::ostream& stream) const
 {
     stream << "[ " << d_name_p << (d_enabled ? " ENABLED ]" : " DISABLED ]");

--- a/groups/bal/balm/balm_collectorrepository.cpp
+++ b/groups/bal/balm/balm_collectorrepository.cpp
@@ -371,6 +371,8 @@ CollectorRepository_MetricCollectors::
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: &__out == &d_collectors
 inline
 CollectorRepository_Collectors<Collector>&
 CollectorRepository_MetricCollectors::collectors()
@@ -403,6 +405,8 @@ void CollectorRepository_MetricCollectors::collect(MetricRecord *record)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_collectors
 inline
 const CollectorRepository_Collectors<Collector>&
 CollectorRepository_MetricCollectors::collectors() const

--- a/groups/bal/balm/balm_configurationutil.cpp
+++ b/groups/bal/balm/balm_configurationutil.cpp
@@ -26,6 +26,8 @@ namespace balm {
                           // ------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (__out == -1 ==> manager == 0) && (__out == 0 ==> manager != 0)
 int ConfigurationUtil::setFormat(const char          *category,
                                  const char          *metricName,
                                  const MetricFormat&  format,

--- a/groups/bal/balm/balm_defaultmetricsmanager.cpp
+++ b/groups/bal/balm/balm_defaultmetricsmanager.cpp
@@ -29,6 +29,8 @@ bslma::Allocator     *balm::DefaultMetricsManager::s_allocator_p = 0;
 
 namespace balm {
 // CLASS METHODS
+// requires: basicAllocator != 0 && s_singleton_p == 0 && s_allocator_p == 0
+// ensures: (__out != 0) && (s_singleton_p == __out) && (s_allocator_p != 0)
 MetricsManager *DefaultMetricsManager::create(bslma::Allocator *basicAllocator)
 {
     BSLS_ASSERT(0 == s_singleton_p);

--- a/groups/bal/balm/balm_metricdescription.cpp
+++ b/groups/bal/balm/balm_metricdescription.cpp
@@ -17,6 +17,8 @@ namespace balm {
                           // -----------------------
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream && SEPFORALL(0, strlen(d_category_p->name() + "." + d_name_p), i, stream + i ↦ (d_category_p->name() + "." + d_name_p)[i])
 bsl::ostream& MetricDescription::print(bsl::ostream& stream) const
 {
     stream << d_category_p->name() << "." << d_name_p;

--- a/groups/bal/balm/balm_metricformat.cpp
+++ b/groups/bal/balm/balm_metricformat.cpp
@@ -29,6 +29,8 @@ const char *balm::MetricFormatSpec::k_DEFAULT_FORMAT = "%f";
 namespace balm {
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& MetricFormatSpec::formatValue(bsl::ostream&           stream,
                                             double                  value,
                                             const MetricFormatSpec& format)
@@ -66,6 +68,8 @@ bsl::ostream& MetricFormatSpec::formatValue(bsl::ostream&           stream,
 }
 
 // ACCESSORS
+// requires: SEPFORALL(0, level, i, (stream + i ↦ sep_v) && (sep_v == sep_v))
+// ensures: __out == stream && SEPFORALL(0, level, i, (stream + i ↦ sep_v) && (sep_v == d_scale || sep_v == d_format))
 bsl::ostream& MetricFormatSpec::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const
@@ -104,6 +108,8 @@ void MetricFormat::clearFormatSpec(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream ⋆ SEPFORALL(0, d_formatSpecs.size(), i, (__out + i ↦ _))
 bsl::ostream& MetricFormat::print(bsl::ostream& stream,
                                   int      level,
                                   int      spacesPerLevel) const

--- a/groups/bal/balm/balm_metricid.cpp
+++ b/groups/bal/balm/balm_metricid.cpp
@@ -19,6 +19,8 @@ BSLMF_ASSERT(bslmf::IsTriviallyCopyableCheck<MetricId>::value);
                                // --------------
 
 // ACCESSORS
+// requires: true
+// ensures: (d_description_p == 0 ==> SEPFORALL(0, sizeof("INVALID_ID"), i, stream + i ↦ "INVALID_ID"[i])) && (d_description_p != 0 ==> SEPFORALL(0, strlen(*d_description_p), i, stream + i ↦ (*d_description_p)[i])) && (__out == stream)
 bsl::ostream& MetricId::print(bsl::ostream& stream) const
 {
     if (0 == d_description_p) {

--- a/groups/bal/balm/balm_metricrecord.cpp
+++ b/groups/bal/balm/balm_metricrecord.cpp
@@ -48,6 +48,8 @@ BSLMF_ASSERT(bsl::is_trivially_copyable<MetricRecord>::value);
 BSLMF_ASSERT(bslmf::IsBitwiseCopyable<MetricRecord>::value);
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == stream) && SEPFORALL(0, sizeof("[ " << d_metricId << ": " << d_count << " " << d_total << " " << d_min << " " << d_max << " ]"), i, stream + i ↦ "[ " << d_metricId << ": " << d_count << " " << d_total << " " << d_min << " " << d_max << " ]"[i])
 bsl::ostream& MetricRecord::print(bsl::ostream& stream) const
 {
     stream << "[ " << d_metricId << ": " << d_count

--- a/groups/bal/balm/balm_metricregistry.cpp
+++ b/groups/bal/balm/balm_metricregistry.cpp
@@ -46,6 +46,8 @@ void combineUserData(bsl::vector<const void *>        *result,
 
 /// Return `true` if the specified `candidatePrefix` is a prefix of the
 /// specified `string`, and `false` otherwise.
+// requires: (candidatePrefix != NULL) && (string != NULL)
+// ensures: (__out == true ==> *candidatePrefix == 0) && (__out == false ==> EXISTS(0, strlen(candidatePrefix), i, candidatePrefix[i] != string[i]))
 bool isPrefix(const char *candidatePrefix, const char *string)
 {
     while (*candidatePrefix == *string && *candidatePrefix) {
@@ -64,6 +66,8 @@ bool isPrefix(const char *candidatePrefix, const char *string)
 namespace balm {
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: (__out.second == false) || (__out.second == true)
 bsl::pair<MetricId, bool>
 MetricRegistry::insertId(const char *category, const char *name)
 {
@@ -172,6 +176,8 @@ MetricRegistry::~MetricRegistry()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out != MetricId() ==> ret.second) && (__out == MetricId() ==> !ret.second)
 MetricId MetricRegistry::addId(const char *category,
                                const char *name)
 {
@@ -393,6 +399,8 @@ MetricDescription::UserDataKey MetricRegistry::createUserDataKey()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_metrics.size()
 bsl::size_t MetricRegistry::numMetrics() const
 {
     bslmt::ReadLockGuard<bslmt::RWMutex> guard(&d_lock);

--- a/groups/bal/balm/balm_metricsample.cpp
+++ b/groups/bal/balm/balm_metricsample.cpp
@@ -16,6 +16,8 @@ namespace balm {
                           // -----------------------
 
 // ACCESSORS
+// requires: stream ↦ _ && level >= 0 && spacesPerLevel >= 0
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream&
 MetricSampleGroup::print(bsl::ostream& stream,
                          int           level,
@@ -56,6 +58,8 @@ MetricSample::MetricSample(const MetricSample&  original,
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == *this) && ((this != &rhs) ==> (d_records ↦ rhs.d_records ⋆ d_timeStamp ↦ rhs.d_timeStamp ⋆ d_numRecords ↦ rhs.d_numRecords))
 MetricSample& MetricSample::operator=(const MetricSample& rhs)
 {
     if (this != &rhs) {
@@ -67,6 +71,8 @@ MetricSample& MetricSample::operator=(const MetricSample& rhs)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& MetricSample::print(bsl::ostream& stream,
                                   int           level,
                                   int           spacesPerLevel) const

--- a/groups/bal/balm/balm_metricsmanager.cpp
+++ b/groups/bal/balm/balm_metricsmanager.cpp
@@ -801,6 +801,8 @@ MetricsManager_PublisherRegistry::~MetricsManager_PublisherRegistry()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == -1 ==> (d_generalPublishers.find(publisher) != d_generalPublishers.end() || (d_registry.find(publisher) != d_registry.end() && !d_registry.find(publisher)->second.empty()))) && (__out == 0 ==> (d_generalPublishers.find(publisher) == d_generalPublishers.end() || (d_registry.find(publisher) == d_registry.end() || d_registry.find(publisher)->second.empty())) && d_generalPublishers.find(publisher) != d_generalPublishers.end())
 int MetricsManager_PublisherRegistry::addGeneralPublisher(
                               const bsl::shared_ptr<Publisher>& publisher)
 {
@@ -1007,6 +1009,8 @@ MetricsManager_CallbackRegistry::~MetricsManager_CallbackRegistry()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == d_nextHandle - 1 && d_callbacks.find(category) != d_callbacks.end() && d_handles.find(__out) != d_handles.end() && d_handles.find(__out)->second->first == category
 MetricsManager_CallbackRegistry::CallbackHandle
 MetricsManager_CallbackRegistry::registerCollectionCallback(
                                     const Category                   *category,

--- a/groups/bal/balm/balm_publicationscheduler.cpp
+++ b/groups/bal/balm/balm_publicationscheduler.cpp
@@ -59,6 +59,8 @@ struct IsPair {
 
 /// Return the invalid scheduling interval value.  Note that this function
 /// is provided to avoid creating a statically initialized constant.
+// requires: true
+// ensures: __out.seconds() == 0 && __out.nanoseconds() == 0
 inline
 bsls::TimeInterval makeInvalidInterval()
 {
@@ -92,6 +94,8 @@ struct CategorySort {
 
 /// Print, to the specified `stream` the specified `categories` in
 /// alphabetic order.
+// requires: categories.size() >= 0 && SEPFORALL(categories.begin(), categories.end(), it, (*it)->name() ↦ _)
+// ensures: __out == stream
 bsl::ostream& printCategorySet(
                             bsl::ostream&                           stream,
                             const bsl::set<const balm::Category *>& categories)
@@ -272,6 +276,8 @@ PublicationScheduler_ClockData::~PublicationScheduler_ClockData()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == &d_mutex
 inline
 bslmt::Mutex *PublicationScheduler_ClockData::mutex()
 {
@@ -688,6 +694,8 @@ int PublicationScheduler::clearDefaultSchedule()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == true ==> (*result ↦ catIt->second)) && (__out == false ==> *result ↦ old_result)
 bool
 PublicationScheduler::findCategorySchedule(bsls::TimeInterval *result,
                                            const Category     *category) const

--- a/groups/bal/balst/balst_stacktrace.cpp
+++ b/groups/bal/balst/balst_stacktrace.cpp
@@ -16,6 +16,8 @@ namespace balst {
                               // ----------------
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& StackTrace::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bal/balst/balst_stacktraceframe.cpp
+++ b/groups/bal/balst/balst_stacktraceframe.cpp
@@ -16,6 +16,8 @@ namespace balst {
                            // ---------------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& StackTraceFrame::print(bsl::ostream& stream,
                                      int           level,
                                      int           spacesPerLevel) const
@@ -57,6 +59,8 @@ void StackTraceFrame::swap(StackTraceFrame& other)
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: !stream.bad()
+// ensures: __out == stream && (stream.bad() || (stream.good() && (stream << object.address() && stream << object.libraryFileName().c_str() && stream << object.lineNumber() && stream << object.mangledSymbolName().c_str() && stream << object.offsetFromSymbol() && stream << object.sourceFileName().c_str() && stream << object.symbolName().c_str())))
 bsl::ostream& balst::operator<<(bsl::ostream&          stream,
                                 const StackTraceFrame& object)
 {

--- a/groups/bal/balst/balst_stacktraceprinter.cpp
+++ b/groups/bal/balst/balst_stacktraceprinter.cpp
@@ -36,6 +36,8 @@ StackTracePrinter::StackTracePrinter(int  maxFrames,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& balst::operator<<(bsl::ostream&            stream,
                                 const StackTracePrinter& object)
 {

--- a/groups/bal/balst/balst_stacktraceprintutil.cpp
+++ b/groups/bal/balst/balst_stacktraceprintutil.cpp
@@ -32,6 +32,8 @@ namespace balst {
                          // -------------------------
 
 // CLASS METHOD
+// requires: (0 <= maxFrames || maxFrames == -1) && (0 <= additionalIgnoreFrames) && (&stream != 0)
+// ensures: __out == &stream
 bsl::ostream& StackTracePrintUtil::printStackTrace(
                                          bsl::ostream& stream,
                                          int           maxFrames,

--- a/groups/bal/balst/balst_stacktracetestallocator.cpp
+++ b/groups/bal/balst/balst_stacktracetestallocator.cpp
@@ -89,6 +89,8 @@ static const UintPtr k_DEALLOCATED_BLOCK_MAGIC = 1999999991 + HIGH_ONES;
 /// `specifiedMaxRecordedFrames`.  The specify value may need to be
 /// adjusted upward to include room for ignored frames, and for the buffer
 /// size in bytes being a multiple of `k_MAX_ALIGNMENT`.
+// requires: specifiedMaxRecordedFrames >= 0
+// ensures: __out >= specifiedMaxRecordedFrames && __out % k_PTRS_PER_MAX == 0
 static
 int getTraceBufferLength(int specifiedMaxRecordedFrames)
 {
@@ -175,6 +177,8 @@ StackTraceTestAllocator::BlockHeader::BlockHeader(
                  // ------------------------------------------
 
 // PRIVATE ACCESSORS
+// requires: true
+// ensures: (__out == -1 ==> (k_ALLOCATED_BLOCK_MAGIC != blockHdr->d_magic || this != blockHdr->d_allocator_p || 0 == d_blocks || 0 == blockHdr->d_prevNext_p || 0 == *blockHdr->d_prevNext_p || (blockHdr->d_next_p && k_ALLOCATED_BLOCK_MAGIC != blockHdr->d_next_p->d_magic))) && (__out == 0 ==> (k_ALLOCATED_BLOCK_MAGIC == blockHdr->d_magic && this == blockHdr->d_allocator_p && d_blocks != 0 && blockHdr->d_prevNext_p != 0 && *blockHdr->d_prevNext_p != 0 && (!blockHdr->d_next_p || k_ALLOCATED_BLOCK_MAGIC == blockHdr->d_next_p->d_magic)))
 int StackTraceTestAllocator::checkBlockHeader(
                                              const BlockHeader *blockHdr) const
 {
@@ -337,6 +341,8 @@ StackTraceTestAllocator::~StackTraceTestAllocator()
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *StackTraceTestAllocator::allocate(size_type size)
 {
     // All updates are protected by a mutex lock, so as to not interleave the
@@ -526,6 +532,8 @@ void StackTraceTestAllocator::setOstream(bsl::ostream *ostream)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_allocationLimit.loadRelaxed()
 bsls::Types::Int64 StackTraceTestAllocator::allocationLimit() const
 {
     return d_allocationLimit.loadRelaxed();

--- a/groups/bal/balst/balst_stacktraceutil.cpp
+++ b/groups/bal/balst/balst_stacktraceutil.cpp
@@ -37,6 +37,8 @@ BSLS_IDENT_RCSID(balst_stacktraceutil_cpp,"$Id$ $CSID$")
 /// address.  If there are no separator characters, return the address of
 /// the first character of `pathName`.  If the last character of `pathName`
 /// is a separator charactor, return the address of the terminating '\0'.
+// requires: pathName != nullptr && SEPFORALL(0, bsl::strlen(pathName), i, pathName + i ↦ _)
+// ensures: (__out >= pathName) && (__out == pathName || (*(__out - 1) == '/' || *(__out - 1) == '\\'))
 static
 const char *findBasename(const char *pathName)
 {
@@ -73,7 +75,9 @@ class ResolverImpl<ObjectFileFormat::Dummy>
     /// which is to be used for memory allocation.  The behavior is
     /// undefined unless all the `address` field in `stackFrames` are valid
     /// and other fields are invalid, and `basicAllocator != 0`.
-    static
+    // requires: true
+// ensures: __out == -1
+static
     int resolve(StackTrace *,    // 'stackTrace'
                 bool        )    // 'demangle'
     {

--- a/groups/bal/baltzo/baltzo_datafileloader.cpp
+++ b/groups/bal/baltzo/baltzo_datafileloader.cpp
@@ -94,6 +94,8 @@ void concatenatePath(STRING             *result,
 
 /// Returns 0 if the specified `timeZoneId` contains only valid characters
 /// and does not start with `/`, and a non-zero value otherwise.
+// requires: timeZoneId && SEPFORALL(0, strlen(timeZoneId), i, (timeZoneId + i ↦ _))
+// ensures: (__out == -1 ==> timeZoneId[0] == '/') && (__out == -2 ==> SEPEXISTS(0, strlen(timeZoneId), i, (timeZoneId + i ↦ sep_v && !bsl::strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890/_+-", sep_v)))) && (__out == 0 ==> !(timeZoneId[0] == '/') && SEPFORALL(0, strlen(timeZoneId), i, (timeZoneId + i ↦ sep_v && bsl::strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890/_+-", sep_v))))
 int validateTimeZoneId(const char *timeZoneId)
 {
     BSLS_ASSERT(timeZoneId);
@@ -151,6 +153,13 @@ int loadTimeZoneFilePath_Impl(STRING             *result,
 /// A return status of `ErrorCode::k_UNSUPPORTED_ID` indicates that
 /// `timeZoneId` is not recognized.  If an error occurs during this
 /// operation, `result` will be left in a valid, but unspecified state.
+// requires: result != nullptr && timeZoneId != nullptr
+// ensures: POST(
+    (__out == u::UNSUPPORTED_ID || __out == u::UNSPECIFIED_ERROR) ||
+    (result->getIdentifier() == timeZoneId)
+)
+
+This postcondition ensures that either the function returns an error code (`u::UNSUPPORTED_ID` or `u::UNSPECIFIED_ERROR`), or it successfully sets the identifier of the `result` object to `timeZoneId`.
 int loadTimeZoneImpl(baltzo::Zoneinfo              *result,
                      const baltzo::DataFileLoader&  loader,
                      const char                    *timeZoneId,
@@ -206,6 +215,8 @@ namespace baltzo {
                             // --------------------
 
 // CLASS METHODS
+// requires: path != nullptr
+// ensures: (__out == true ==> (bdls::FilesystemUtil::isDirectory(path, true) && bdls::FilesystemUtil::isRegularFile((bsl::string(path) + "/GMT").c_str(), true))) && (__out == false ==> !(bdls::FilesystemUtil::isDirectory(path, true) && bdls::FilesystemUtil::isRegularFile((bsl::string(path) + "/GMT").c_str(), true)))
 bool DataFileLoader::isPlausibleZoneinfoRootPath(const char *path)
 {
     BSLS_ASSERT(path);
@@ -274,6 +285,8 @@ int DataFileLoader::loadTimeZoneRaw(Zoneinfo *result, const char *timeZoneId)
 }
 
 // ACCESSORS
+// requires: result != nullptr && timeZoneId != nullptr
+// ensures: __out == u::loadTimeZoneFilePath_Impl(result, timeZoneId, d_rootPath) && (result ↦ _)
 int DataFileLoader::loadTimeZoneFilePath(bsl::string      *result,
                                          const char       *timeZoneId) const
 {

--- a/groups/bal/baltzo/baltzo_defaultzoneinfocache.cpp
+++ b/groups/bal/baltzo/baltzo_defaultzoneinfocache.cpp
@@ -62,6 +62,8 @@ static baltzo::ZoneinfoCache *userSingletonCachePtr   = 0; // default usr cache
 /// not previously been called.  Subsequent calls to this method return the
 /// previously created (singleton) instance with no other effect.  This
 /// methods is *not* thread safe.
+// requires: true
+// ensures: __out != 0
 static
 baltzo::ZoneinfoCache *initSystemDefaultCache()
 {
@@ -100,6 +102,8 @@ namespace baltzo {
                          // --------------------------
 
 // PRIVATE CLASS METHODS
+// requires: true
+// ensures: (u::userSingletonCachePtr != 0 ==> __out == u::userSingletonCachePtr) && (u::userSingletonCachePtr == 0 ==> (__out == u::systemSingletonCachePtr && u::systemSingletonCachePtr != 0))
 ZoneinfoCache *DefaultZoneinfoCache::instance()
 {
     if (u::userSingletonCachePtr) {
@@ -116,6 +120,8 @@ ZoneinfoCache *DefaultZoneinfoCache::instance()
 }
 
 // CLASS METHODS
+// requires: true
+// ensures: (__out != 0) && ((__out == getenv("BDE_ZONEINFO_ROOT_PATH")) || (SEPEXISTS(0, u::k_NUM_BALTZO_DATA_LOCATIONS, ii, __out == u::BALTZO_DATA_LOCATIONS[ii])) || (__out == "."))
 const char *DefaultZoneinfoCache::defaultZoneinfoDataLocation()
 {
     const char *envValue = getenv("BDE_ZONEINFO_ROOT_PATH");

--- a/groups/bal/baltzo/baltzo_localdatetime.cpp
+++ b/groups/bal/baltzo/baltzo_localdatetime.cpp
@@ -38,6 +38,8 @@ bsl::ostream& LocalDatetime::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: (stream.bad() ==> true) && (!stream.bad() ==> (SEPFORALL(0, object.timeZoneId().size(), i, object.timeZoneId().c_str()[i] ↦ _) ⋆ SEPFORALL(0, object.datetimeTz().size(), j, object.datetimeTz().c_str()[j] ↦ _)))
+// ensures: __out == stream && (stream.bad() || (stream.good() && (SEPFORALL(0, object.timeZoneId().size(), i, stream + i ↦ object.timeZoneId().c_str()[i]) ⋆ SEPFORALL(0, object.datetimeTz().size(), j, stream + j ↦ object.datetimeTz().c_str()[j]))))
 bsl::ostream& baltzo::operator<<(bsl::ostream&        stream,
                                  const LocalDatetime& object)
 {

--- a/groups/bal/baltzo/baltzo_localtimedescriptor.cpp
+++ b/groups/bal/baltzo/baltzo_localtimedescriptor.cpp
@@ -37,6 +37,8 @@ bsl::ostream& LocalTimeDescriptor::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream && SEPFORALL(0, 3, i, (__out + i ↦ sep_v && (sep_v == object.utcOffsetInSeconds() || sep_v == object.dstInEffectFlag() || sep_v == object.description().c_str())))
 bsl::ostream& baltzo::operator<<(bsl::ostream&              stream,
                                  const LocalTimeDescriptor& object)
 {

--- a/groups/bal/baltzo/baltzo_localtimeoffsetutil.cpp
+++ b/groups/bal/baltzo/baltzo_localtimeoffsetutil.cpp
@@ -30,6 +30,8 @@ namespace baltzo {
                          // --------------------------
 
 // PRIVATE CLASS METHODS
+// requires: timezone != NULL
+// ensures: __out == 0 || __out != 0
 inline
 int LocalTimeOffsetUtil::configureImp(const char            *timezone,
                                       const bdlt::Datetime&  utcDatetime)

--- a/groups/bal/baltzo/baltzo_localtimeperiod.cpp
+++ b/groups/bal/baltzo/baltzo_localtimeperiod.cpp
@@ -18,6 +18,8 @@ namespace baltzo {
                         // Aspects
 
 // ACCESSORS
+// requires: stream ↦ _ && !stream.bad()
+// ensures: (__out == stream) && (stream ↦ _)
 bsl::ostream& LocalTimePeriod::print(bsl::ostream& stream,
                                      int           level,
                                      int           spacesPerLevel) const

--- a/groups/bal/baltzo/baltzo_localtimevalidity.cpp
+++ b/groups/bal/baltzo/baltzo_localtimevalidity.cpp
@@ -16,6 +16,8 @@ namespace baltzo {
                           // ------------------------
 
 // CLASS METHODS
+// requires: stream.good() && (value == LocalTimeValidity::Enum::VALID || value == LocalTimeValidity::Enum::INVALID)
+// ensures: __out == stream && SEPFORALL(0, strlen(toAscii(value)), i, (stream + i ↦ toAscii(value)[i]))
 bsl::ostream& LocalTimeValidity::print(bsl::ostream&           stream,
                                        LocalTimeValidity::Enum value,
                                        int                     level,

--- a/groups/bal/baltzo/baltzo_timezoneutil.cpp
+++ b/groups/bal/baltzo/baltzo_timezoneutil.cpp
@@ -26,6 +26,8 @@ namespace baltzo {
                              // ------------------
 
 // CLASS METHODS
+// requires: result != 0
+// ensures: (result != 0) && (result->datetimeTz().utcDatetime() == (originalTime.datetimeTz().utcDatetime() + bdlt::IntervalConversionUtil::convertToDatetimeInterval(interval))) ⋆ (__out == convertUtcToLocalTime(result, originalTime.timeZoneId().c_str(), originalTime.datetimeTz().utcDatetime() + bdlt::IntervalConversionUtil::convertToDatetimeInterval(interval)))
 int TimeZoneUtil::addInterval(LocalDatetime             *result,
                               const LocalDatetime&       originalTime,
                               const bsls::TimeInterval&  interval)

--- a/groups/bal/baltzo/baltzo_timezoneutilimp.cpp
+++ b/groups/bal/baltzo/baltzo_timezoneutilimp.cpp
@@ -36,6 +36,8 @@ namespace BloombergLP {
 /// `cache`.  Return 0 on success, and a non-zero value otherwise.  A return
 /// status of `baltzo::ErrorCode::k_UNSUPPORTED_ID` indicates that
 /// `timeZoneId` is not recognized.
+// requires: timeZone != 0 && timeZoneId != 0 && cache != 0
+// ensures: (__out == 0 ==> (timeZone != 0 && *timeZone != 0)) && (__out != 0 ==> *timeZone == 0)
 static
 int lookupTimeZone(const baltzo::Zoneinfo **timeZone,
                    const char              *timeZoneId,
@@ -65,6 +67,8 @@ int lookupTimeZone(const baltzo::Zoneinfo **timeZone,
 /// `timeZone.endTransition()` if `timeZone` does not contain any transition
 /// having a local-time descriptor with `dstFlag`.  The behavior is
 /// undefined unless `start` is a valid iterator in `timeZone`.
+// requires: start >= timeZone.beginTransitions() && start < timeZone.endTransitions()
+// ensures: (__out != timeZone.endTransitions() ==> __out->descriptor().dstInEffectFlag() == dstFlag) || (__out == timeZone.endTransitions())
 static
 baltzo::Zoneinfo::TransitionConstIterator findTransitionWithDstFlag(
                      const bool                                       dstFlag,
@@ -206,6 +210,8 @@ namespace baltzo {
                            // ---------------------
 
 // CLASS METHODS
+// requires: result != 0 && resultTimeZoneId != 0 && cache != 0
+// ensures: (__out == 0 ==> (result != 0)) && (__out != 0 ==> true)
 int TimeZoneUtilImp::convertUtcToLocalTime(
                                        bdlt::DatetimeTz      *result,
                                        const char            *resultTimeZoneId,

--- a/groups/bal/baltzo/baltzo_windowstimezoneutil.cpp
+++ b/groups/bal/baltzo/baltzo_windowstimezoneutil.cpp
@@ -42,6 +42,8 @@ typedef struct TimeZoneIdEntry {
 
 /// Return `true` if the "key" field of the specified `a` is lexically less
 /// that the "key" field of the specified `b`, and 'false otherwise.
+// requires: true
+// ensures: (__out == true ==> bsl::strcmp(a.d_key, b.d_key) < 0) && (__out == false ==> bsl::strcmp(a.d_key, b.d_key) >= 0)
 static bool isLessThan(const TimeZoneIdEntry& a,
                        const TimeZoneIdEntry& b)
 {
@@ -286,6 +288,8 @@ namespace baltzo {
                          // --------------------------
 
 // CLASS METHODS
+// requires: result != 0 && windowsTimeZoneId != 0
+// ensures: (__out == 0 ==> (*result ↦ ptr->d_value)) && (__out == -1 ==> true)
 int WindowsTimeZoneUtil::getZoneinfoId(const char **result,
                                        const char  *windowsTimeZoneId)
 {

--- a/groups/bal/baltzo/baltzo_zoneinfo.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfo.cpp
@@ -22,6 +22,8 @@ namespace BloombergLP {
 
 /// Return `true` if the specified `transitions` contain a transition with
 /// the specified `descriptor`, and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> SEPEXISTS(0, transitions.size(), i, transitions[i].descriptor() == descriptor)) && (__out == false ==> SEPFORALL(0, transitions.size(), i, transitions[i].descriptor() != descriptor))
 static
 bool containsDescriptor(
                     const bsl::vector<baltzo::ZoneinfoTransition>& transitions,
@@ -44,6 +46,8 @@ namespace baltzo {
                           // ------------------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream&
 ZoneinfoTransition::print(bsl::ostream& stream,
                           int           level,
@@ -125,6 +129,8 @@ namespace baltzo {
                        // ------------------------------
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == (lhs.utcOffsetInSeconds() < rhs.utcOffsetInSeconds())) || (lhs.utcOffsetInSeconds() == rhs.utcOffsetInSeconds() && __out == (lhs.description() < rhs.description())) || (lhs.utcOffsetInSeconds() == rhs.utcOffsetInSeconds() && lhs.description() == rhs.description() && __out == (lhs.dstInEffectFlag() < rhs.dstInEffectFlag()))
 bool Zoneinfo::DescriptorLess::operator()(const LocalTimeDescriptor& lhs,
                                           const LocalTimeDescriptor& rhs) const
 {
@@ -346,6 +352,8 @@ bsl::ostream& Zoneinfo::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: SEPFORALL(object.beginTransitions(), object.endTransitions(), it, *it ↦ _)
+// ensures: __out == stream && SEPFORALL(object.beginTransitions(), object.endTransitions(), it, *it ↦ _)
 bsl::ostream& baltzo::operator<<(bsl::ostream& stream, const Zoneinfo& object)
 {
     stream << "[ \"" << object.identifier() << "\" "

--- a/groups/bal/baltzo/baltzo_zoneinfobinaryreader.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfobinaryreader.cpp
@@ -130,6 +130,8 @@ const bsls::Types::Int64 MINIMUM_ZIC_TRANSITION = -576460752303423488LL;
 
 /// Return `true` if every character in the specified `buffer` of the
 /// specified `length` is printable, and `false` otherwise.
+// requires: buffer != 0 && 0 <= length && SEPFORALL(0, length, i, buffer + i ↦ _)
+// ensures: (__out == true ==> SEPFORALL(0, length, i, (buffer + i ↦ sep_v && bdlb::CharType::isPrint(sep_v)))) && (__out == false ==> SEPEXISTS(0, length, i, (buffer + i ↦ sep_v && !bdlb::CharType::isPrint(sep_v))))
 static
 bool areAllPrintable(const char *buffer, int length)
 {
@@ -229,6 +231,8 @@ bool validIndex(const bsl::vector<TYPE>& vector, int index)
 /// Read the 32-bit big-endian integer in the array of bytes located at the
 /// specified `address` and return that value.  The behavior is undefined
 /// unless `address` points to an accessible memory location.
+// requires: address != 0 && SEPFORALL(0, 4, i, address + i ↦ _)
+// ensures: __out == BSLS_BYTEORDER_BE_U32_TO_HOST(*reinterpret_cast<const int*>(address))
 static inline
 int decode32(const char *address)
 {
@@ -690,6 +694,8 @@ namespace baltzo {
                          // --------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == readImpl(zoneinfoResult, &description, k_READ_NORMALIZED, stream)
 int ZoneinfoBinaryReader::read(Zoneinfo *zoneinfoResult, bsl::istream& stream)
 {
     ZoneinfoBinaryHeader description;

--- a/groups/bal/baltzo/baltzo_zoneinfocache.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfocache.cpp
@@ -39,6 +39,8 @@ ZoneinfoCache::~ZoneinfoCache()
 }
 
 // MANIPULATORS
+// requires: rc != 0 && timeZoneId != 0
+// ensures: (__out == 0 ==> *rc != 0) && (__out != 0 ==> (*rc == 0 && (__out->identifier() ↦ timeZoneId)))
 const Zoneinfo *ZoneinfoCache::getZoneinfo(int *rc, const char *timeZoneId)
 {
     BSLS_ASSERT(0 != rc);
@@ -124,6 +126,8 @@ const Zoneinfo *ZoneinfoCache::getZoneinfo(int *rc, const char *timeZoneId)
 }
 
 // ACCESSORS
+// requires: timeZoneId != 0
+// ensures: (__out != 0 ==> d_cache.find(timeZoneId) != d_cache.end() && __out == d_cache.find(timeZoneId)->second) && (__out == 0 ==> d_cache.find(timeZoneId) == d_cache.end())
 const Zoneinfo *ZoneinfoCache::lookupZoneinfo(const char *timeZoneId) const
 {
     BSLS_ASSERT(0 != timeZoneId);

--- a/groups/bal/baltzo/baltzo_zoneinfoutil.cpp
+++ b/groups/bal/baltzo/baltzo_zoneinfoutil.cpp
@@ -28,6 +28,8 @@ namespace baltzo {
                              // ------------------
 
 // CLASS METHODS
+// requires: resultTime != NULL && resultTransition != NULL && isWellFormed(timeZone) && EXISTS(0, timeZone.endTransitions(), it, it != timeZone.endTransitions())
+// ensures: (__out == 0) || (__out == ErrorCode::k_OUT_OF_RANGE)
 int ZoneinfoUtil::convertUtcToLocalTime(
                            bdlt::DatetimeTz                  *resultTime,
                            Zoneinfo::TransitionConstIterator *resultTransition,

--- a/groups/bal/balxml/balxml_decoder.cpp
+++ b/groups/bal/balxml/balxml_decoder.cpp
@@ -378,6 +378,8 @@ Decoder::checkForErrors(const ErrorInfo& errInfo)
 }
 
 // MANIPULATORS
+// requires: context != 0 && (context ↦ _ ⋆ d_reader ↦ _)
+// ensures: (__out == BAEXML_SUCCESS || __out == BAEXML_FAILURE) && (context ↦ _ ⋆ d_reader ↦ _)
 int
 Decoder::parse(Decoder_ElementContext *context)
 {

--- a/groups/bal/balxml/balxml_elementattribute.cpp
+++ b/groups/bal/balxml/balxml_elementattribute.cpp
@@ -85,6 +85,8 @@ void ElementAttribute::reset(const PrefixStack *prefixStack,
 }
 
 // ACCESSORS
+// requires: (d_prefix || !d_qualifiedName) || (!d_prefixStack && d_qualifiedName) || (d_prefixStack && d_qualifiedName)
+// ensures: __out == d_prefix
 const char *ElementAttribute::prefix() const
 {
     if (d_prefix || ! d_qualifiedName) {

--- a/groups/bal/balxml/balxml_encoder.cpp
+++ b/groups/bal/balxml/balxml_encoder.cpp
@@ -97,6 +97,8 @@ Encoder_Context::Encoder_Context(
                   // ---------------------------------------
 
 // PRIVATE CLASS METHODS
+// requires: true
+// ensures: (options.encodingStyle() == balxml::EncodingStyle::COMPACT ==> __out == 0) && (options.encodingStyle() == balxml::EncodingStyle::PRETTY ==> __out == options.initialIndentLevel())
 int Encoder_OptionsCompatibilityUtil::getFormatterInitialIndentLevel(
                                          const balxml::EncoderOptions& options)
 {

--- a/groups/bal/balxml/balxml_formatter.cpp
+++ b/groups/bal/balxml/balxml_formatter.cpp
@@ -62,6 +62,8 @@ Formatter_State::~Formatter_State()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (d_mode == rhs.d_mode
 Formatter_State& Formatter_State::operator=(const Formatter_State& rhs)
 {
     switch (d_mode) {

--- a/groups/bal/balxml/balxml_formatter_prettyimpl.cpp
+++ b/groups/bal/balxml/balxml_formatter_prettyimpl.cpp
@@ -260,6 +260,8 @@ void Formatter_PrettyImplUtil::addListDataImpl(bsl::ostream&            stream,
 }
 
 // CLASS METHODS
+// requires: state != 0
+// ensures: (__out == stream) && (state->column() == 0
 bsl::ostream& Formatter_PrettyImplUtil::addBlankLine(bsl::ostream&  stream,
                                                      State         *state)
 {

--- a/groups/bal/balxml/balxml_minireader.cpp
+++ b/groups/bal/balxml/balxml_minireader.cpp
@@ -104,6 +104,8 @@ namespace {
 
 /// Return the specified `s` if `s` != 0, or "" otherwise.  Never returns a
 /// null pointer.
+// requires: true
+// ensures: (s != nullptr ==> __out == s) && (s == nullptr ==> __out == "")
 inline
 const char* nonNullStr(const char *s)
 {
@@ -112,6 +114,8 @@ const char* nonNullStr(const char *s)
 
 /// Return the specified `val` cast to a `char`.  Bits of `val` that are
 /// too high-order to fit in a `char` will be discarded.
+// requires: true
+// ensures: __out == static_cast<char>(val)
 inline
 char toChar(unsigned val)
 {
@@ -122,6 +126,8 @@ char toChar(unsigned val)
 /// and write the characters to the character array at the specified
 /// `output` address.  Return the number of characters output or 0 if `val`
 /// is not in the legal range.
+// requires: val < 0x110000U
+// ensures: (val >= 0x110000U ==> __out == 0) && (val < 0x110000U ==> __out > 0)
 int unicodeToUtf8(char *output, unsigned val)
 {
     /*
@@ -465,6 +471,8 @@ MiniReader::~MiniReader()
 }
 
 // MANIPULATORS
+// requires: (error >= ErrorInfo::e_ERROR) ==> res_tmp == -1 && (error < ErrorInfo::e_ERROR) ==> res_tmp == 0
+// ensures: (error >= ErrorInfo::e_ERROR ==> __out == -1) && (error < ErrorInfo::e_ERROR ==> __out == 0)
 int MiniReader::setError(ErrorInfo::Severity error, const bsl::string &msg)
 {
     Node&  node = currentNode();
@@ -641,6 +649,8 @@ int MiniReader::open(bsl::streambuf *stream,
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_errorInfo
 const ErrorInfo&
 MiniReader::errorInfo () const
 {
@@ -1220,6 +1230,8 @@ MiniReader::advanceToNextNode()
 // ----------------------------------------------------------------------------
 //                              PRIVATE methods
 // ----------------------------------------------------------------------------
+// requires: d_scanPtr != nullptr && d_endPtr != nullptr && d_scanPtr <= d_endPtr
+// ensures: (__out == 0 ==> d_scanPtr == d_endPtr) && (__out != 0 ==> (*d_scanPtr ↦ __out))
 int
 MiniReader::skipSpaces()
 {

--- a/groups/bal/balxml/balxml_namespaceregistry.cpp
+++ b/groups/bal/balxml/balxml_namespaceregistry.cpp
@@ -30,6 +30,8 @@ const char *const predefinedNamespaces[] =
 
 /// Private function.  Look up the specified `namespaceUri` in the list of
 /// preregistered namespaces and return the namespace ID or -1 if not found.
+// requires: true
+// ensures: (__out != -1 ==> EXISTS(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri == predefinedNamespaces[i])) && (__out == -1 ==> FORALL(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri != predefinedNamespaces[i]))
 int lookupPredefinedId(const bsl::string_view& namespaceUri)
 {
     for (int i = 0; i < ARRAY_LEN(predefinedNamespaces); ++i) {

--- a/groups/bal/balxml/balxml_prefixstack.cpp
+++ b/groups/bal/balxml/balxml_prefixstack.cpp
@@ -71,6 +71,8 @@ PrefixStack::PrefixStack(const PrefixStack&  original,
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == nsId && (d_prefixes[d_numPrefixes - 1].first ↦ prefix ⋆ d_prefixes[d_numPrefixes - 1].second ↦ nsId) ⋆ d_numPrefixes == d_numPrefixes + 1
 int PrefixStack::pushPrefix(const bsl::string_view& prefix,
                             const bsl::string_view& namespaceUri)
 {
@@ -106,6 +108,8 @@ int PrefixStack::popPrefixes(int count)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (EXISTS(0, d_numPrefixes, i, (d_prefixes[i].first == prefix) && (__out == d_prefixes[i].second))) || (FORALL(0, d_numPrefixes, i, (d_prefixes[i].first != prefix)) ==> (__out == lookupPredefinedPrefix(prefix).d_nsid))
 int
 PrefixStack::lookupNamespaceId(const bsl::string_view& prefix) const
 {

--- a/groups/bal/balxml/balxml_typesparserutil.cpp
+++ b/groups/bal/balxml/balxml_typesparserutil.cpp
@@ -35,6 +35,8 @@ namespace u {
 /// specified length `inputLength` is "1" or "true" and false if `input` is
 /// "0" or "false".  Strings are case-insensitive.  Return 0 on success and
 /// non-zero if `input` is not "1", "0", "true", or "false".
+// requires: input != nullptr && result != nullptr && (inputLength == 1 || inputLength == 4 || inputLength == 5)
+// ensures: (__out == BAEXML_SUCCESS ==> ((*result == true && (input[0] == '1' || (inputLength == 4 && input[0] == 't' && input[1] == 'r' && input[2] == 'u' && input[3] == 'e'))) || (*result == false && (input[0] == '0' || (inputLength == 5 && input[0] == 'f' && input[1] == 'a' && input[2] == 'l' && input[3] == 's' && input[4] == 'e'))))) && (__out == BAEXML_FAILURE ==> *result == old_result)
 int parseBoolean(bool *result, const char *input, int inputLength)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -80,6 +82,8 @@ int parseBoolean(bool *result, const char *input, int inputLength)
 /// digits, period and sign characters (i.e., INF/NaN, and exponential
 /// notation are not allowed); otherwise `input` can contain any floating-
 /// point representation form.  Return 0 on success and non-zero otherwise.
+// requires: result != 0 && input != 0 && input[bsl::strlen(input)] == '\0'
+// ensures: (__out == BAEXML_SUCCESS ==> (result != 0 && (result ↦ _))) && (__out == BAEXML_FAILURE ==> true)
 int parseDoubleImpl(double *result, const char *input, bool formatDecimal)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -155,6 +159,8 @@ int parseDoubleImpl(double *result, const char *input, bool formatDecimal)
 /// specified length `inputLength` should contain only decimal digits,
 /// period and sign characters; otherwise `input` can contain any floating-
 /// point representation form.  Return 0 on success and non-zero otherwise.
+// requires: input != NULL && inputLength >= 0
+// ensures: (inputLength == 0 ==> __out == BAEXML_FAILURE) && (inputLength != 0 ==> (__out == BAEXML_SUCCESS || __out == BAEXML_FAILURE))
 int parseDouble(double     *result,
                 const char *input,
                 int         inputLength,
@@ -185,6 +191,8 @@ int parseDouble(double     *result,
 }
 
 /// Parse an unsigned long decimal string
+// requires: inputLength >= 0
+// ensures: (__out == BAEXML_SUCCESS ==> consumed == inputLength) && (__out == BAEXML_FAILURE ==> consumed != inputLength || inputLength == 0)
 int parseInt(int *result, const char *input, int inputLength)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -225,6 +233,8 @@ int parseInt(int *result, const char *input, int inputLength)
 }
 
 /// Parse an unsigned long decimal string
+// requires: inputLength > 0
+// ensures: (__out == BAEXML_SUCCESS ==> consumed == inputLength && errno == 0) && (__out == BAEXML_FAILURE ==> consumed != inputLength || errno != 0 || inputLength == 0)
 int parseUnsignedInt(unsigned int *result, const char *input, int inputLength)
 {
     enum { BAEXML_SUCCESS = 0, BAEXML_FAILURE = -1 };
@@ -304,6 +314,8 @@ int parseUnsignedDecimal(INT_TYPE *result, const char *input, int inputLength)
 /// Load, into the specificed `result`, the `Decimal64` value represented by
 /// the specified `input` string.  Return 0 on success and non-zero
 /// otherwise.
+// requires: input != NULL
+// ensures: (__out == BAEXML_SUCCESS) || (__out == BAEXML_FAILURE)
 int parseDecimal64Impl(bdldfp::Decimal64  *result,
                        const char         *input,
                        bool                decimalMode)

--- a/groups/bal/balxml/balxml_typesprintutil.cpp
+++ b/groups/bal/balxml/balxml_typesprintutil.cpp
@@ -751,6 +751,8 @@ const char *printTextReplacingXMLEscapes(
 /// `stream` and do not write anything.
 ///
 /// Return a modifiable reference to `stream`.
+// requires: true
+// ensures: __out == stream
 bsl::ostream& printDecimalWithDigitsOptions(bsl::ostream& stream,
                                             double        object,
                                             int           maxTotalDigits,

--- a/groups/bal/balxml/balxml_utf8readerwrapper.cpp
+++ b/groups/bal/balxml/balxml_utf8readerwrapper.cpp
@@ -49,6 +49,8 @@ namespace {
 namespace u {
 
 /// Return the specified `str` is `str != 0`, and "" otherwise.
+// requires: true
+// ensures: (str != 0 ==> __out == str) && (str == 0 ==> __out == "")
 inline
 const char *nonNullStr(const char *str)
 {
@@ -66,6 +68,8 @@ namespace balxml {
                                 // ------------
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: (__out == 0 || __out != 0)
 inline
 int Utf8ReaderWrapper::doOpen(const char *url, const char *encoding)
 {
@@ -265,6 +269,8 @@ int Utf8ReaderWrapper::advanceToNextNode()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_errorInfo.source().get_allocator().mechanism()
 bslma::Allocator *Utf8ReaderWrapper::allocator() const
 {
     return d_errorInfo.source().get_allocator().mechanism();

--- a/groups/bal/balxml/balxml_util.cpp
+++ b/groups/bal/balxml/balxml_util.cpp
@@ -145,6 +145,8 @@ namespace balxml {
                                 // -----------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == u::extractNamespaceFromXsd_Impl(xsdSource, targetNamespace)
 bool Util::extractNamespaceFromXsd(const bsl::string_view&  xsdSource,
                                    bsl::string             *targetNamespace)
 {

--- a/groups/bbl/bblb/bblb_schedulegenerationutil.cpp
+++ b/groups/bbl/bblb/bblb_schedulegenerationutil.cpp
@@ -66,6 +66,8 @@ void computeSerialMonthAndDay(int               *serialMonth,
 /// of the `month in `year'.  The behavior is undefined unless
 /// `1 <= year <= 9999`, `1 <= month <= 12`, and the resulting date is a
 /// valid `bdlt::Date`.
+// requires: (1 <= year && year <= 9999) && (1 <= month && month <= 12) && (1 <= day && day <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, month)) && (dayOfFeb == 0 || (1 <= dayOfFeb && dayOfFeb <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, 2)))
+// ensures: (__out == bdlt::Date(year, month, __out.day())) && (1 <= __out.day() && __out.day() <= bdlt::SerialDateImpUtil::lastDayOfMonth(year, month))
 inline
 bdlt::Date getDayOfMonth(int year, int month, int day, int dayOfFeb)
 {
@@ -86,6 +88,8 @@ bdlt::Date getDayOfMonth(int year, int month, int day, int dayOfFeb)
 /// by the ratio of the specified `numerator` and the specified
 /// `denominator`, without the use of floating-point calculations.  The
 /// behavior is undefined unless `denominator > 0`.
+// requires: denominator > 0
+// ensures: (numerator < 0 && numerator % denominator != 0) ==> (__out == (numerator / denominator - 1)) && (!(numerator < 0 && numerator % denominator != 0)) ==> (__out == (numerator / denominator))
 inline
 int rationalFloor(int numerator, int denominator)
 {
@@ -100,6 +104,8 @@ int rationalFloor(int numerator, int denominator)
 /// by the ratio of the specified `numerator` and the specified
 /// `denominator`, without the use of floating-point calculations.  The
 /// behavior is undefined unless `denominator > 0`.
+// requires: denominator > 0
+// ensures: ((numerator > 0 && numerator % denominator != 0) ==> __out == (numerator / denominator + 1)) && ((numerator <= 0 || numerator % denominator == 0) ==> __out == (numerator / denominator))
 inline
 int rationalCeiling(int numerator, int denominator)
 {
@@ -120,6 +126,8 @@ int rationalCeiling(int numerator, int denominator)
 /// serial month.  The behavior is undefined unless
 /// `k_MIN_SERIAL_MONTH <= exampleSerialMonth <= k_MAX_SERIAL_MONTH`, and
 /// `earliestSerialMonth <= latestSerialMonth`.
+// requires: u::k_MIN_SERIAL_MONTH <= exampleSerialMonth && exampleSerialMonth <= u::k_MAX_SERIAL_MONTH && earliestSerialMonth <= latestSerialMonth
+// ensures: (__out == e_OUT_OF_RANGE) ==> (startSerialMonthCandidate > u::k_MAX_SERIAL_MONTH || endSerialMonthCandidate < u::k_MIN_SERIAL_MONTH)
 int computeMonthRange(int *startSerialMonth,
                       int *endSerialMonth,
                       int  earliestSerialMonth,
@@ -197,6 +205,7 @@ int computeMonthRange(int *startSerialMonth,
 /// `k_MIN_SERIAL_MONTH <= *endSerialMonth <= k_MAX_SERIAL_MONTH`,
 /// `k_MIN_SERIAL_MONTH <= earliestSerialMonth <= k_MAX_SERIAL_MONTH`,
 /// `1 <= startDay <= 31`, and `1 <= endDay <= 31`.
+// ensures: (__out == e_VALID_RANGE ==> ((*startSerialMonth ↦ startSerialMonthCandidate) ⋆ (*endSerialMonth ↦ endSerialMonthCandidate))) && (__out == e_OUT_OF_RANGE ==> ((*startSerialMonth ↦ old_startSerialMonth) ⋆ (*endSerialMonth ↦ old_endSerialMonth)))
 int adjustMonthRange(int *startSerialMonth,
                      int *endSerialMonth,
                      int  startDay,

--- a/groups/bbl/bbldc/bbldc_basicactual360.cpp
+++ b/groups/bbl/bbldc/bbldc_basicactual360.cpp
@@ -14,6 +14,8 @@ namespace bbldc {
                           // ---------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == (endDate - beginDate) / 360.0
 double BasicActual360::yearsDiff(const bdlt::Date& beginDate,
                                  const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicactual36525.cpp
+++ b/groups/bbl/bbldc/bbldc_basicactual36525.cpp
@@ -14,6 +14,8 @@ namespace bbldc {
                          // -----------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == (endDate - beginDate) / 365.25
 double BasicActual36525::yearsDiff(const bdlt::Date& beginDate,
                                    const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicactual365fixed.cpp
+++ b/groups/bbl/bbldc/bbldc_basicactual365fixed.cpp
@@ -14,6 +14,8 @@ namespace bbldc {
                         // --------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == (endDate - beginDate) / 365.0
 double BasicActual365Fixed::yearsDiff(const bdlt::Date& beginDate,
                                       const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicdaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_basicdaycountutil.cpp
@@ -28,6 +28,8 @@ namespace bbldc {
                          // ------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (convention == DayCountConvention::e_ACTUAL_360 || convention == DayCountConvention::e_ACTUAL_365_25 || convention == DayCountConvention::e_ACTUAL_365_FIXED || convention == DayCountConvention::e_ISDA_1_1 || convention == DayCountConvention::e_ISDA_30_360_EOM || convention == DayCountConvention::e_ISDA_ACTUAL_ACTUAL || convention == DayCountConvention::e_ISMA_30_360 || convention == DayCountConvention::e_NL_365 || convention == DayCountConvention::e_PSA_30_360_EOM || convention == DayCountConvention::e_SIA_30_360_EOM || convention == DayCountConvention::e_SIA_30_360_NEOM) ==> __out == numDays
 int BasicDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                 const bdlt::Date&        endDate,
                                 DayCountConvention::Enum convention)

--- a/groups/bbl/bbldc/bbldc_basicisdaactualactual.cpp
+++ b/groups/bbl/bbldc/bbldc_basicisdaactualactual.cpp
@@ -17,6 +17,8 @@ namespace bbldc {
                        // ----------------------------
 
 // CLASS METHODS
+// requires: beginDate <= endDate
+// ensures: __out == (yDiff * daysInBeginYear * daysInEndYear + beginYearDayDiff * daysInEndYear + endYearDayDiff * daysInBeginYear) / static_cast<double>(daysInBeginYear * daysInEndYear)
 double BasicIsdaActualActual::yearsDiff(const bdlt::Date& beginDate,
                                         const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicisma30360.cpp
+++ b/groups/bbl/bbldc/bbldc_basicisma30360.cpp
@@ -17,6 +17,8 @@ namespace bbldc {
 /// `endDate` according to the ISMA 30/360 day-count convention.  If
 /// `beginDate <= endDate`, then the result is non-negative.  Note that
 /// reversing the order of `beginDate` and `endDate` negates the result.
+// requires: true
+// ensures: __out == ((yEnd - yBegin) * 360 + (mEnd - mBegin) * 30 + (dEnd == 31 ? 30 : dEnd) - (dBegin == 31 ? 30 : dBegin))
 static int computeDaysDiff(const bdlt::Date& beginDate,
                            const bdlt::Date& endDate)
 {
@@ -41,6 +43,8 @@ static int computeDaysDiff(const bdlt::Date& beginDate,
                              // ----------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == computeDaysDiff(beginDate, endDate)
 int BasicIsma30360::daysDiff(const bdlt::Date& beginDate,
                              const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicnl365.cpp
+++ b/groups/bbl/bbldc/bbldc_basicnl365.cpp
@@ -12,6 +12,8 @@ namespace bbldc {
                             // -----------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == ((y2 - y1) * 365 + (m2 - m1) * 31 - (s_daysInMonthCorrection[m2] - s_daysInMonthCorrection[m1]) + d2 - d1)
 int BasicNl365::daysDiff(const bdlt::Date& beginDate,
                          const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicpsa30360eom.cpp
+++ b/groups/bbl/bbldc/bbldc_basicpsa30360eom.cpp
@@ -19,6 +19,8 @@ namespace bbldc {
 /// specified `year` is the last day of February for that `year`, and
 /// `false` otherwise.  The behavior is undefined unless `year`, `month`,
 /// and `day` represent a valid `bdlt::Date` value.
+// requires: bdlt::Date::isValidYearMonthDay(year, month, day)
+// ensures: (__out == true ==> (month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year))))) && (__out == false ==> !(month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year)))))
 inline
 static bool isLastDayOfFebruary(int year, int month, int day)
 {
@@ -30,6 +32,8 @@ static bool isLastDayOfFebruary(int year, int month, int day)
 }
 
 /// Return the maximum of the specified `lhs` and `rhs` values.
+// requires: true
+// ensures: __out == lhs ==> lhs > rhs && __out == rhs ==> lhs <= rhs
 inline
 static int max(int lhs, int rhs)
 {
@@ -40,6 +44,8 @@ static int max(int lhs, int rhs)
 /// `endDate` according to the PSA 30/360 end-of-month day-count convention.
 /// If `beginDate <= endDate`, then the result is non-negative.  Note that
 /// reversing the order of `beginDate` and `endDate` negates the result.
+// requires: true
+// ensures: (beginDate <= endDate ==> __out >= 0) && (beginDate > endDate ==> __out <= 0)
 static int computeDaysDiff(const bdlt::Date& beginDate,
                            const bdlt::Date& endDate)
 {
@@ -81,6 +87,8 @@ static int computeDaysDiff(const bdlt::Date& beginDate,
                             // ------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == computeDaysDiff(beginDate, endDate)
 int BasicPsa30360Eom::daysDiff(const bdlt::Date& beginDate,
                                const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicsia30360eom.cpp
+++ b/groups/bbl/bbldc/bbldc_basicsia30360eom.cpp
@@ -19,6 +19,8 @@ namespace bbldc {
 /// specified `year` is the last day of February for that `year`, and
 /// `false` otherwise.  The behavior is undefined unless `year`, `month`,
 /// and `day` represent a valid `bdlt::Date` value.
+// requires: bdlt::Date::isValidYearMonthDay(year, month, day)
+// ensures: (__out == true ==> (month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year))))) && (__out == false ==> !(month == 2 && (day == 29 || (day == 28 && !bdlt::SerialDateImpUtil::isLeapYear(year)))))
 inline
 static bool isLastDayOfFebruary(int year, int month, int day)
 {
@@ -33,6 +35,8 @@ static bool isLastDayOfFebruary(int year, int month, int day)
 /// `endDate` according to the SIA 30/360 end-of-month day-count convention.
 /// If `beginDate <= endDate`, then the result is non-negative.  Note that
 /// reversing the order of `beginDate` and `endDate` negates the result.
+// requires: true
+// ensures: (beginDate > endDate ==> __out <= 0) && (beginDate < endDate ==> __out >= 0) && (beginDate == endDate ==> __out == 0)
 static int computeDaysDiff(const bdlt::Date& beginDate,
                            const bdlt::Date& endDate)
 {
@@ -74,6 +78,8 @@ static int computeDaysDiff(const bdlt::Date& beginDate,
                          // -----------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == computeDaysDiff(beginDate, endDate)
 int BasicSia30360Eom::daysDiff(const bdlt::Date& beginDate,
                                const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_basicsia30360neom.cpp
+++ b/groups/bbl/bbldc/bbldc_basicsia30360neom.cpp
@@ -18,6 +18,8 @@ namespace bbldc {
 /// convention.  If `beginDate <= endDate`, then the result is non-negative.
 /// Note that reversing the order of `beginDate` and `endDate` negates the
 /// result.
+// requires: true
+// ensures: (beginDate > endDate ==> __out <= 0) && (beginDate < endDate ==> __out >= 0) && (beginDate == endDate ==> __out == 0)
 inline
 static int computeDaysDiff(const bdlt::Date& beginDate,
                            const bdlt::Date& endDate)
@@ -54,6 +56,8 @@ static int computeDaysDiff(const bdlt::Date& beginDate,
                          // ------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == computeDaysDiff(beginDate, endDate)
 int BasicSia30360Neom::daysDiff(const bdlt::Date& beginDate,
                                 const bdlt::Date& endDate)
 {

--- a/groups/bbl/bbldc/bbldc_calendardaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_calendardaycountutil.cpp
@@ -19,6 +19,8 @@ namespace bbldc {
                        // ---------------------------
 
 // CLASS METHODS
+// requires: calendar.isInRange(beginDate) && calendar.isInRange(endDate)
+// ensures: (convention == DayCountConvention::e_CALENDAR_BUS_252 ==> __out == bbldc::CalendarBus252::daysDiff(beginDate, endDate, calendar)) && (convention != DayCountConvention::e_CALENDAR_BUS_252 ==> __out == 0)
 int CalendarDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                    const bdlt::Date&        endDate,
                                    const bdlt::Calendar&    calendar,

--- a/groups/bbl/bbldc/bbldc_daycountconvention.cpp
+++ b/groups/bbl/bbldc/bbldc_daycountconvention.cpp
@@ -16,6 +16,8 @@ namespace bbldc {
                         // -------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (__out == stream) && SEPFORALL(0, sizeof(toAscii(value)), i, stream + i ↦ toAscii(value)[i])
 bsl::ostream& DayCountConvention::print(
                                        bsl::ostream&            stream,
                                        DayCountConvention::Enum value,

--- a/groups/bbl/bbldc/bbldc_perioddaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_perioddaycountutil.cpp
@@ -41,6 +41,8 @@ static bool isSortedAndUnique(const ITER& begin, const ITER& end)
                         // -------------------------
 
 // PRIVATE CLASS METHODS
+// requires: 2 <= (periodDateEnd - periodDateBegin) && *periodDateBegin <= beginDate && beginDate <= *(periodDateEnd - 1) && *periodDateBegin <= endDate && endDate <= *(periodDateEnd - 1) && FORALL(periodDateBegin, periodDateEnd, i, *(i) <= *(i + 1))
+// ensures: (convention == DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == bbldc::PeriodIcmaActualActual::yearsDiff(beginDate, endDate, periodDateBegin, periodDateEnd, periodYearDiff)) && (convention != DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == 0.0)
 double PeriodDayCountUtil::yearsDiffImp(
                                      const bdlt::Date&         beginDate,
                                      const bdlt::Date&         endDate,
@@ -77,6 +79,8 @@ double PeriodDayCountUtil::yearsDiffImp(
 }
 
 // CLASS METHODS
+// requires: true
+// ensures: (convention == DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == bbldc::PeriodIcmaActualActual::daysDiff(beginDate, endDate)) && (convention != DayCountConvention::e_PERIOD_ICMA_ACTUAL_ACTUAL ==> __out == 0)
 int PeriodDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                  const bdlt::Date&        endDate,
                                  DayCountConvention::Enum convention)

--- a/groups/bbl/bbldc/bbldc_periodicmaactualactual.cpp
+++ b/groups/bbl/bbldc/bbldc_periodicmaactualactual.cpp
@@ -48,6 +48,8 @@ namespace bbldc {
                       // -----------------------------
 
 // CLASS METHODS
+// requires: ...
+// ensures: (beginDate == endDate ==> __out == 0.0) && (beginDate != endDate ==> __out != 0.0)
 double PeriodIcmaActualActual::yearsDiff(const bdlt::Date&  beginDate,
                                          const bdlt::Date&  endDate,
                                          const bdlt::Date  *periodDateBegin,

--- a/groups/bbl/bbldc/bbldc_terminateddaycountutil.cpp
+++ b/groups/bbl/bbldc/bbldc_terminateddaycountutil.cpp
@@ -18,6 +18,8 @@ namespace bbldc {
                       // -----------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (convention == DayCountConvention::e_ISDA_30_360_EOM ==> __out == bbldc::TerminatedIsda30360Eom::daysDiff(beginDate, endDate, terminationDate)) && (convention != DayCountConvention::e_ISDA_30_360_EOM ==> __out == 0)
 int TerminatedDayCountUtil::daysDiff(const bdlt::Date&        beginDate,
                                      const bdlt::Date&        endDate,
                                      const bdlt::Date&        terminationDate,

--- a/groups/bbl/bbldc/bbldc_terminatedisda30360eom.cpp
+++ b/groups/bbl/bbldc/bbldc_terminatedisda30360eom.cpp
@@ -15,6 +15,8 @@ namespace bbldc {
                       // -----------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == ((beginDate <= endDate ? 1 : -1) * (((y2 - y1) * 360 + (m2 - m1) * 30 + d2) - d1))
 int TerminatedIsda30360Eom::daysDiff(const bdlt::Date& beginDate,
                                      const bdlt::Date& endDate,
                                      const bdlt::Date& terminationDate)

--- a/groups/bdl/bdlat/bdlat_enumeratorinfo.cpp
+++ b/groups/bdl/bdlat/bdlat_enumeratorinfo.cpp
@@ -13,6 +13,8 @@ namespace BloombergLP {
                         // ---------------------------
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& operator<<(bsl::ostream&               stream,
                          const bdlat_EnumeratorInfo& enumeratorInfo)
 {

--- a/groups/bdl/bdlat/bdlat_selectioninfo.cpp
+++ b/groups/bdl/bdlat/bdlat_selectioninfo.cpp
@@ -13,6 +13,8 @@ namespace BloombergLP {
                          // --------------------------
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& operator<<(bsl::ostream&              stream,
                          const bdlat_SelectionInfo& selectionInfo)
 {

--- a/groups/bdl/bdlb/bdlb_bigendian.cpp
+++ b/groups/bdl/bdlb/bdlb_bigendian.cpp
@@ -27,6 +27,8 @@ namespace bdlb {
                          // --------------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: __out == stream
 bsl::ostream& BigEndianInt16::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const
@@ -80,6 +82,8 @@ bsl::ostream& BigEndianUint16::print(bsl::ostream& stream,
                          // --------------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: (__out == stream) && (!stream.bad()) && (stream ↦ _)
 bsl::ostream& BigEndianInt32::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const

--- a/groups/bdl/bdlb/bdlb_bitstringutil.cpp
+++ b/groups/bdl/bdlb/bdlb_bitstringutil.cpp
@@ -123,6 +123,8 @@ BSLMF_ASSERT(0 == (k_BITS_PER_UINT64 & (k_BITS_PER_UINT64 - 1))); // power of 2
 /// cast to is `unsigned int`, not `int`, since the `int` could wind up
 /// negative, in which case the `%` operation could return a negative
 /// result.
+// requires: true
+// ensures: __out == static_cast<unsigned int>(value)
 static inline
 unsigned int u32(uint64_t value)
 {
@@ -232,6 +234,8 @@ BitPtrDiff::BitPtrDiff(IntPtr hi, unsigned lo)
 }
 
 // ACCESSOR
+// requires: true
+// ensures: (__out.d_hi == (~d_hi + (d_lo & k_UNUSED_LO_MASK ? 1 : 0))
 inline
 BitPtrDiff BitPtrDiff::operator-() const
 {
@@ -260,6 +264,8 @@ BitPtrDiff BitPtrDiff::operator-() const
 
 /// Return `true` if the specified `lhs` is greater than the specified
 /// `rhs`, and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (lhs.d_hi > rhs.d_hi || (lhs.d_hi == rhs.d_hi && lhs.d_lo > rhs.d_lo))) && (__out == false ==> !(lhs.d_hi > rhs.d_hi || (lhs.d_hi == rhs.d_hi && lhs.d_lo > rhs.d_lo)))
 inline
 bool operator>(const BitPtrDiff& lhs, const BitPtrDiff& rhs)
 {
@@ -415,6 +421,7 @@ BitPtr::BitPtr(const uint64_t *ptr, size_t index)
 
 /// Return a `BitPtrDiff` representing the distance in bits between the
 /// specified `lhs` and `rhs`.
+// ensures: (__out.d_hi == lhs.d_hi - rhs.d_hi - (lhs.d_lo < rhs.d_lo ? 1 : 0)) && (__out.d_lo == lhs.d_lo - rhs.d_lo + (lhs.d_lo < rhs.d_lo ? k_BITS_PER_UINT64 : 0))
 inline
 BitPtrDiff operator-(const BitPtr& lhs, const BitPtr& rhs)
 {
@@ -889,6 +896,8 @@ void Mover<OPER_DO_BITS, OPER_DO_ALIGNED_WORD>::move(
 /// `0 <= numBits < k_BITS_PER_UINT64`.  Note that this function performs
 /// the same calculation as `BitMaskUtil::lt64`, except that it doesn't
 /// waste time handling the case of `k_BITS_PER_UINT64 == numBits`.
+// requires: 0 <= numBits && numBits < 64
+// ensures: __out == ((1ULL << numBits) - 1)
 static inline
 uint64_t lt64Raw(int numBits)
 {
@@ -903,6 +912,8 @@ uint64_t lt64Raw(int numBits)
 /// `0 <= numBits < k_BITS_PER_UINT64`.  Note that this function performs
 /// the same calculation as `BitMaskUtil::ge64`, except that it doesn't
 /// waste time handling the case of `k_BITS_PER_UINT64 == numBits`.
+// requires: 0 <= numBits && numBits < 64
+// ensures: (__out == (~0ULL << numBits)) && (0 <= numBits) && (numBits < 64)
 static inline
 uint64_t ge64Raw(int numBits)
 {
@@ -933,6 +944,8 @@ TYPE absRaw(TYPE x)
 /// `pos1 + numBits <= k_BITS_PER_UINT64`, and
 /// `pos2 + numBits <= k_BITS_PER_UINT64`.  Note that this function does not
 /// handle the case of `0 == numBits`.
+// requires: numBits + pos1 <= k_BITS_PER_UINT64 && numBits + pos2 <= k_BITS_PER_UINT64
+// ensures: (__out == true ==> (((word1 >> pos1) ^ (word2 >> pos2)) & BitMaskUtil::lt64(numBits)) != 0) && (__out == false ==> (((word1 >> pos1) ^ (word2 >> pos2)) & BitMaskUtil::lt64(numBits)) == 0)
 static inline
 bool bitsInWordsDiffer(uint64_t word1,
                        int      pos1,
@@ -1022,6 +1035,8 @@ void putSpaces(bsl::ostream& stream, int numSpaces)
 /// Output indentation to the specified `stream` that is appropriate
 /// according to BDE printing conventions for the specified `level` and
 /// the specified `spacesPerLevel`.
+// requires: level >= 0 && spacesPerLevel >= 0
+// ensures: (__out == stream) && (spacesPerLevel >= 0) && SEPFORALL(0, level * spacesPerLevel, i, (stream + i ↦ ' '))
 static
 bsl::ostream& indent(bsl::ostream& stream,
                      int           level,

--- a/groups/bdl/bdlb/bdlb_caselessstringviewhash.cpp
+++ b/groups/bdl/bdlb/bdlb_caselessstringviewhash.cpp
@@ -22,6 +22,8 @@ namespace bdlb {
                        // -----------------------------
 
 // ACCESSORS
+// requires: true
+// ensures: true
 bsl::size_t CaselessStringViewHash::operator()(bsl::string_view argument) const
 {
     char buffer[1024];

--- a/groups/bdl/bdlb/bdlb_doublecompareutil.cpp
+++ b/groups/bdl/bdlb/bdlb_doublecompareutil.cpp
@@ -15,6 +15,8 @@ const double DoubleCompareUtil::k_DEFAULT_RELATIVE_TOLERANCE = 1e-12;
 const double DoubleCompareUtil::k_DEFAULT_ABSOLUTE_TOLERANCE = 1e-24;
 
 /// Return the absolute value of the specified `input`.
+// requires: true
+// ensures: (input >= 0.0 ==> __out == input) && (input < 0.0 ==> __out == -input)
 static inline
 double fabsval(double input)
 {

--- a/groups/bdl/bdlb/bdlb_float.cpp
+++ b/groups/bdl/bdlb/bdlb_float.cpp
@@ -58,6 +58,8 @@ namespace {
 /// Using `bsl::memcpy` is the only portable way to copy the contents of
 /// `number` into an integral type without aliasing and/or alignment
 /// problems.
+// requires: true
+// ensures: __out == *reinterpret_cast<FloatRep_t*>(&number)
 inline
 FloatRep_t toRep(float number)
 {
@@ -67,6 +69,8 @@ FloatRep_t toRep(float number)
 }
 
 /// Implementation of `bdlb::Float::classify(float number)`.
+// requires: true
+// ensures: (numberExp == 0 && (number & floatManMask) != 0 ==> __out == bdlb::Float::k_SUBNORMAL) && (numberExp == 0 && (number & floatManMask) == 0 ==> __out == bdlb::Float::k_ZERO) && (numberExp == floatExpMask && (number & floatManMask) != 0 ==> __out == bdlb::Float::k_NAN) && (numberExp == floatExpMask && (number & floatManMask) == 0 ==> __out == bdlb::Float::k_INFINITE) && (numberExp != 0 && numberExp != floatExpMask ==> __out == bdlb::Float::k_NORMAL)
 inline
 bdlb::Float::Classification classifyImp(FloatRep_t number)
 {
@@ -202,6 +206,8 @@ namespace {
 /// Using `bsl::memcpy` is the only portable way to copy the contents of
 /// `number` into an integral type without aliasing and/or alignment
 /// problems.
+// requires: true
+// ensures: __out == *reinterpret_cast<DoubleRep_t*>(&number)
 inline
 DoubleRep_t toRep(double number)
 {
@@ -212,6 +218,8 @@ DoubleRep_t toRep(double number)
 }
 
 /// Implementation of `bdlb::Float::classify(double number)`.
+// requires: true
+// ensures: (numberExp == 0 && (number & doubleManMask) != 0 ==> __out == bdlb::Float::k_SUBNORMAL) && (numberExp == 0 && (number & doubleManMask) == 0 ==> __out == bdlb::Float::k_ZERO) && (numberExp == doubleExpMask && (number & doubleManMask) != 0 ==> __out == bdlb::Float::k_NAN) && (numberExp == doubleExpMask && (number & doubleManMask) == 0 ==> __out == bdlb::Float::k_INFINITE) && (numberExp != 0 && numberExp != doubleExpMask ==> __out == bdlb::Float::k_NORMAL)
 inline
 bdlb::Float::Classification classifyImp(DoubleRep_t number)
 {

--- a/groups/bdl/bdlb/bdlb_guid.cpp
+++ b/groups/bdl/bdlb/bdlb_guid.cpp
@@ -57,6 +57,8 @@ void hex16sse(void *dst, const unsigned char *src)
 
 #else
 
+// requires: x >= 0 && x <= 15
+// ensures: __out == "0123456789abcdef"[x]
 char hex1(unsigned x)
     // Return the equivalent hex ASCII character for the nibble specified in
     // 'x'.
@@ -142,6 +144,8 @@ bsl::ostream& Guid::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == (bsl::memcmp(&lhs[0], &rhs[0], bdlb::Guid::k_GUID_NUM_BYTES) < 0)
 bool bdlb::operator<(const bdlb::Guid& lhs, const bdlb::Guid& rhs)
 {
     return bsl::memcmp(&lhs[0], &rhs[0], bdlb::Guid::k_GUID_NUM_BYTES) < 0;

--- a/groups/bdl/bdlb/bdlb_guidutil.cpp
+++ b/groups/bdl/bdlb/bdlb_guidutil.cpp
@@ -51,6 +51,8 @@ namespace {
 /// Convert the character in the specified `c` to it suitable hex
 /// equivalent if one exists, load the value into the specified `hex`.
 /// Return 0 if the conversion was successful, and non-zero otherwise.
+// requires: hex != 0 && (c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F')
+// ensures: (__out == 0 && ((c >= '0' && c <= '9' && (hex ↦ c - '0')) || (c >= 'a' && c <= 'f' && (hex ↦ c - 'a' + 10)) || (c >= 'A' && c <= 'F' && (hex ↦ c - 'A' + 10)))) || (__out == -1 && (hex ↦ old_hex))
 int charToHex(unsigned char* hex, unsigned char c)
 {
     switch (c) {
@@ -196,6 +198,8 @@ void guidToStringImpl<bsl::string>(bsl::string *result, const Guid& guid)
 
 /// Return the process id.  Having this be separate from `Obj::getProcessId`
 /// allows us to call it inline within the component.
+// requires: true
+// ensures: true
 inline int getPid()
 {
 #ifdef BSLS_PLATFORM_OS_WINDOWS

--- a/groups/bdl/bdlb/bdlb_hashutil.cpp
+++ b/groups/bdl/bdlb/bdlb_hashutil.cpp
@@ -152,6 +152,8 @@ namespace bdlb {
                             // ---------------
 
 // CLASS METHODS
+// requires: (length >= 0) && (length == 0 || data != NULL)
+// ensures: __out >= 0
 unsigned int HashUtil::hash1(const char *data, int length)
 {
     BSLS_ASSERT(0 <= length);

--- a/groups/bdl/bdlb/bdlb_numericparseutil.cpp
+++ b/groups/bdl/bdlb/bdlb_numericparseutil.cpp
@@ -83,6 +83,8 @@ typedef bsls::Types::Uint64 Uint64;
 /// Return a string reference to the characters of the specified
 /// `positiveNum` that do not contain the optionally present first `+`
 /// ASCII character.  The behavior is undefined if `positiveNum.empty()`.
+// requires: !positiveNum.empty()
+// ensures: (positiveNum[0] == '+' ==> __out == positiveNum.substr(1)) && (positiveNum[0] != '+' ==> __out == positiveNum)
 static
 inline
 bsl::string_view stripOptionalPlus(const bsl::string_view& positiveNum)
@@ -135,6 +137,8 @@ double reparseOutOfRange(const char              **restPtr,
 #else   // end - using 'double' 'from_chars' / begin - using 'strtod'
 
                               // Portability
+// requires: true
+// ensures: (__out == true ==> bsl::isinf(number)) && (__out == false ==> !bsl::isinf(number))
 static
 bool isInf(double number)
     // Return 'true' if the specified 'number' is a positive or negative
@@ -161,6 +165,8 @@ bool isInf(double number)
 }
 
 #ifdef BDLB_NUMERICPARSEUTIL_STRTOD_PARSES_HEXFLOAT
+// requires: stdlibInput.size() >= 2
+// ensures: (__out == true ==> (stdlibInput.substr(0, 2) == "0x" || stdlibInput.substr(0, 2) == "0X")) && (__out == false ==> (stdlibInput.substr(0, 2) != "0x" && stdlibInput.substr(0, 2) != "0X"))
 static
 bool hasHexPrefix(const bsl::string_view& stdlibInput)
     // Return 'true' if the first two characters of the specified 'stdlibInput'
@@ -185,6 +191,8 @@ namespace bdlb {
                         // struct NumericParseUtil
                         // -----------------------
 // CLASS METHODS
+// requires: (2 <= base && base <= 36) && (Ct::isDigit(character) || (Ct::isAlpha(character) && (Ct::toLower(character) - aShift < base)))
+// ensures: (0 <= __out && __out < base) || __out == -1
 int NumericParseUtil::characterToDigit(char character, int base)
 {
     BSLS_ASSERT_SAFE(2 <= base);

--- a/groups/bdl/bdlb/bdlb_print.cpp
+++ b/groups/bdl/bdlb/bdlb_print.cpp
@@ -362,6 +362,8 @@ namespace bdlb {
                              // ------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& Print::indent(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel)

--- a/groups/bdl/bdlb/bdlb_randomdevice.cpp
+++ b/groups/bdl/bdlb/bdlb_randomdevice.cpp
@@ -82,6 +82,8 @@ namespace bdlb {
                         // ------------------------
 
 // CLASS METHODS
+// requires: (numBytes == 0) || (buffer != 0 && SEPFORALL(0, numBytes, i, (buffer + i ↦ _)))
+// ensures: (numBytes == 0 ==> __out == 0) && (numBytes > 0 ==> SEPFORALL(0, numBytes, i, (buffer + i ↦ _)))
 int RandomDevice::getRandomBytes(unsigned char *buffer, size_t numBytes)
 {
     if (0 == numBytes) {

--- a/groups/bdl/bdlb/bdlb_string.cpp
+++ b/groups/bdl/bdlb/bdlb_string.cpp
@@ -15,6 +15,8 @@ namespace bdlb {
                                // -------------
 
 // CLASS METHODS
+// requires: lhsString != nullptr && rhsString != nullptr && SEPFORALL(0, strlen(lhsString), i, (lhsString + i ↦ _)) && SEPFORALL(0, strlen(rhsString), i, (rhsString + i ↦ _))
+// ensures: (__out == true ==> SEPFORALL(0, strlen(lhsString), i, (bdlb::CharType::toLower(lhsString[i]) == bdlb::CharType::toLower(rhsString[i])))) && (__out == false ==> SEPEXISTS(0, strlen(lhsString), i, (bdlb::CharType::toLower(lhsString[i]) != bdlb::CharType::toLower(rhsString[i]))) || strlen(lhsString) != strlen(rhsString))
 bool String::areEqualCaseless(const char *lhsString,
                               const char *rhsString)
 {

--- a/groups/bdl/bdlb/bdlb_stringrefutil.cpp
+++ b/groups/bdl/bdlb/bdlb_stringrefutil.cpp
@@ -13,6 +13,8 @@ namespace bdlb {
 /// case character, and return `ch` otherwise; the sequence of characters
 /// `[A .. Z]` is mapped to `[a .. z]`.  The behavior is undefined unless
 /// characters are ASCII encoded.
+// requires: true
+// ensures: (('A' <= ch && ch <= 'Z') ==> __out == (ch | 0x20)) && (!(('A' <= ch && ch <= 'Z')) ==> __out == ch)
 static inline int u_upperToLower(int ch)
 {
     return 'A' <= ch && ch <= 'Z'
@@ -24,6 +26,8 @@ static inline int u_upperToLower(int ch)
 /// case character, and return `ch` otherwise; the sequence of characters
 /// `[a .. z]` is mapped to `[A .. Z]`.  The behavior is undefined unless
 /// characters are ASCII encoded.
+// requires: true
+// ensures: (('a' <= ch && ch <= 'z') ==> __out == (ch & ~0x20)) && (!(('a' <= ch && ch <= 'z')) ==> __out == ch)
 static inline int u_lowerToUpper(int ch)
 {
     return 'a' <= ch && ch <= 'z'

--- a/groups/bdl/bdlb/bdlb_tokenizer.cpp
+++ b/groups/bdl/bdlb/bdlb_tokenizer.cpp
@@ -152,6 +152,8 @@ TokenizerIterator::TokenizerIterator(const TokenizerIterator& origin)
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (this != &rhs ==> (d_sharedData_p == rhs.d_sharedData_p ⋆ d_cursor_p == rhs.d_cursor_p ⋆ d_token_p == rhs.d_token_p ⋆ d_postDelim_p == rhs.d_postDelim_p ⋆ d_end_p == rhs.d_end_p ⋆ d_endFlag == rhs.d_endFlag)) && (__out == *this)
 TokenizerIterator& TokenizerIterator::operator=(const TokenizerIterator& rhs)
 {
     if (this != &rhs)
@@ -314,6 +316,8 @@ Tokenizer::~Tokenizer()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: &__out == this
 Tokenizer& Tokenizer::operator++()
 {
     // Operator++ called on invalid tokenizer
@@ -408,6 +412,8 @@ void Tokenizer::reset(const bsl::string_view& input)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == true ==> SEPEXISTS(0, d_token_p - d_prevDelim_p, i, (d_prevDelim_p + i) ↦ sep_v && d_sharedData.inputType(sep_v) == SFT)) && (__out == false ==> SEPFORALL(0, d_token_p - d_prevDelim_p, i, (d_prevDelim_p + i) ↦ sep_v && d_sharedData.inputType(sep_v) != SFT))
 bool Tokenizer::hasPreviousSoft() const
 {
     const char *p = d_prevDelim_p;

--- a/groups/bdl/bdlbb/bdlbb_blob.cpp
+++ b/groups/bdl/bdlbb/bdlbb_blob.cpp
@@ -37,6 +37,8 @@ namespace bdlbb {
                               // ================
 
 // MANIPULATORS
+// requires: rhs.d_buffer ↦ _ ⋆ rhs.d_size ↦ _
+// ensures: (this->d_buffer ↦ rhs.d_buffer) ⋆ (this->d_size ↦ rhs.d_size)
 BlobBuffer& BlobBuffer::operator=(const BlobBuffer& rhs)
 {
     d_buffer = rhs.d_buffer;
@@ -97,6 +99,8 @@ BlobBuffer BlobBuffer::trim(int toSize)
 }
 
 // ACCESSORS
+// requires: stream ↦ _
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& BlobBuffer::print(bsl::ostream& stream, int, int) const
 {
     bdlb::Print::hexDump(stream, d_buffer.get(), d_size);
@@ -105,6 +109,8 @@ bsl::ostream& BlobBuffer::print(bsl::ostream& stream, int, int) const
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == buffer.print(stream, 0, -1)
 bsl::ostream& bdlbb::operator<<(bsl::ostream& stream, const BlobBuffer& buffer)
 {
     return buffer.print(stream, 0, -1);
@@ -134,6 +140,7 @@ BlobBufferFactory::~BlobBufferFactory()
                                  // ==========
 
 // PRIVATE ACCESSORS
+// ensures: __out == 0
 int Blob::assertInvariants() const
 {
     BSLS_ASSERT(0 <= d_totalSize);
@@ -761,6 +768,8 @@ void Blob::moveAndAppendDataBuffers(Blob *srcBlob)
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == true ==> (lhs.d_buffers == rhs.d_buffers && lhs.d_totalSize == rhs.d_totalSize && lhs.d_dataLength == rhs.d_dataLength && lhs.d_dataIndex == rhs.d_dataIndex && lhs.d_preDataIndexLength == rhs.d_preDataIndexLength)) && (__out == false ==> !(lhs.d_buffers == rhs.d_buffers && lhs.d_totalSize == rhs.d_totalSize && lhs.d_dataLength == rhs.d_dataLength && lhs.d_dataIndex == rhs.d_dataIndex && lhs.d_preDataIndexLength == rhs.d_preDataIndexLength))
 bool bdlbb::operator==(const Blob& lhs, const Blob& rhs)
 {
     return lhs.d_buffers == rhs.d_buffers &&

--- a/groups/bdl/bdlbb/bdlbb_blobstreambuf.cpp
+++ b/groups/bdl/bdlbb/bdlbb_blobstreambuf.cpp
@@ -100,6 +100,8 @@ void InBlobStreamBuf::setGetPosition(bsl::size_t position)
 }
 
 // PRIVATE ACCESSORS
+// requires: true
+// ensures: __out == 0
 int InBlobStreamBuf::checkInvariant() const
 {
     bsl::size_t numBuffers = d_blob_p->numBuffers();
@@ -125,6 +127,8 @@ int InBlobStreamBuf::checkInvariant() const
 }
 
 // PROTECTED MANIPULATORS
+// requires: true
+// ensures: __out == traits_type::eof()
 InBlobStreamBuf::int_type InBlobStreamBuf::overflow(InBlobStreamBuf::int_type)
 {
     return traits_type::eof();
@@ -405,6 +409,8 @@ void OutBlobStreamBuf::setPutPosition(bsl::size_t position)
 }
 
 // PRIVATE ACCESSORS
+// requires: true
+// ensures: __out == 0
 int OutBlobStreamBuf::checkInvariant() const
 {
     bsl::size_t numBuffers = d_blob_p->numBuffers();
@@ -431,6 +437,8 @@ int OutBlobStreamBuf::checkInvariant() const
 }
 
 // PROTECTED MANIPULATORS
+// requires: true
+// ensures: (c == EOF ==> __out == traits_type::not_eof(c)) && (c != EOF ==> __out == c)
 OutBlobStreamBuf::int_type OutBlobStreamBuf::overflow(
                                                   OutBlobStreamBuf::int_type c)
 {

--- a/groups/bdl/bdlbb/bdlbb_blobutil.cpp
+++ b/groups/bdl/bdlbb/bdlbb_blobutil.cpp
@@ -60,6 +60,8 @@ void copyFromPlace(char                *dstBuffer,
 /// `stream`.  The behavior is undefined unless `0 <= bufferIndex`,
 /// `0 <= numBytes`, and the incrementing `bufferIndex` does not reach the
 /// number of data buffers.
+// requires: 0 <= bufferIndex && bufferIndex < source.numDataBuffers() && 0 <= numBytes && numBytes <= source.totalSize() - source.sizeUpToBuffer(bufferIndex)
+// ensures: SEPFORALL(0, numBytes, i, stream + i ↦ source.buffer(bufferIndex + i / source.buffer(bufferIndex).size()).data()[i % source.buffer(bufferIndex).size()])
 bsl::ostream& asciiDumpFromBufferStart(bsl::ostream&      stream,
                                        const bdlbb::Blob& source,
                                        int                bufferIndex,

--- a/groups/bdl/bdlbb/bdlbb_simpleblobbufferfactory.cpp
+++ b/groups/bdl/bdlbb/bdlbb_simpleblobbufferfactory.cpp
@@ -45,6 +45,8 @@ void SimpleBlobBufferFactory::setBufferSize(int bufferSize)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_size
 int SimpleBlobBufferFactory::bufferSize() const
 {
     return d_size;

--- a/groups/bdl/bdlc/bdlc_bitarray.cpp
+++ b/groups/bdl/bdlc/bdlc_bitarray.cpp
@@ -28,6 +28,8 @@ namespace bdlc {
 /// behavior is undefined unless `0 <= numBits < k_BITS_PER_UINT64`.  Note
 /// that this is a faster version of `bdlb::BitMaskUtil::lt64` with a
 /// narrower contract.
+// requires: 0 <= numBits && numBits < BitArray::k_BITS_PER_UINT64
+// ensures: __out == ((static_cast<uint64_t>(1) << numBits) - 1)
 static inline
 uint64_t rawLt64(int numBits)
 {

--- a/groups/bdl/bdlc/bdlc_hashtable.cpp
+++ b/groups/bdl/bdlc/bdlc_hashtable.cpp
@@ -287,6 +287,8 @@ const int           HashTable_ImpUtil::NUM_PRIME_NUMBERS
                                                        = NUM_PRIME_NUMBERS_IMP;
 
 // CLASS METHODS
+// requires: hint != 0
+// ensures: __out != 0 && (__out == *bsl::lower_bound(PRIME_NUMBERS, PRIME_NUMBERS + NUM_PRIME_NUMBERS, (0 < hint) ? hint : -hint) || __out == *(bsl::lower_bound(PRIME_NUMBERS, PRIME_NUMBERS + NUM_PRIME_NUMBERS, (0 < hint) ? hint : -hint) - 1))
 unsigned int HashTable_ImpUtil::hashSize(bsls::Types::Int64 hint)
 {
     BSLS_ASSERT(0 != hint);

--- a/groups/bdl/bdlc/bdlc_indexclerk.cpp
+++ b/groups/bdl/bdlc/bdlc_indexclerk.cpp
@@ -31,6 +31,8 @@ namespace bdlc {
                               // ----------------
 
 // PRIVATE ACCESSORS
+// requires: true
+// ensures: (__out == false) ==> (indicesInvalid != 0 || indicesNotUnique & 0x2)
 bool
 IndexClerk::areInvariantsPreserved(const bsl::vector<int>& unusedStack,
                                    int                     nextNewIndex)
@@ -60,6 +62,8 @@ IndexClerk::areInvariantsPreserved(const bsl::vector<int>& unusedStack,
 }
 
 // ACCESSORS
+// requires: (unsigned int)index < (unsigned int)d_nextNewIndex
+// ensures: (__out == false ==> EXISTS(0, d_unusedStack.size(), i, d_unusedStack[i] == index)) && (__out == true ==> FORALL(0, d_unusedStack.size(), i, d_unusedStack[i] != index))
 bool IndexClerk::isInUse(int index) const
 {
     BSLS_ASSERT((unsigned int) index < (unsigned int)d_nextNewIndex);

--- a/groups/bdl/bdlcc/bdlcc_fixedqueueindexmanager.cpp
+++ b/groups/bdl/bdlcc/bdlcc_fixedqueueindexmanager.cpp
@@ -227,6 +227,8 @@ static const unsigned int k_NUM_REPRESENTABLE_COMBINED_INDICES =
 /// Return an encoded state value comprising the specified `generation` and
 /// the specified `indexState`.  Note that the resulting encoded value is
 /// appropriate for storage in the `d_states` array.
+// requires: true
+// ensures: __out == ((generation << k_GENERATION_COUNT_SHIFT) | indexState)
 inline
 static unsigned int encodeElementState(unsigned int generation,
                                        ElementState indexState)
@@ -238,6 +240,8 @@ static unsigned int encodeElementState(unsigned int generation,
 /// behavior is undefined unless `value` was encoded by
 /// `encodeElementState`.  Note that `encodedState` is typically obtained
 /// from the `d_states` array.
+// requires: true
+// ensures: __out == (encodedState >> k_GENERATION_COUNT_SHIFT)
 inline
 static unsigned int decodeGenerationFromElementState(unsigned int encodedState)
 {
@@ -248,6 +252,8 @@ static unsigned int decodeGenerationFromElementState(unsigned int encodedState)
 /// is undefined unless `encodedState` was encoded by `encodeElementState`.
 /// Note that `encodedState` is typically obtained from the `d_states`
 /// array.
+// requires: true
+// ensures: __out == ElementState(encodedState & k_ELEMENT_STATE_MASK)
 inline
 static ElementState decodeStateFromElementState(unsigned int encodedState)
 {
@@ -261,6 +267,8 @@ static ElementState decodeStateFromElementState(unsigned int encodedState)
 
 /// Return `true` if the specified `encodedPushIndex` has the disabled flag
 /// set, and 'false otherwise.
+// requires: true
+// ensures: __out == ((encodedPushIndex & k_DISABLED_STATE_MASK) != 0)
 inline
 static bool isDisabledFlagSet(unsigned int encodedPushIndex)
 {
@@ -269,6 +277,8 @@ static bool isDisabledFlagSet(unsigned int encodedPushIndex)
 
 /// Return the push-index of the specified `encodedPushIndex`, discarding
 /// the disabled flag.
+// requires: true
+// ensures: __out == (encodedPushIndex & ~k_DISABLED_STATE_MASK)
 inline
 static unsigned int discardDisabledFlag(unsigned int encodedPushIndex)
 {
@@ -780,6 +790,8 @@ void FixedQueueIndexManager::abortPushIndexReservation(unsigned int generation,
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out >= 0) && (__out <= d_capacity)
 bsl::size_t FixedQueueIndexManager::length() const
 {
     // Note that 'FixedQueue::pushBack' and 'FixedQueue::popFront' rely on the

--- a/groups/bdl/bdld/bdld_datum.cpp
+++ b/groups/bdl/bdld/bdld_datum.cpp
@@ -855,6 +855,8 @@ BSLMF_ASSERT(sizeof(bdlt::Time) <= sizeof(long long));
 BSLMF_ASSERT(sizeof(Datum_MapHeader) <= sizeof(DatumMapEntry));
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 Datum Datum::createDecimal64(bdldfp::Decimal64    value,
                              const AllocatorType& allocator)
 {
@@ -1371,6 +1373,8 @@ void Datum::destroy(const Datum& value, const AllocatorType& allocator)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: true
 Datum Datum::clone(const AllocatorType& allocator) const
 {
     Datum result;
@@ -1437,6 +1441,8 @@ bsl::ostream& Datum::print(bsl::ostream& stream,
                          // -------------------
 
 // ACCESSORS
+// requires: stream.good() && (stream ↦ _)
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& DatumArrayRef::print(bsl::ostream& stream,
                                    int           level,
                                    int           spacesPerLevel) const
@@ -1462,6 +1468,8 @@ bsl::ostream& DatumArrayRef::print(bsl::ostream& stream,
                           // ----------------------
 
 // ACCESSORS
+// requires: true
+// ensures: (stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == stream && (__out << bsl::flush)))
 bsl::ostream& DatumIntMapEntry::print(bsl::ostream& stream,
                                       int           level,
                                       int           spacesPerLevel) const
@@ -1487,6 +1495,8 @@ bsl::ostream& DatumIntMapEntry::print(bsl::ostream& stream,
                             // -------------------
 
 // ACCESSORS
+// requires: stream.good()
+// ensures: (__out == stream) && (__out ↦ _)
 bsl::ostream& DatumMapEntry::print(bsl::ostream& stream,
                                    int           level,
                                    int           spacesPerLevel) const
@@ -1508,6 +1518,8 @@ bsl::ostream& DatumMapEntry::print(bsl::ostream& stream,
                           // class DatumMapRef
                           // -----------------
 // ACCESSORS
+// requires: true
+// ensures: (__out != 0 ==> findElementBinary(key, *this) == __out || findElementLinear(key, *this) == __out) && (__out == 0 ==> findElementBinary(key, *this) == nullptr && findElementLinear(key, *this) == nullptr)
 const Datum *DatumIntMapRef::find(int key) const
 {
     return d_sorted ? findElementBinary(key, *this) :
@@ -1563,6 +1575,25 @@ bsl::ostream& DatumIntMapRef::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: POST(
+    (__out == true) == 
+    (lhs.type() == rhs.type() && 
+     (
+         (lhs.type() == Datum::e_DOUBLE && lhs.theDouble() == rhs.theDouble()) ||
+         (lhs.type() == Datum::e_STRING && lhs.theString() == rhs.theString()) ||
+         (lhs.type() == Datum::e_INTEGER && lhs.theInteger() == rhs.theInteger()) ||
+         (lhs.type() == Datum::e_BOOLEAN && lhs.theBoolean() == rhs.theBoolean()) ||
+         (lhs.type() == Datum::e_NIL) ||
+         (lhs.type() == Datum::e_ERROR && lhs.theError() == rhs.theError()) ||
+         (lhs.type() == Datum::e_DATE && lhs.theDate() == rhs.theDate()) ||
+         (lhs.type() == Datum::e_TIME && lhs.theTime() == rhs.theTime()) ||
+         (lhs.type() == Datum::e_DATETIME && lhs.theDatetime() == rhs.theDatetime()) ||
+         (lhs.type() == Datum::e_DATETIME_INTERVAL && lhs.theDatetimeInterval() == rhs.theDatetimeInterval()) ||
+         (lhs.type() == Datum::e_INTEGER64 && lhs.theInteger64() == rhs.theInteger64()) ||
+         (lhs.type() == Datum::e_BINARY && lhs.theBinary() == rhs.theBinary()) ||
+         (lhs.type() == Datum::e_DECIMAL64 && lhs.theDecimal64() == rhs.theDecimal64()) ||
+         (lhs.type() == Datum::e_ARRAY && lhs.theArray() == rhs.theArray()) ||
 bool bdld::operator==(const Datum& lhs, const Datum& rhs)
 {
     const Datum::DataType type = lhs.type();

--- a/groups/bdl/bdld/bdld_datumarraybuilder.cpp
+++ b/groups/bdl/bdld/bdld_datumarraybuilder.cpp
@@ -22,6 +22,8 @@ typedef DatumArrayBuilder::allocator_type allocator_type;
 
 /// Calculate the new capacity needed to accommodate data having the
 /// specified `length` for the datum array having the specified `capacity`.
+// requires: length >= 0 && length < bsl::numeric_limits<DatumArrayBuilder::SizeType>::max() / 2 && capacity >= 0
+// ensures: __out >= length && (capacity == 0 ? __out == 1 : __out >= capacity && __out % capacity == 0)
 static DatumArrayBuilder::SizeType getNewCapacity(
                                           DatumArrayBuilder::SizeType capacity,
                                           DatumArrayBuilder::SizeType length)

--- a/groups/bdl/bdld/bdld_datumbinaryref.cpp
+++ b/groups/bdl/bdld/bdld_datumbinaryref.cpp
@@ -16,6 +16,8 @@ namespace bdld {
                         // --------------------
 
 // ACCESSORS
+// requires: true
+// ensures: (stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == (stream << bsl::flush) ⋆ stream ↦ _))
 bsl::ostream& DatumBinaryRef::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const

--- a/groups/bdl/bdld/bdld_datumerror.cpp
+++ b/groups/bdl/bdld/bdld_datumerror.cpp
@@ -16,6 +16,8 @@ namespace bdld {
                         // ----------------
 
 // ACCESSORS
+// requires: stream ↦ _ && !stream.bad()
+// ensures: (__out == stream) && (stream ↦ _)
 bsl::ostream& DatumError::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bdl/bdld/bdld_datumintmapbuilder.cpp
+++ b/groups/bdl/bdld/bdld_datumintmapbuilder.cpp
@@ -25,6 +25,8 @@ typedef DatumIntMapBuilder::allocator_type allocator_type;
 
 /// Calculate the new capacity needed to accommodate data having the
 /// specified `size` for the datum int-map having the specified `capacity`.
+// requires: size >= 0 && (capacity == 0 || (capacity > 0 && size < bsl::numeric_limits<DatumIntMapBuilder::SizeType>::max() / 2))
+// ensures: __out >= size && (capacity == 0 ? __out == 1 : __out >= capacity && __out % capacity == 0)
 static DatumIntMapBuilder::SizeType getNewCapacity(
                                          DatumIntMapBuilder::SizeType capacity,
                                          DatumIntMapBuilder::SizeType size)
@@ -75,6 +77,8 @@ static bool compareGreater(const DatumIntMapEntry& lhs,
 
 /// Return `true` if key in the specified `lhs` is less than key in the
 /// specified `rhs` and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())
 static bool compareLess(const DatumIntMapEntry& lhs,
                         const DatumIntMapEntry& rhs)
 {

--- a/groups/bdl/bdld/bdld_datummaker.cpp
+++ b/groups/bdl/bdld/bdld_datummaker.cpp
@@ -29,6 +29,8 @@ namespace bdld {
                               // ----------------
 
 // ACCESSORS
+// requires: size >= 0 && (size == 0 || FORALL(0, size, i, elements[i].isValid()))
+// ensures: true
 bdld::Datum DatumMaker::operator()(const bdld::DatumMapEntry *elements,
                                    int                        size,
                                    bool                       sorted) const

--- a/groups/bdl/bdld/bdld_datummapbuilder.cpp
+++ b/groups/bdl/bdld/bdld_datummapbuilder.cpp
@@ -26,6 +26,8 @@ typedef DatumMapBuilder::allocator_type allocator_type;
 
 /// Calculate the new capacity needed to accommodate data having the
 /// specified `size` for the datum map having the specified `capacity`.
+// requires: size < bsl::numeric_limits<DatumMapBuilder::SizeType>::max() / 2 && capacity >= 0
+// ensures: __out >= size && (capacity == 0 ? __out == 1 : __out >= capacity && __out % capacity == 0)
 static DatumMapBuilder::SizeType getNewCapacity(
                                             DatumMapBuilder::SizeType capacity,
                                             DatumMapBuilder::SizeType size)
@@ -74,6 +76,8 @@ static bool compareGreater(const DatumMapEntry& lhs, const DatumMapEntry& rhs)
 
 /// Return `true` if key in the specified `lhs` is less than key in the
 /// specified `rhs` and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())
 static bool compareLess(const DatumMapEntry& lhs, const DatumMapEntry& rhs)
 {
     return lhs.key() < rhs.key();

--- a/groups/bdl/bdld/bdld_datummapowningkeysbuilder.cpp
+++ b/groups/bdl/bdld/bdld_datummapowningkeysbuilder.cpp
@@ -25,6 +25,7 @@ namespace {
 /// Calculate the new capacity needed to accommodate data/keys having the
 /// specified `size` for the datum-key-owning map having the specified
 /// `capacity` as its capacity/`keys-capacity`.
+// ensures: __out >= size && (capacity == 0 ==> EXISTS(0, 31, k, __out == (1 << k))) && (capacity != 0 ==> EXISTS(0, 31, k, __out == (capacity << k)))
 static DatumMapOwningKeysBuilder::SizeType getNewCapacity(
                                   DatumMapOwningKeysBuilder::SizeType capacity,
                                   DatumMapOwningKeysBuilder::SizeType size)
@@ -80,6 +81,8 @@ static bool compareGreater(const DatumMapEntry& lhs, const DatumMapEntry& rhs)
 
 /// Return `true` if key in the specified `lhs` is less than key in the
 /// specified `rhs` and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> lhs.key() < rhs.key()) && (__out == false ==> lhs.key() >= rhs.key())
 static bool compareLess(const DatumMapEntry& lhs, const DatumMapEntry& rhs)
 {
     return lhs.key() < rhs.key();

--- a/groups/bdl/bdld/bdld_datumudt.cpp
+++ b/groups/bdl/bdld/bdld_datumudt.cpp
@@ -16,6 +16,8 @@ namespace bdld {
                         // --------------
 
 // ACCESSORS
+// requires: !stream.bad() && stream.rdbuf()->in_sync()
+// ensures: __out == &stream && !stream.bad() && stream.rdbuf()->in_sync()
 bsl::ostream& DatumUdt::print(bsl::ostream& stream,
                               int           level,
                               int           spacesPerLevel) const

--- a/groups/bdl/bdlde/bdlde_base64alphabet.cpp
+++ b/groups/bdl/bdlde/bdlde_base64alphabet.cpp
@@ -48,6 +48,8 @@ const char *Base64Alphabet::toAscii(Base64Alphabet::Enum value)
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& bdlde::operator<<(bsl::ostream&               stream,
                                 bdlde::Base64Alphabet::Enum value)
 {

--- a/groups/bdl/bdlde/bdlde_base64decoderoptions.cpp
+++ b/groups/bdl/bdlde/bdlde_base64decoderoptions.cpp
@@ -16,6 +16,8 @@ namespace bdlde {
                             // --------------------
 
 // ACCESSORS
+// requires: stream ↦ _ && level >= 0 && spacesPerLevel >= 0
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream& Base64DecoderOptions::print(bsl::ostream& stream,
                                           int           level,
                                           int           spacesPerLevel) const
@@ -37,6 +39,8 @@ bsl::ostream& Base64DecoderOptions::print(bsl::ostream& stream,
 // inline in anticipation of their being rarely used.
 
 // FREE FUNCTIONS
+// requires: true
+// ensures: (__out == true ==> (lhs.ignoreMode() == rhs.ignoreMode() && lhs.alphabet() == rhs.alphabet() && lhs.isPadded() == rhs.isPadded())) && (__out == false ==> !(lhs.ignoreMode() == rhs.ignoreMode() && lhs.alphabet() == rhs.alphabet() && lhs.isPadded() == rhs.isPadded()))
 bool bdlde::operator==(const bdlde::Base64DecoderOptions& lhs,
                        const bdlde::Base64DecoderOptions& rhs)
 {

--- a/groups/bdl/bdlde/bdlde_base64encoderoptions.cpp
+++ b/groups/bdl/bdlde/bdlde_base64encoderoptions.cpp
@@ -16,6 +16,8 @@ namespace bdlde {
                             // --------------------
 
 // ACCESSORS
+// requires: stream ↦ _ && level >= 0 && spacesPerLevel >= 0
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream& Base64EncoderOptions::print(bsl::ostream& stream,
                                           int           level,
                                           int           spacesPerLevel) const
@@ -37,6 +39,8 @@ bsl::ostream& Base64EncoderOptions::print(bsl::ostream& stream,
 // inline in anticipation of their being rarely used.
 
 // FREE FUNCTIONS
+// requires: true
+// ensures: (__out == true) ==> (lhs.alphabet() == rhs.alphabet() && lhs.maxLineLength() == rhs.maxLineLength() && lhs.isPadded() == rhs.isPadded()) && (__out == false) ==> !(lhs.alphabet() == rhs.alphabet() && lhs.maxLineLength() == rhs.maxLineLength() && lhs.isPadded() == rhs.isPadded())
 bool bdlde::operator==(const bdlde::Base64EncoderOptions& lhs,
                        const bdlde::Base64EncoderOptions& rhs)
 {

--- a/groups/bdl/bdlde/bdlde_base64ignoremode.cpp
+++ b/groups/bdl/bdlde/bdlde_base64ignoremode.cpp
@@ -16,6 +16,8 @@ namespace bdlde {
                           // -----------------------
 
 // CLASS METHODS
+// requires: stream ↦ _ && !stream.bad()
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& Base64IgnoreMode::print(bsl::ostream&          stream,
                                       Base64IgnoreMode::Enum value,
                                       int                    level,
@@ -49,6 +51,8 @@ const char *Base64IgnoreMode::toAscii(Base64IgnoreMode::Enum value)
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& bdlde::operator<<(bsl::ostream&                 stream,
                                 bdlde::Base64IgnoreMode::Enum value)
 {

--- a/groups/bdl/bdlde/bdlde_byteorder.cpp
+++ b/groups/bdl/bdlde/bdlde_byteorder.cpp
@@ -15,6 +15,8 @@ namespace bdlde {
                               // ----------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == stream ⋆ SEPFORALL(0, sizeof(ByteOrder::toAscii(value)), i, stream + i ↦ ByteOrder::toAscii(value)[i])))
 bsl::ostream& ByteOrder::print(bsl::ostream&   stream,
                                ByteOrder::Enum value,
                                int             level,

--- a/groups/bdl/bdlde/bdlde_charconvertstatus.cpp
+++ b/groups/bdl/bdlde/bdlde_charconvertstatus.cpp
@@ -16,6 +16,8 @@ namespace bdlde {
                           // ------------------------
 
 // CLASS METHODS
+// requires: stream.bad() ==> true && !stream.bad() ==> (stream ↦ _)
+// ensures: (stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == stream && (stream ↦ _)))
 bsl::ostream& CharConvertStatus::print(bsl::ostream&           stream,
                                        CharConvertStatus::Enum value,
                                        int                     level,

--- a/groups/bdl/bdlde/bdlde_charconvertutf32.cpp
+++ b/groups/bdl/bdlde/bdlde_charconvertutf32.cpp
@@ -222,6 +222,8 @@ void Capacity::operator-=(int delta)
 
 /// Return `true` if `d_capacity` is less than the specified `rhs`, and
 /// `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> d_capacity < rhs) && (__out == false ==> d_capacity >= rhs)
 inline
 bool Capacity::operator<( bsl::size_t rhs) const
 {
@@ -230,6 +232,8 @@ bool Capacity::operator<( bsl::size_t rhs) const
 
 /// Return `true` if `d_capacity` is greater than or equal to the specified
 /// `rhs`, and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> d_capacity >= rhs) && (__out == false ==> d_capacity < rhs)
 inline
 bool Capacity::operator>=(bsl::size_t rhs) const
 {
@@ -296,6 +300,8 @@ void NoopCapacity::operator-=(int)
 // ACCESSORS
 
 /// Return `false`.
+// requires: true
+// ensures: __out == false
 inline
 bool NoopCapacity::operator<( bsl::size_t) const
 {
@@ -303,6 +309,8 @@ bool NoopCapacity::operator<( bsl::size_t) const
 }
 
 /// Return `true`.
+// requires: true
+// ensures: __out == true
 inline
 bool NoopCapacity::operator>=(bsl::size_t) const
 {
@@ -403,6 +411,8 @@ Utf8PtrBasedEnd::Utf8PtrBasedEnd(const char *end)
 {}
 
 // ACCESSORS
+// requires: position <= d_end
+// ensures: (__out == false ==> position < d_end) && (__out == true ==> position == d_end)
 inline
 bool Utf8PtrBasedEnd::isFinished(const OctetType *position) const
 {
@@ -498,6 +508,8 @@ Utf8ZeroBasedEnd::Utf8ZeroBasedEnd()
 }
 
 // ACCESSORS
+// requires: position != nullptr
+// ensures: (__out == true ==> (*position ↦ 0)) && (__out == false ==> (*position ↦ sep_v && sep_v != 0))
 inline
 bool Utf8ZeroBasedEnd::isFinished(const OctetType *position) const
 {
@@ -580,6 +592,8 @@ Utf32PtrBasedEnd::Utf32PtrBasedEnd(const unsigned int *end)
 {}
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == false ==> position < d_end_p) && (__out == true ==> position >= d_end_p)
 inline
 bool Utf32PtrBasedEnd::isFinished(const unsigned int *position) const
 {
@@ -620,6 +634,8 @@ Utf32ZeroBasedEnd::Utf32ZeroBasedEnd()
 }
 
 // ACCESSORS
+// requires: position != nullptr
+// ensures: (__out == true ==> (*position ↦ 0)) && (__out == false ==> (*position ↦ sep_v && sep_v != 0))
 inline
 bool Utf32ZeroBasedEnd::isFinished(const unsigned int *position) const
 {
@@ -632,6 +648,8 @@ bool Utf32ZeroBasedEnd::isFinished(const unsigned int *position) const
 /// `static_cast` does not work here, and the idea is to be sure in these
 /// casts that one is never accidentally casting between pointers to `char`
 /// or `OctetType` and pointers to `unsigned int`.
+// requires: true
+// ensures: __out == reinterpret_cast<const OctetType*>(ptr)
 static inline
 const OctetType *constOctetCast(const char *ptr)
 {
@@ -643,6 +661,8 @@ const OctetType *constOctetCast(const char *ptr)
 /// `static_cast` does not work here, and the idea is to be sure in these
 /// casts that one is never accidentally casting between pointers to `char`
 /// or `OctetType` and pointers to `unsigned int`.
+// requires: true
+// ensures: __out == reinterpret_cast<OctetType*>(ptr)
 static inline
 OctetType *octetCast(char *ptr)
 {
@@ -651,6 +671,8 @@ OctetType *octetCast(char *ptr)
 }
 
 /// Return `true` if the specified `oct` is a single-octet UTF-8 sequence.
+// requires: true
+// ensures: __out == !(oct & k_ONE_OCTET_MASK)
 static inline
 bool isSingleOctet(OctetType oct)
 {
@@ -659,6 +681,8 @@ bool isSingleOctet(OctetType oct)
 
 /// Return `true` if the specified `oct` is a continuation octet and `false`
 /// otherwise.
+// requires: true
+// ensures: (__out == true ==> (oct & k_CONTINUE_MASK) == k_CONTINUE_TAG) && (__out == false ==> (oct & k_CONTINUE_MASK) != k_CONTINUE_TAG)
 static inline
 bool isContinuation(OctetType oct)
 {
@@ -667,6 +691,8 @@ bool isContinuation(OctetType oct)
 
 /// Return `true` if the specified `oct` is the first octet of a two-octet
 /// UTF-8 sequence and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (oct & k_TWO_OCTET_MASK) == k_TWO_OCTET_TAG) && (__out == false ==> (oct & k_TWO_OCTET_MASK) != k_TWO_OCTET_TAG)
 static inline
 bool isTwoOctetHeader(OctetType oct)
 {
@@ -675,6 +701,8 @@ bool isTwoOctetHeader(OctetType oct)
 
 /// Return `true` if the specified `oct` is the first octet of a three-octet
 /// UTF-8 sequence and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (oct & k_THREE_OCTET_MASK) == k_THREE_OCTET_TAG) && (__out == false ==> (oct & k_THREE_OCTET_MASK) != k_THREE_OCTET_TAG)
 static inline
 bool isThreeOctetHeader(OctetType oct)
 {
@@ -683,6 +711,8 @@ bool isThreeOctetHeader(OctetType oct)
 
 /// Return `true` if the specified `oct` is the first octet of a four-octet
 /// UTF-8 sequence and `false` otherwise.
+// requires: true
+// ensures: (__out == true) ==> ((oct & k_FOUR_OCTET_MASK) == k_FOUR_OCTET_TAG) && (__out == false) ==> ((oct & k_FOUR_OCTET_MASK) != k_FOUR_OCTET_TAG)
 static inline
 bool isFourOctetHeader(OctetType oct)
 {
@@ -691,6 +721,8 @@ bool isFourOctetHeader(OctetType oct)
 
 /// Return the value of the two-octet sequence that begins with the octet
 /// pointed to by the specified `octBuf`.
+// requires: octBuf ↦ _ ⋆ (octBuf + 1) ↦ _
+// ensures: __out == ((octBuf[1] & ~k_CONTINUE_MASK) | ((octBuf[0] & ~k_TWO_OCTET_MASK) << k_CONTINUE_CONT_WID))
 static inline
 unsigned int decodeTwoOctets(const OctetType *octBuf)
 {
@@ -700,6 +732,8 @@ unsigned int decodeTwoOctets(const OctetType *octBuf)
 
 /// Return the value of the three-octet sequence that begins with the octet
 /// pointed to by the specified `octBuf`.
+// requires: SEPFORALL(0, 3, i, octBuf + i ↦ _)
+// ensures: __out == ((octBuf[2] & ~k_CONTINUE_MASK) | ((octBuf[1] & ~k_CONTINUE_MASK) << k_CONTINUE_CONT_WID) | ((octBuf[0] & ~k_THREE_OCTET_MASK) << 2 * k_CONTINUE_CONT_WID))
 static inline
 unsigned int decodeThreeOctets(const OctetType *octBuf)
 {
@@ -710,6 +744,8 @@ unsigned int decodeThreeOctets(const OctetType *octBuf)
 
 /// Return the value of the four-octet sequence that begins with the octet
 /// pointed to by the specified `octBuf`.
+// requires: SEPFORALL(0, 4, i, octBuf + i ↦ _)
+// ensures: __out == ((octBuf[3] & ~k_CONTINUE_MASK) | ((octBuf[2] & ~k_CONTINUE_MASK) << k_CONTINUE_CONT_WID) | ((octBuf[1] & ~k_CONTINUE_MASK) << 2 * k_CONTINUE_CONT_WID) | ((octBuf[0] & ~k_FOUR_OCTET_MASK) << 3 * k_CONTINUE_CONT_WID))
 static inline
 unsigned int decodeFourOctets(const OctetType *octBuf)
 {
@@ -722,6 +758,8 @@ unsigned int decodeFourOctets(const OctetType *octBuf)
 /// Return the number of continuation octets beginning at the specified
 /// `octBuf`, up to but not greater than the specified `n`.  Note that a
 /// null octet is not a continuation and is taken to end the scan.
+// requires: SEPFORALL(0, n, i, (octBuf + i ↦ sep_v))
+// ensures: (__out == 0 ==> !isContinuation(octBuf[0])) && (__out > 0 ==> (SEPFORALL(0, __out, i, (octBuf + i ↦ sep_v) && isContinuation(sep_v)) && (__out == n || !isContinuation(octBuf[__out]))))
 static inline
 bsl::size_t lookaheadContinuations(const OctetType * const octBuf, int n)
 {
@@ -735,6 +773,8 @@ bsl::size_t lookaheadContinuations(const OctetType * const octBuf, int n)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in a
 /// single UTF-8 octet and `false` otherwise.
+// requires: true
+// ensures: __out == ((uc & (~ (unsigned int) 0 << k_ONE_OCT_CONT_WID)) == 0)
 static inline
 bool fitsInSingleOctet(unsigned int uc)
 {
@@ -743,6 +783,8 @@ bool fitsInSingleOctet(unsigned int uc)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in two
 /// UTF-8 octets or less and `false` otherwise.
+// requires: true
+// ensures: (__out ==> (uc & (~0 << (k_TWO_OCT_CONT_WID + k_CONTINUE_CONT_WID))) == 0) && (!__out ==> (uc & (~0 << (k_TWO_OCT_CONT_WID + k_CONTINUE_CONT_WID))) != 0)
 static inline
 bool fitsInTwoOctets(unsigned int uc)
 {
@@ -752,6 +794,8 @@ bool fitsInTwoOctets(unsigned int uc)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in three
 /// UTF-8 octets or less and `false` otherwise.
+// requires: true
+// ensures: (__out == ((uc & (~ (unsigned int) 0 << (k_THREE_OCT_CONT_WID + 2 * k_CONTINUE_CONT_WID))) == 0))
 static inline
 bool fitsInThreeOctets(unsigned int uc)
 {
@@ -761,6 +805,8 @@ bool fitsInThreeOctets(unsigned int uc)
 
 /// Return `true` if the specified Unicode value `uc` can be coded in four
 /// UTF-8 octets or less and `false` otherwise.
+// requires: true
+// ensures: (__out == true) || (__out == false)
 static inline
 bool fitsInFourOctets(unsigned int uc)
 {
@@ -807,6 +853,8 @@ void encodeFourOctets(OctetType *octBuf, unsigned int isoBuf)
 /// Return `true` if the specified Unicode value `uc` is a value reserved
 /// for the encoding of double-word planes in UTF-16 (such values are
 /// illegal in ANY Unicode format) and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (uc >= 0xd800 && uc < 0xe000)) && (__out == false ==> !(uc >= 0xd800 && uc < 0xe000))
 static inline
 bool isIllegal16BitValue(unsigned int uc)
 {
@@ -815,6 +863,8 @@ bool isIllegal16BitValue(unsigned int uc)
 
 /// Return `true` if the specified 32-bit value `uc` is too high to be
 /// represented in Unicode and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> uc > 0x10ffff) && (__out == false ==> uc <= 0x10ffff)
 static inline
 bool isIllegalFourOctetValue(unsigned int uc)
 {
@@ -836,6 +886,8 @@ bool isLegalUtf32ErrorWord(unsigned int uc)
 /// incomplete sequence is skipped as a single char, and that any first byte
 /// that is neither a single byte nor a header of a valid UTF-8 sequence is
 /// interpreted as a 5-byte header.
+// requires: true
+// ensures: __out >= input
 static inline
 const OctetType *skipUtf8CodePoint(const OctetType *input)
 {

--- a/groups/bdl/bdlde/bdlde_crc32.cpp
+++ b/groups/bdl/bdlde/bdlde_crc32.cpp
@@ -189,6 +189,8 @@ void Crc32::update(const void *data, bsl::size_t length)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: SEPFORALL(0, 11, i, stream + i ↦ array[i])
 bsl::ostream& Crc32::print(bsl::ostream& stream) const
 {
     const char *hex = "0123456789abcdef";

--- a/groups/bdl/bdlde/bdlde_crc32c.cpp
+++ b/groups/bdl/bdlde/bdlde_crc32c.cpp
@@ -716,6 +716,8 @@ class Crc32cCalculator {
 /// over the specified `length` number of bytes, using the specified `crc`
 /// value as the starting point for the calculation.  Note that the `data`
 /// is permitted to be null if the `length` is 0.
+// requires: length == 0 || data != NULL
+// ensures: true
 inline
 unsigned int calculateCrc32c(const unsigned char *data,
                              bsl::size_t          length,
@@ -769,6 +771,8 @@ unsigned int sparcHardware(const unsigned char *data,
 /// over the specified `length` number of bytes, using the specified `crc`
 /// value as the starting point for the calculation.  Note that the `data`
 /// is permitted to be null if the `length` is 0.
+// requires: (data == 0 && length == 0) || (data != 0 && SEPFORALL(0, length, i, data + i ↦ _)) && length >= 0 && crc >= 0
+// ensures: __out == ~crc
 unsigned int crc32cSoftware(const unsigned char *data,
                             bsl::size_t          length,
                             unsigned int         crc)

--- a/groups/bdl/bdlde/bdlde_crc64.cpp
+++ b/groups/bdl/bdlde/bdlde_crc64.cpp
@@ -329,6 +329,8 @@ void Crc64::update(const void *data, bsl::size_t length)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: SEPFORALL(0, 18, i, (stream + i ↦ out[i]))
 bsl::ostream& Crc64::print(bsl::ostream& stream) const
 {
     static const char hex[] = "0123456789abcdef";

--- a/groups/bdl/bdlde/bdlde_hexdecoder.cpp
+++ b/groups/bdl/bdlde/bdlde_hexdecoder.cpp
@@ -164,6 +164,8 @@ HexDecoder::HexDecoder()
 }
 
 // MANIPULATORS
+// requires: (d_state == e_ERROR_STATE || d_firstDigit) ==> res_tmp == -1 && (!d_firstDigit) ==> res_tmp == 0
+// ensures: (__out == -1 ==> (d_state == e_ERROR_STATE || d_firstDigit)) && (__out == 0 ==> (d_state == e_DONE_STATE && !d_firstDigit))
 int HexDecoder::endConvert()
 {
     if (e_ERROR_STATE == d_state) {

--- a/groups/bdl/bdlde/bdlde_md5.cpp
+++ b/groups/bdl/bdlde/bdlde_md5.cpp
@@ -403,6 +403,8 @@ static void append(unsigned int *state, const unsigned char *data)
 
 /// Return the number of bytes in use in the buffer for the total specified
 /// `length`.
+// requires: true
+// ensures: __out == (length & 0x3f)
 inline
 static int getLengthInUse(bsls::Types::Int64 length)
 {
@@ -646,6 +648,8 @@ bsl::ostream& Md5::print(bsl::ostream& stream) const
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == (lhs.d_length == rhs.d_length && 0 == bsl::memcmp(lhs.d_state, rhs.d_state, sizeof lhs.d_state) && 0 == bsl::memcmp(lhs.d_buffer, rhs.d_buffer, (sizeof *lhs.d_buffer) * getLengthInUse(lhs.d_length))))
 bool bdlde::operator==(const Md5& lhs, const Md5& rhs)
 {
     if (lhs.d_length != rhs.d_length

--- a/groups/bdl/bdlde/bdlde_quotedprintabledecoder.cpp
+++ b/groups/bdl/bdlde/bdlde_quotedprintabledecoder.cpp
@@ -210,6 +210,8 @@ QuotedPrintableDecoder::~QuotedPrintableDecoder()
 }
 
 // MANIPULATORS
+// requires: out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL && maxNumOut >= 0
+// ensures: (__out == -1 || __out == 0) && (__out == -1 ==> (d_state == e_ERROR_STATE || d_state == e_DONE_STATE)) && (__out == 0 ==> (d_state == e_INPUT_STATE || d_state == e_SAW_WS_STATE || d_state == e_SAW_EQUAL_STATE || d_state == e_NEED_HEX_STATE || d_state == e_NEED_SOFT_LF_STATE || d_state == e_NEED_HARD_LF_STATE))
 int QuotedPrintableDecoder::convert(char       *out,
                                     int        *numOut,
                                     int        *numIn,

--- a/groups/bdl/bdlde/bdlde_quotedprintableencoder.cpp
+++ b/groups/bdl/bdlde/bdlde_quotedprintableencoder.cpp
@@ -252,6 +252,8 @@ QuotedPrintableEncoder::~QuotedPrintableEncoder()
 }
 
 // MANIPULATORS
+// requires: out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL && maxNumOut >= 0
+// ensures: (maxNumOut == 0 ==> __out == numOutputPending()) && (*numOut >= 0) && (*numIn >= 0)
 int QuotedPrintableEncoder::convert(char       *out,
                                     int        *numOut,
                                     int        *numIn,

--- a/groups/bdl/bdlde/bdlde_sha1.cpp
+++ b/groups/bdl/bdlde/bdlde_sha1.cpp
@@ -51,6 +51,8 @@ const Sha1Word k_SHA1_CONSTANTS[80] = {
 /// Return the result of a bitwise rotation on the specified `value` by the
 /// specified `shift` number of bits.  The behavior is undefined unless
 /// `shift` is positive and strictly less than 32.
+// requires: 0 <= shift && shift < (sizeof(value) * CHAR_BIT)
+// ensures: __out == ((value << shift) | (value >> ((sizeof(value) * CHAR_BIT) - shift)))
 static Sha1Word rotateLeft(Sha1Word value, int shift)
 {
     return (value << shift) | (value >> ((sizeof(value) * CHAR_BIT) - shift));
@@ -60,6 +62,8 @@ static Sha1Word rotateLeft(Sha1Word value, int shift)
 /// the corresponding bit from the specified `x`, otherwise uses the
 /// corresponding bit from the specified `y`.  This function is named `Ch`
 /// in FIPS 180-4.
+// requires: true
+// ensures: __out == ((condition & (x ^ y)) ^ y)
 static Sha1Word bitwiseConditional(Sha1Word condition, Sha1Word x, Sha1Word y)
 {
     // The following implementation, taken from bdlde_sha2.cpp, only uses 3
@@ -73,6 +77,8 @@ static Sha1Word bitwiseConditional(Sha1Word condition, Sha1Word x, Sha1Word y)
 /// Return a value that has each bit set if and only if the corresponding
 /// bit is set in at least two out of three of the specified `x`, `y`, and
 /// `z`.  This function is named `Maj` in FIPS 180-4.
+// requires: true
+// ensures: __out == ((x & y) | ((x | y) & z))
 static Sha1Word bitwiseMajority(Sha1Word x, Sha1Word y, Sha1Word z)
 {
     return (x & y) | ((x | y) & z);
@@ -82,6 +88,8 @@ static Sha1Word bitwiseMajority(Sha1Word x, Sha1Word y, Sha1Word z)
 /// specified `x`, `y`, and `z` as arguments, as defined in section 4.1.1 of
 /// FIPS 180-4.  The behavior is undefined unless `index` is nonnegative and
 /// less than or equal to 79.
+// requires: true
+// ensures: (index <= 19 ==> __out == bitwiseConditional(x, y, z)) && (index >= 40 && index <= 59 ==> __out == bitwiseMajority(x, y, z)) && ((index > 19 && index < 40) || (index > 59) ==> __out == (x ^ y ^ z))
 static Sha1Word f(Sha1Word x, Sha1Word y, Sha1Word z, int index)
 {
     if (index <= 19) {
@@ -97,6 +105,8 @@ static Sha1Word f(Sha1Word x, Sha1Word y, Sha1Word z, int index)
 /// indicated by the specified `bytes` interpreted as a big-endian integer
 /// of type `Word`.  The behavior is undefined unless
 /// `[bytes, bytes + sizeof(INTEGER))` is a valid range.
+// requires: true
+// ensures: true
 static Sha1Word pack(const unsigned char *bytes)
 {
     bsl::size_t shift = sizeof(Sha1Word) * CHAR_BIT;
@@ -360,6 +370,20 @@ bsl::ostream& Sha1::print(bsl::ostream& stream) const
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: ```cpp
+PRE(lhs.d_totalSize >= 0 && rhs.d_totalSize >= 0 &&
+    lhs.d_bufferSize >= 0 && rhs.d_bufferSize >= 0 &&
+    lhs.d_bufferSize == rhs.d_bufferSize &&
+    SEPFORALL(0, lhs.d_bufferSize, i, lhs.d_buffer + i ↦ _ ⋆ rhs.d_buffer + i ↦ _) &&
+    SEPFORALL(0, 5, i, bsl::begin(lhs.d_state) + i ↦ _ ⋆ bsl::begin(rhs.d_state) + i ↦ _))
+```
+
+This precondition ensures that:
+- The `d_totalSize` and `d_bufferSize` fields are non-negative.
+- The `d_bufferSize` fields of `lhs` and `rhs` are equal.
+- The `d_buffer` arrays of `lhs` and `rhs` are properly allocated and of the same size.
+- The `d_state` arrays of `lhs` and `rhs` are properly allocated and of the same size (assuming `d_state` is an array of
+// ensures: (__out == true ==> (lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && bsl::equal(lhs.d_buffer, lhs.d_buffer + lhs.d_bufferSize, rhs.d_buffer) && bsl::equal(bsl::begin(lhs.d_state), bsl::end(lhs.d_state), bsl::begin(rhs.d_state)))) && (__out == false ==> !(lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && bsl::equal(lhs.d_buffer, lhs.d_buffer + lhs.d_bufferSize, rhs.d_buffer) && bsl::equal(bsl::begin(lhs.d_state), bsl::end(lhs.d_state), bsl::begin(rhs.d_state))))
 bool bdlde::operator==(const Sha1& lhs, const Sha1& rhs)
 {
     return lhs.d_totalSize == rhs.d_totalSize &&

--- a/groups/bdl/bdlde/bdlde_sha2.cpp
+++ b/groups/bdl/bdlde/bdlde_sha2.cpp
@@ -40,6 +40,8 @@ INTEGER bitwiseMajority(INTEGER x, INTEGER y, INTEGER z)
 
 /// First mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 2) ^ rotateRight(value, 13) ^ rotateRight(value, 22))
 bsl::uint32_t f1(bsl::uint32_t value)
 {
     return rotateRight(value,  2)
@@ -49,6 +51,8 @@ bsl::uint32_t f1(bsl::uint32_t value)
 
 /// First mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 28) ^ rotateRight(value, 34) ^ rotateRight(value, 39))
 bsl::uint64_t f1(bsl::uint64_t value)
 {
     return rotateRight(value, 28)
@@ -58,6 +62,8 @@ bsl::uint64_t f1(bsl::uint64_t value)
 
 /// Second mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 6) ^ rotateRight(value, 11) ^ rotateRight(value, 25))
 bsl::uint32_t f2(bsl::uint32_t value)
 {
     return rotateRight(value,  6)
@@ -67,6 +73,8 @@ bsl::uint32_t f2(bsl::uint32_t value)
 
 /// Second mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 14) ^ rotateRight(value, 18) ^ rotateRight(value, 41))
 bsl::uint64_t f2(bsl::uint64_t value)
 {
     return rotateRight(value, 14)
@@ -76,6 +84,8 @@ bsl::uint64_t f2(bsl::uint64_t value)
 
 /// Third mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 7) ^ rotateRight(value, 18) ^ (value >> 3))
 bsl::uint32_t f3(bsl::uint32_t value)
 {
     return rotateRight(value,  7) ^ rotateRight(value, 18) ^ (value >>  3);
@@ -83,6 +93,8 @@ bsl::uint32_t f3(bsl::uint32_t value)
 
 /// Third mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 1) ^ rotateRight(value, 8) ^ (value >> 7))
 bsl::uint64_t f3(bsl::uint64_t value)
 {
     return rotateRight(value,  1) ^ rotateRight(value,  8) ^ (value >>  7);
@@ -90,6 +102,8 @@ bsl::uint64_t f3(bsl::uint64_t value)
 
 /// Fourth mixing function used by SHA-224 and SHA-256.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 17) ^ rotateRight(value, 19) ^ (value >> 10))
 bsl::uint32_t f4(bsl::uint32_t value)
 {
     return rotateRight(value, 17) ^ rotateRight(value, 19) ^ (value >> 10);
@@ -97,6 +111,8 @@ bsl::uint32_t f4(bsl::uint32_t value)
 
 /// Fourth mixing function used by SHA-384 and SHA-512.  Mixes together the
 /// bits of the specified `value`.
+// requires: true
+// ensures: __out == (rotateRight(value, 19) ^ rotateRight(value, 61) ^ (value >> 6))
 bsl::uint64_t f4(bsl::uint64_t value)
 {
     return rotateRight(value, 19) ^ rotateRight(value, 61) ^ (value >>  6);
@@ -653,6 +669,8 @@ bsl::ostream& Sha512::print(bsl::ostream& stream) const
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == true ==> (lhs.d_totalSize == rhs.d_totalSize && lhs.d_bufferSize == rhs.d_bufferSize && SEPFORALL(0, lhs.d_bufferSize, i, (lhs.d_buffer + i ↦ sep_v) && (rhs.d_buffer + i ↦ sep_v)) && SEPFORALL(0, 8, i, (lhs.d_state + i ↦ sep_v) && (rhs.d_state + i ↦ sep_v)))) && (__out == false ==> (lhs.d_totalSize != rhs.d_totalSize || lhs.d_bufferSize != rhs.d_bufferSize || SEPEXISTS(0, lhs.d_bufferSize, i, (lhs.d_buffer + i ↦ sep_v1) && (rhs.d_buffer + i ↦ sep_v2) && sep_v1 != sep_v2) || SEPEXISTS(0, 8, i, (lhs.d_state + i ↦ sep_v1) && (rhs.d_state + i ↦ sep_v2) && sep_v1 != sep_v2)))
 bool bdlde::operator==(const Sha224& lhs, const Sha224& rhs)
 {
     return lhs.d_totalSize  == rhs.d_totalSize

--- a/groups/bdl/bdlde/bdlde_utf8checkinginstreambufwrapper.cpp
+++ b/groups/bdl/bdlde/bdlde_utf8checkinginstreambufwrapper.cpp
@@ -29,6 +29,8 @@ namespace bdlde {
                      // ------------------------------------
 
 // PRIVATE MANIPULATOR
+// requires: true
+// ensures: __out == -1 && d_offset == 0 && d_errorStatus == k_SEEK_FAIL && d_bufEndStatus == 0 && d_putBackMode == false
 inline
 bsl::streambuf::pos_type Utf8CheckingInStreamBufWrapper::setSeekFailure(
                                                   bsl::ios_base::openmode mode)
@@ -54,6 +56,8 @@ bsl::streambuf::pos_type Utf8CheckingInStreamBufWrapper::setSeekFailure(
 
                             // implementation functions
 
+// requires: true
+// ensures: __out == traits_type::eof()
 bsl::streambuf::int_type
 Utf8CheckingInStreamBufWrapper::overflow(int_type)
     // This method is normally associated with output and is stubbed out in
@@ -340,6 +344,8 @@ bsl::streamsize Utf8CheckingInStreamBufWrapper::xsputn(const char      *,
 }
 
 // PUBLIC CLASS METHOD
+// requires: true
+// ensures: (errorStatus == 0 ==> __out == "NO_ERROR") && (errorStatus == k_SEEK_FAIL ==> __out == "SEEK_FAIL") && (errorStatus != 0 && errorStatus != k_SEEK_FAIL ==> __out == Utf8Util::toAscii(errorStatus))
 const char *Utf8CheckingInStreamBufWrapper::toAscii(int errorStatus)
 {
     if (0 == errorStatus) {

--- a/groups/bdl/bdlde/bdlde_utf8util.cpp
+++ b/groups/bdl/bdlde/bdlde_utf8util.cpp
@@ -91,6 +91,8 @@ bool BSLA_UNUSED isValidUtf8CodePoint(const char *sequence)
 /// Return the length of the UTF-8 code point for which the specified
 /// `character` is the first `char`.  The behavior is undefined unless
 /// `character` is the first `char` of a UTF-8 code point.
+// requires: true
+// ensures: (character & k_ONEBYTEHEAD_TEST == k_ONEBYTEHEAD_RES ==> __out == 1) && (character & k_TWOBYTEHEAD_TEST == k_TWOBYTEHEAD_RES ==> __out == 2) && (character & k_THREEBYTEHEAD_TEST == k_THREEBYTEHEAD_RES ==> __out == 3) && ((character & k_ONEBYTEHEAD_TEST != k_ONEBYTEHEAD_RES && character & k_TWOBYTEHEAD_TEST != k_TWOBYTEHEAD_RES && character & k_THREEBYTEHEAD_TEST != k_THREEBYTEHEAD_RES) ==> __out == 4)
 int utf8Size(char character)
 {
     if ((character & k_ONEBYTEHEAD_TEST) == k_ONEBYTEHEAD_RES) {
@@ -165,6 +167,8 @@ int appendUtf8CodePointImpl(ITERATOR output, unsigned int codePoint)
 
 /// Return `true` if the specified `value` is NOT a UTF-8 continuation byte,
 /// and `false` otherwise.
+// requires: true
+// ensures: __out == (0x80 != (value & 0xc0))
 inline
 bool isNotContinuation(char value)
 {
@@ -173,6 +177,8 @@ bool isNotContinuation(char value)
 
 /// Return `true` if the specified `value` is a surrogate value, and `false`
 /// otherwise.
+// requires: true
+// ensures: __out == (((k_SURROGATE_MASK & value) == k_MIN_SURROGATE))
 inline
 bool isSurrogateValue(int value)
 {
@@ -185,6 +191,8 @@ bool isSurrogateValue(int value)
 /// 2-byte UTF-8 sequence referred to by the specified `pc`.  The behavior
 /// is undefined unless the 2 bytes starting at `pc` contain a UTF-8
 /// sequence describing a single valid code point.
+// requires: (pc ↦ _ ⋆ (pc + 1) ↦ _)
+// ensures: __out == ((*pc & 0x1f) << 6) | (pc[1] & k_CONT_VALUE_MASK)
 inline
 int get2ByteValue(const char *pc)
 {
@@ -195,6 +203,8 @@ int get2ByteValue(const char *pc)
 /// 3-byte UTF-8 sequence referred to by the specified `pc`.  The behavior
 /// is undefined unless the 3 bytes starting at `pc` contain a UTF-8
 /// sequence describing a single valid code point.
+// requires: pc ↦ _ ⋆ (pc + 1) ↦ _ ⋆ (pc + 2) ↦ _
+// ensures: __out == ((*pc & 0xf) << 12) | ((pc[1] & k_CONT_VALUE_MASK) << 6) | (pc[2] & k_CONT_VALUE_MASK)
 inline
 int get3ByteValue(const char *pc)
 {
@@ -206,6 +216,8 @@ int get3ByteValue(const char *pc)
 /// 4-byte UTF-8 sequence referred to by the specified `pc`.  The behavior
 /// is undefined unless the 4 bytes starting at `pc` contain a UTF-8
 /// sequence describing a single valid code point.
+// requires: SEPFORALL(0, 4, i, (pc + i) ↦ _)
+// ensures: __out == ((*pc & 0x7) << 18) | ((pc[1] & k_CONT_VALUE_MASK) << 12) | ((pc[2] & k_CONT_VALUE_MASK) << 6) | (pc[3] & k_CONT_VALUE_MASK)
 inline
 int get4ByteValue(const char *pc)
 {
@@ -299,6 +311,8 @@ Utf8Util::size_type replaceErrors(STRING_TYPE      *output,
 /// `string` is necessarily null-terminated, so it cannot contain embedded
 /// null bytes.  Note that `string` may contain less than
 /// `bsl::strlen(string)` Unicode code points.
+// requires: invalidString != nullptr && string != nullptr
+// ensures: (__out >= 0 ==> __out == count) && (__out < 0 ==> (*invalidString != 0 && *invalidString == string))
 int validateAndCountCodePoints(const char **invalidString, const char *string)
 {
     // The following assertions are redundant with those in the CLASS METHODS.
@@ -438,6 +452,8 @@ int validateAndCountCodePoints(const char **invalidString, const char *string)
 /// embedded null bytes.  The behavior is undefined unless
 /// `0 <= IntPtr(length)`.  Note that `string` may contain less than
 /// `length` Unicode code points.
+// requires: invalidString != nullptr && (string != nullptr || length == 0) && length >= 0
+// ensures: (__out >= 0) || (__out < 0 && *invalidString != nullptr)
 int validateAndCountCodePoints(const char             **invalidString,
                                const char              *string,
                                bsls::Types::size_type   length)
@@ -679,6 +695,8 @@ namespace bdlde {
                           // -----------------------
 
 // CLASS METHODS
+// requires: input.length() >= 1
+// ensures: (__out >= 1) && (__out <= input.length())
 Utf8Util_ImpUtil::size_type
 Utf8Util_ImpUtil::advancePastValidOrInvalidCodePoint(
                                                  const bsl::string_view& input)

--- a/groups/bdl/bdldfp/bdldfp_decimal.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimal.cpp
@@ -293,6 +293,8 @@ doGetCommon(ITER_TYPE                    begin,
 }
 
 /// Return `true` if the specified `x` is negative and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (x.value().d_raw & k_SIGN_MASK != 0)) && (__out == false ==> (x.value().d_raw & k_SIGN_MASK == 0))
 inline
 bool isNegative(const Decimal32& x)
 {
@@ -312,6 +314,8 @@ bool isNegative(const Decimal64& x)
 
 
 /// Return `true` if the specified `x` is negative and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (x.value().d_raw.w[PlatformIndex()] & k_SIGN_MASK != 0)) && (__out == false ==> (x.value().d_raw.w[PlatformIndex()] & k_SIGN_MASK == 0))
 inline
 bool isNegative(const Decimal128& x)
 {
@@ -337,6 +341,8 @@ namespace bdldfp {
                             // --------------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: __out == stream
 bsl::ostream& Decimal_Type64::print(bsl::ostream& stream,
                                     int           level,
                                     int           spacesPerLevel) const

--- a/groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp
@@ -53,6 +53,8 @@ void memrev(void *buffer, size_t count)
 /// Reverse the first specified `count` bytes from the specified `buffer`,
 /// if the host endian is different from network endian, and return the
 /// address computed from `static_cast<unsigned char *>(buffer) + count`.
+// requires: true
+// ensures: __out == static_cast<unsigned char*>(buffer) + count
 inline
 unsigned char *memReverseIfNeeded(void *buffer, size_t count)
 {
@@ -258,6 +260,8 @@ bool restoreSingularDecimalFromBinary(DECIMAL_TYPE *decimal,
 /// Return the specified `low` if the specified `value` is less than 1, the
 /// specified `high` if `value` is greater than `high`, and `value`
 /// otherwise.
+// requires: low <= high
+// ensures: (value < 1 ==> __out == low) && (value > high ==> __out == high) && ((value >= 1 && value <= high) ==> __out == value)
 inline
 int bound(int value, int low, int high)
 {

--- a/groups/bdl/bdldfp/bdldfp_decimalimputil.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalimputil.cpp
@@ -95,6 +95,8 @@ T divmod10(T* v)
 
 /// Load the resultant value of dividing the specified value `v` by 10 into
 /// `v`.  Return the remainder of the division.
+// requires: true
+// ensures: __out >= 0 && __out < 10
 bsls::Types::Uint64 divmod10(Uint128* v)
 {
     // Set a = v.high(), b = v.low().
@@ -595,6 +597,8 @@ struct Properties64
 /// underlying implementation.  Note that `classification` is of an
 /// implementation defined type, and corresponds to specific underlying
 /// library constants.
+// requires: classification == static_cast<int>(class_types::signalingNaN) || classification == static_cast<int>(class_types::quietNaN)
+// ensures: (classification == static_cast<int>(class_types::signalingNaN) || classification == static_cast<int>(class_types::quietNaN)
 static int canonicalizeDecimalValueClassification(int classification)
 {
     enum class_types cl = static_cast<class_types>(classification);

--- a/groups/bdl/bdljsn/bdljsn_error.cpp
+++ b/groups/bdl/bdljsn/bdljsn_error.cpp
@@ -43,6 +43,8 @@ bsl::ostream& Error::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& bdljsn::operator<<(bsl::ostream& stream,
                                  const Error&  object)
 {

--- a/groups/bdl/bdljsn/bdljsn_jsontestsuiteutil.cpp
+++ b/groups/bdl/bdljsn/bdljsn_jsontestsuiteutil.cpp
@@ -28,6 +28,8 @@ namespace u {
 
 /// Return the address of a null-terminated string containing the input of
 /// the `n_structure_100000_opening_arrays.json` test point.
+// requires: true
+// ensures: __out != 0 && SEPFORALL(0, 100000, i, (__out + i ↦ '['))
 static const char *getLeftBrackets100000()
 {
     static bsl::string leftBrackets100000(bslma::Default::globalAllocator());
@@ -46,6 +48,8 @@ static const bsl::size_t lenLeftBrackets100000 = 100000;
 
 /// Return the address of a null-terminated string containing the input of
 /// the `n_structure_open_array_object.json` test point.
+// requires: true
+// ensures: __out != 0 && SEPFORALL(0, 50000 * lenOpenArrayObjectSubsequence + 1, i, (__out + i ↦ openArrayObject50000[i]))
 static const char *getOpenArrayObject50000()
 {
     static char              openArrayObjectSubsequence[] = "[{\"\":";
@@ -1102,6 +1106,8 @@ const bsl::size_t JsonTestSuiteUtil::s_numData = sizeof  s_data
 #undef JSON
 
 // ACCESSORS
+// requires: index < s_numData
+// ensures: __out != 0 && (__out == &s_data[index] && (index == 68 ==> (__out->d_JSON_p ↦ u::leftBrackets100000 ⋆ __out->d_length ↦ u::lenLeftBrackets100000)))
 const JsonTestSuiteUtil::Datum *JsonTestSuiteUtil::data(bsl::size_t index)
 {
     BSLS_ASSERT(index < s_numData);

--- a/groups/bdl/bdljsn/bdljsn_jsonutil.cpp
+++ b/groups/bdl/bdljsn/bdljsn_jsonutil.cpp
@@ -51,6 +51,8 @@ int read(Json *result, Error *error, Tokenizer *tokenizer, int maxNestedDepth);
     // exceeding the specified 'maxNestedDepth'.  Return 0 on success, and a
     // non-0 value populating the specified 'error' accordingly on failure.
 
+// requires: result != 0 && error != 0 && tokenizer != 0
+// ensures: (__out == 0 ==> (result != 0)) && (__out != 0 ==> (error != 0 && (error->message() ↦ _)))
 int readObject(JsonObject *result,
                Error      *error,
                Tokenizer  *tokenizer,
@@ -112,6 +114,8 @@ int readObject(JsonObject *result,
     return 0;
 }
 
+// requires: tokenizer != 0 && tokenizer->tokenType() == Tokenizer::e_START_ARRAY && result != 0 && error != 0 && maxNestedDepth >= 0
+// ensures: (__out == 0 ==> (result != 0 && tokenizer->tokenType() == Tokenizer::e_END_ARRAY)) && (__out != 0 ==> error != 0)
 int readArray(JsonArray *result,
               Error     *error,
               Tokenizer *tokenizer,
@@ -152,6 +156,8 @@ int readArray(JsonArray *result,
 
 // BDE_VERIFY pragma: push
 // BDE_VERIFY pragma: -FABC01
+// requires: true
+// ensures: __out == 0 || __out != 0
 int readScalar(Json *result, Error *error, Tokenizer *tokenizer)
     // Read into the specified 'result' from the specified 'tokenizer', not
     // exceeding the specified 'maxNestedDepth'.  Return 0 on success, and a
@@ -313,7 +319,9 @@ class JsonObjectUnsortedMemberIterator {
     }
 
     // MANIPULATORS
-    bool next()
+    // requires: d_it != d_end
+// ensures: (__out == true ==> d_it != d_end) && (__out == false ==> d_it == d_end)
+bool next()
         // Advance to the next member in the object.  Return 'true' if the new
         // position is valid.
     {
@@ -322,19 +330,25 @@ class JsonObjectUnsortedMemberIterator {
     }
 
     // ACCESSORS
-    bool isFirst() const
+    // requires: true
+// ensures: (__out == true ==> d_it == d_begin) && (__out == false ==> d_it != d_begin)
+bool isFirst() const
         // Return 'true' if this object is in its initial state.
     {
         return d_it == d_begin;
     }
 
-    bool isValid() const
+    // requires: true
+// ensures: __out == (d_it != d_end)
+bool isValid() const
         // Return 'true' if the current position of this iterator is valid.
     {
         return d_it != d_end;
     }
 
-    const bsl::pair<const bsl::string, Json>& member() const
+    // requires: d_it != nullptr && *d_it != nullptr
+// ensures: __out == *d_it
+const bsl::pair<const bsl::string, Json>& member() const
         // Return the current member.
     {
         return *d_it;
@@ -344,7 +358,9 @@ class JsonObjectUnsortedMemberIterator {
 struct ObjectMemberLess {
     // This struct provides a comparator allowing object entries to be compared
     // lexicographically based on their 'bsl::string' keys.
-    bool operator()(const JsonObject::ConstIterator& lhs,
+    // requires: lhs->first ↦ _ ⋆ rhs->first ↦ _
+// ensures: (__out == true ==> lhs->first < rhs->first) && (__out == false ==> lhs->first >= rhs->first)
+bool operator()(const JsonObject::ConstIterator& lhs,
                     const JsonObject::ConstIterator& rhs)
         // Return true if the key of the specified 'lhs' is lexicographically
         // less than the key of the specified 'rhs'.
@@ -393,7 +409,9 @@ class JsonObjectSortedMemberIterator {
     }
 
     // MANIPULATORS
-    bool next()
+    // requires: true
+// ensures: true
+bool next()
         // Advance to the next member in the object.  Return 'true' if the new
         // position is valid.
     {
@@ -402,19 +420,25 @@ class JsonObjectSortedMemberIterator {
     }
 
     // ACCESSORS
-    bool isFirst() const
+    // requires: true
+// ensures: (__out == true ==> d_it == d_sortedMembers.begin()) && (__out == false ==> d_it != d_sortedMembers.begin())
+bool isFirst() const
         // Return 'true' if this object is in its initial state.
     {
         return d_it == d_sortedMembers.begin();
     }
 
-    bool isValid() const
+    // requires: true
+// ensures: __out == (d_it != d_sortedMembers.end())
+bool isValid() const
         // Return 'true' if the current position of this iterator is valid.
     {
         return d_it != d_sortedMembers.end();
     }
 
-    const bsl::pair<const bsl::string, Json>& member() const
+    // requires: d_it != nullptr && *d_it != nullptr
+// ensures: __out == **d_it
+const bsl::pair<const bsl::string, Json>& member() const
         // Return the current member.
     {
         return **d_it;

--- a/groups/bdl/bdljsn/bdljsn_location.cpp
+++ b/groups/bdl/bdljsn/bdljsn_location.cpp
@@ -33,6 +33,8 @@ bsl::ostream& Location::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& bdljsn::operator<<(bsl::ostream&           stream,
                                  const bdljsn::Location& object)
 {

--- a/groups/bdl/bdljsn/bdljsn_numberutil.cpp
+++ b/groups/bdl/bdljsn/bdljsn_numberutil.cpp
@@ -164,6 +164,8 @@ bsl::ostream& operator<<(bsl::ostream& stream, const DecomposedNumber& n)
 /// for equality), and primarily serves to ignore a `+` character if it
 /// appears in the Exp.  E.g., "1e100000000000000000000" and
 /// "1e+100000000000000000000" would compare equal.
+// requires: true
+// ensures: (lhs.d_isExpNegative == rhs.d_isExpNegative && lhs.d_significantDigits == rhs.d_significantDigits && lhs.d_exponent == rhs.d_exponent) ==> __out == true && (!(lhs.d_isExpNegative == rhs.d_isExpNegative && lhs.d_significantDigits == rhs.d_significantDigits) || lhs.d_exponent != rhs.d_exponent) ==> __out == false
 static bool compareNumberTextFallback(const DecomposedNumber& lhs,
                                       const DecomposedNumber& rhs)
 {
@@ -182,6 +184,8 @@ static bool compareNumberTextFallback(const DecomposedNumber& lhs,
 /// iterator, and prior to the specified `end` character.  Return `end` if
 /// all of the characters are digits.  Note that `find_if_not` is a C++20
 /// algorithm.
+// requires: begin <= end
+// ensures: (__out == end) || (!bdlb::CharType::isDigit(*__out))
 static bsl::string_view::const_iterator findFirstNonDigit(
                                         bsl::string_view::const_iterator begin,
                                         bsl::string_view::const_iterator end)

--- a/groups/bdl/bdljsn/bdljsn_readoptions.cpp
+++ b/groups/bdl/bdljsn/bdljsn_readoptions.cpp
@@ -25,6 +25,8 @@ ReadOptions::ReadOptions()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: d_allowTrailingText ↦ s_DEFAULT_INITIALIZER_ALLOW_TRAILING_TEXT ⋆ d_maxNestedDepth ↦ s_DEFAULT_INITIALIZER_MAX_NESTED_DEPTH
 ReadOptions& ReadOptions::reset()
 {
     d_allowTrailingText = s_DEFAULT_INITIALIZER_ALLOW_TRAILING_TEXT;

--- a/groups/bdl/bdljsn/bdljsn_stringutil.cpp
+++ b/groups/bdl/bdljsn/bdljsn_stringutil.cpp
@@ -202,6 +202,8 @@ namespace bdljsn {
                              // -----------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == u::readUnquotedStringImp(value, string, flags)
 int StringUtil::readUnquotedString(bsl::string             *value,
                                    const bsl::string_view&  string,
                                    int                      flags)

--- a/groups/bdl/bdljsn/bdljsn_tokenizer.cpp
+++ b/groups/bdl/bdljsn/bdljsn_tokenizer.cpp
@@ -76,6 +76,8 @@ namespace bdljsn {
                               // ---------------
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: (__out == 0 ==> numRead != 0) && (__out == -1 ==> numRead == 0)
 int Tokenizer::expandBufferForLargeValue()
 {
     const bsl::string::size_type currLength = d_stringBuffer.length();
@@ -331,6 +333,8 @@ int Tokenizer::skipWhitespace()
 }
 
 // MANIPULATORS
+// requires: d_streambuf_p != nullptr && d_tokenType != e_ERROR
+// ensures: (__out == -1 ==> d_tokenType == e_ERROR) && (__out == 0 ==> d_tokenType != e_ERROR)
 int Tokenizer::advanceToNextToken()
 {
     BSLS_ASSERT(d_streambuf_p);
@@ -719,6 +723,8 @@ int Tokenizer::resetStreamBufGetPointer()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == 0 ==> (d_tokenType == e_ELEMENT_NAME || d_tokenType == e_ELEMENT_VALUE) && (d_valueBegin != d_valueEnd) && (*data ↦ bsl::string_view(d_stringBuffer).substr(d_valueBegin, d_valueEnd - d_valueBegin))) && (__out == -1 ==> !(d_tokenType == e_ELEMENT_NAME || d_tokenType == e_ELEMENT_VALUE) || (d_valueBegin == d_valueEnd))
 int Tokenizer::value(bsl::string_view *data) const
 {
     if ((e_ELEMENT_NAME == d_tokenType || e_ELEMENT_VALUE == d_tokenType) &&

--- a/groups/bdl/bdljsn/bdljsn_writeoptions.cpp
+++ b/groups/bdl/bdljsn/bdljsn_writeoptions.cpp
@@ -33,6 +33,8 @@ WriteOptions::WriteOptions()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: d_initialIndentLevel ↦ s_DEFAULT_INITIALIZER_INITIAL_INDENT_LEVEL ⋆ d_sortMembers ↦ s_DEFAULT_INITIALIZER_SORT_MEMBERS ⋆ d_escapeForwardSlash ↦ s_DEFAULT_INITIALIZER_ESCAPE_FORWARD_SLASH ⋆ d_spacesPerLevel ↦ s_DEFAULT_INITIALIZER_SPACES_PER_LEVEL ⋆ d_style ↦ s_DEFAULT_INITIALIZER_STYLE
 WriteOptions& WriteOptions::reset()
 {
     d_initialIndentLevel = s_DEFAULT_INITIALIZER_INITIAL_INDENT_LEVEL;

--- a/groups/bdl/bdlma/bdlma_aligningallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_aligningallocator.cpp
@@ -49,6 +49,8 @@ AligningAllocator::AligningAllocator(bsls::Types::size_type  alignment,
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 && (reinterpret_cast<bsls::Types::size_type>(__out) & d_mask) == 0 && (__out ↦ _)))
 void *AligningAllocator::allocate(bsls::Types::size_type size)
 {
     void *ret;

--- a/groups/bdl/bdlma/bdlma_blocklist.cpp
+++ b/groups/bdl/bdlma/bdlma_blocklist.cpp
@@ -20,6 +20,8 @@ namespace bdlma {
 /// supplied allocator returning naturally-aligned memory, the size of the
 /// overall allocation will be rounded up to an integral multiple of
 /// `bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT`.
+// requires: true
+// ensures: __out == ((size + sizeOfBlock - 1) & ~(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))
 inline
 static bsls::Types::size_type alignedAllocationSize(
                                             bsls::Types::size_type size,
@@ -48,6 +50,8 @@ BlockList::~BlockList()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *BlockList::allocate(bsls::Types::size_type size)
 {
     if (0 == size) {

--- a/groups/bdl/bdlma/bdlma_buffermanager.cpp
+++ b/groups/bdl/bdlma/bdlma_buffermanager.cpp
@@ -14,6 +14,8 @@ namespace bdlma {
                            // -------------------
 
 // MANIPULATORS
+// requires: address != NULL && size > 0
+// ensures: __out == size || __out > size
 bsls::Types::size_type BufferManager::expand(void                   *address,
                                              bsls::Types::size_type  size)
 {

--- a/groups/bdl/bdlma/bdlma_concurrentallocatoradapter.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentallocatoradapter.cpp
@@ -19,6 +19,8 @@ ConcurrentAllocatorAdapter::~ConcurrentAllocatorAdapter()
 }
 
 // MANIPULATORS
+// requires: numBytes >= 0
+// ensures: __out == 0 || (__out != 0 && (__out ↦ _))
 void *ConcurrentAllocatorAdapter::allocate(bsls::Types::size_type numBytes)
 {
     bslmt::LockGuard<bslmt::Mutex> guard(d_mutex_p);

--- a/groups/bdl/bdlma/bdlma_concurrentfixedpool.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentfixedpool.cpp
@@ -55,6 +55,8 @@ namespace bdlma {
                         // -------------------------
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: (__out == 0) || (__out != 0)
 void *ConcurrentFixedPool::allocateNew()
 {
     Node *node;

--- a/groups/bdl/bdlma/bdlma_concurrentmultipool.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentmultipool.cpp
@@ -174,6 +174,8 @@ void ConcurrentMultipool::initialize(
 }
 
 // PRIVATE ACCESSORS
+// requires: true
+// ensures: __out == 31 - bdlb::BitUtil::numLeadingUnsetBits(static_cast<bsl::uint32_t>(((size + k_MIN_BLOCK_SIZE - 1) >> 3) * 2 - 1))
 inline
 int ConcurrentMultipool::findPool(bsls::Types::size_type size) const
 {
@@ -292,6 +294,8 @@ ConcurrentMultipool::~ConcurrentMultipool()
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ ((__out - 1) ↦ sep_v ⋆ (sep_v.d_header.d_poolIdx == findPool(size) || sep_v.d_header.d_poolIdx == -1))))
 void *ConcurrentMultipool::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlma/bdlma_concurrentmultipoolallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentmultipoolallocator.cpp
@@ -19,6 +19,8 @@ ConcurrentMultipoolAllocator::~ConcurrentMultipoolAllocator()
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *ConcurrentMultipoolAllocator::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {

--- a/groups/bdl/bdlma/bdlma_concurrentpool.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentpool.cpp
@@ -52,6 +52,8 @@ enum {
 
 /// Round up the specified `x` to the nearest whole integer multiple of the
 /// specified `y`.
+// requires: y > 0
+// ensures: (__out % y == 0) && (__out >= x)
 static inline
 bsls::Types::size_type roundUp(bsls::Types::size_type x,
                                bsls::Types::size_type y)
@@ -60,6 +62,8 @@ bsls::Types::size_type roundUp(bsls::Types::size_type x,
 }
 
 /// Return a linked-list link at the specified `address`.
+// requires: true
+// ensures: __out == static_cast<LLink *>(static_cast<void *>(address))
 static inline
 LLink *toLink(char *address)
 {
@@ -76,6 +80,8 @@ LLink *toLink(char *address)
 /// free list).  Note that this value is the maximum of either the size of a
 /// `LLink` object or `blockSize` rounded up to the alignment required for a
 /// `LLink` object (i.e., the maximum platform alignment).
+// requires: true
+// ensures: __out == roundUp(bsl::max(blockSize + HEADER_LENGTH, MINIMUM_LENGTH), bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT)
 static inline
 bsls::Types::size_type computeInternalBlockSize(
                                               bsls::Types::size_type blockSize)
@@ -202,6 +208,8 @@ ConcurrentPool::~ConcurrentPool()
 }
 
 // MANIPULATORS
+// requires: d_freeList != 0
+// ensures: __out != 0
 void *ConcurrentPool::allocate()
 {
     Link *p;

--- a/groups/bdl/bdlma/bdlma_concurrentpoolallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_concurrentpoolallocator.cpp
@@ -20,6 +20,8 @@ enum {
 };
 
 // STATIC METHODS
+// requires: true
+// ensures: (__out % BloombergLP::bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT) == 0
 static inline
 BloombergLP::bsls::Types::size_type calculateMaxAlignedSize(
                                  BloombergLP::bsls::Types::size_type totalSize)
@@ -142,6 +144,8 @@ ConcurrentPoolAllocator::~ConcurrentPoolAllocator()
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *ConcurrentPoolAllocator::allocate(size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {

--- a/groups/bdl/bdlma/bdlma_countingallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_countingallocator.cpp
@@ -65,6 +65,8 @@ CountingAllocator::~CountingAllocator()
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *CountingAllocator::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {
@@ -105,6 +107,8 @@ void CountingAllocator::deallocate(void *address)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& CountingAllocator::print(bsl::ostream& stream) const
 {
     stream << "----------------------------------------\n"

--- a/groups/bdl/bdlma/bdlma_guardingallocator.cpp
+++ b/groups/bdl/bdlma/bdlma_guardingallocator.cpp
@@ -49,6 +49,8 @@ struct AfterUserBlockDeallocationData
 
 /// Utility function to compute the `AfterUserBlockDeallocationData*`
 /// corresponding to the specified `address`.
+// requires: true
+// ensures: __out == static_cast<AfterUserBlockDeallocationData*>(static_cast<void*>(static_cast<char*>(address) - OFFSET * 2))
 AfterUserBlockDeallocationData *getDataBlockAddress(void *address)
 {
     return static_cast<AfterUserBlockDeallocationData*>(
@@ -62,6 +64,8 @@ BSLMF_ASSERT(sizeof(AfterUserBlockDeallocationData) <= OFFSET * 2);
 // HELPER FUNCTIONS
 
 /// Return the size (in bytes) of a system memory page.
+// requires: true
+// ensures: __out == pageSize.loadRelaxed()
 int getSystemPageSize()
 {
     static bsls::AtomicInt pageSize(0);
@@ -88,6 +92,8 @@ int getSystemPageSize()
 /// Allocate a page-aligned block of memory of the specified `size` (in
 /// bytes), and return the address of the allocated block.  The behavior is
 /// undefined unless `size > 0`.
+// requires: size > 0
+// ensures: (__out == 0 ==> size <= 0) && (__out != 0 ==> SEPFORALL(0, size, i, (__out + i) ↦ _))
 void *systemAlloc(bsl::size_t size)
 {
     BSLS_ASSERT(size > 0);
@@ -141,6 +147,8 @@ void systemFree(void *address, size_t size)
 /// Protect from read/write access the page of memory at the specified
 /// `address` having the specified `pageSize` (in bytes).  The behavior is
 /// undefined unless `pageSize == getSystemPageSize()`.
+// requires: address != 0 && pageSize == getSystemPageSize()
+// ensures: (__out == 0 ==> (address ↦ _)) && (__out != 0 ==> (address ↦ _))
 int systemProtect(void *address, int pageSize)
 {
     BSLS_ASSERT(address);
@@ -164,6 +172,8 @@ int systemProtect(void *address, int pageSize)
 /// Unprotect from read/write access the page of memory at the specified
 /// `address` having the specified `pageSize` (in bytes).  The behavior is
 /// undefined unless `pageSize == getSystemPageSize()`.
+// requires: address != 0 && pageSize == getSystemPageSize()
+// ensures: true
 int systemUnprotect(void *address, int pageSize)
 {
     BSLS_ASSERT(address);
@@ -199,6 +209,8 @@ GuardingAllocator::~GuardingAllocator()
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (__out == 0 ==> size == 0) && (__out != 0 ==> (__out ↦ _ ⋆ (__out + size) ↦ _))
 void *GuardingAllocator::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == size)) {

--- a/groups/bdl/bdlma/bdlma_infrequentdeleteblocklist.cpp
+++ b/groups/bdl/bdlma/bdlma_infrequentdeleteblocklist.cpp
@@ -21,6 +21,8 @@ namespace BloombergLP {
 /// supplied allocator returning naturally-aligned memory, the size of the
 /// overall allocation will be rounded up to an integral multiple of
 /// `bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT`.
+// requires: true
+// ensures: __out == ((size + sizeOfBlock - 1) & ~static_cast<bsls::Types::size_type>(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))
 inline
 static bsls::Types::size_type alignedAllocationSize(
                                             bsls::Types::size_type size,
@@ -53,6 +55,8 @@ InfrequentDeleteBlockList::~InfrequentDeleteBlockList()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ d_head_p->d_next_p ↦ old_d_head_p ⋆ d_head_p ↦ _))
 void *InfrequentDeleteBlockList::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlma/bdlma_multipool.cpp
+++ b/groups/bdl/bdlma/bdlma_multipool.cpp
@@ -178,6 +178,8 @@ void Multipool::initialize(
 }
 
 // PRIVATE ACCESSORS
+// requires: size <= d_maxBlockSize
+// ensures: __out == (31 - bdlb::BitUtil::numLeadingUnsetBits(static_cast<bsl::uint32_t>(((size + k_MIN_BLOCK_SIZE - 1) >> 3) * 2 - 1)))
 int Multipool::findPool(bsls::Types::size_type size) const
 {
     BSLS_ASSERT(size <= d_maxBlockSize);
@@ -314,6 +316,8 @@ Multipool::~Multipool()
 }
 
 // MANIPULATORS
+// requires: size >= 0
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *Multipool::allocate(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlma/bdlma_pool.cpp
+++ b/groups/bdl/bdlma/bdlma_pool.cpp
@@ -37,6 +37,8 @@ enum {
 
 /// Round up the specified `x` to the nearest whole integer multiple of the
 /// specified `y`.  The behavior is undefined unless `1 <= y`.
+// requires: 1 <= y
+// ensures: (__out % y == 0) && (__out >= x) && (__out - y < x || __out - y % y != 0)
 static inline
 bsls::Types::size_type roundUp(bsls::Types::size_type x,
                                bsls::Types::size_type y)

--- a/groups/bdl/bdlma/bdlma_sequentialpool.cpp
+++ b/groups/bdl/bdlma/bdlma_sequentialpool.cpp
@@ -30,6 +30,8 @@ namespace BloombergLP {
 /// in the presence of a supplied allocator returning naturally-aligned
 /// memory, the size of the overall allocation will be rounded up to an
 /// integral multiple of `bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT`.
+// requires: true
+// ensures: __out == ((size + sizeOfBlock - 1) & ~(bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT - 1))
 inline
 static bsls::Types::size_type alignedAllocationSize(
                                             bsls::Types::size_type size,
@@ -55,6 +57,8 @@ namespace bdlma {
                            // --------------------
 
 // PRIVATE CLASS FUNCTIONS
+// requires: true
+// ensures: __out == ((static_cast<uint64_t>(-1) << k_NUM_GEOMETRIC_BIN) | (bdlb::BitUtil::roundUpToBinaryPower(static_cast<uint64_t>(initialSize)) - 1))
 uint64_t SequentialPool::initAlwaysUnavailable(
                                             bsls::Types::size_type initialSize)
 {
@@ -73,6 +77,8 @@ uint64_t SequentialPool::initAlwaysUnavailable(
 }
 
 // PRIVATE MANIPULATORS
+// requires: size >= 0
+// ensures: (__out != 0 ==> (__out ↦ _)) && (__out == 0 ==> size == 0)
 void *SequentialPool::allocateNonFastPath(bsls::Types::size_type size)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(size)) {

--- a/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp
+++ b/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp
@@ -77,6 +77,8 @@ bsl::function<bsls::TimeInterval()> createDefaultCurrentTimeFunctor(
 }
 
 /// Return a value that is guaranteed never to be a valid thread id.
+// requires: true
+// ensures: true
 static inline
 bsls::Types::Uint64 invalidThreadId()
 {
@@ -140,6 +142,8 @@ EventSchedulerTestTimeSource_Data::EventSchedulerTestTimeSource_Data(
 }
 
 // MANIPULATORS
+// requires: amount > 0
+// ensures: __out == d_currentTime && d_currentTime == amount + old_d_currentTime
 bsls::TimeInterval EventSchedulerTestTimeSource_Data::advanceTime(
                                                      bsls::TimeInterval amount)
 {
@@ -151,6 +155,8 @@ bsls::TimeInterval EventSchedulerTestTimeSource_Data::advanceTime(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_currentTime
 bsls::TimeInterval EventSchedulerTestTimeSource_Data::currentTime() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_currentTimeMutex);
@@ -165,6 +171,8 @@ bsls::TimeInterval EventSchedulerTestTimeSource_Data::currentTime() const
 const char EventScheduler::s_defaultThreadName[16] = { "bdl.EventSched" };
 
 // PRIVATE CLASS METHODS
+// requires: true
+// ensures: __out == 0
 bsls::Types::Int64 EventScheduler::returnZero()
 {
     return 0;
@@ -176,6 +184,8 @@ bsls::Types::Int64 EventScheduler::returnZeroInt(int)
 }
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: true
 bsls::Types::Int64 EventScheduler::chooseNextEvent(bsls::AtomicInt64 *now)
 {
     BSLS_ASSERT(0 != d_currentRecurringEvent || 0 != d_currentEvent);
@@ -881,6 +891,8 @@ EventScheduler::~EventScheduler()
 }
 
 // MANIPULATORS
+// requires: handle != nullptr && ((*handle == 0) || ((*handle != 0) && (*(const Event **)handle != 0)))
+// ensures: ((*handle == 0) ==> (__out == EventQueue::e_INVALID)) && ((*handle != 0) ==> (__out != EventQueue::e_INVALID))
 int EventScheduler::cancelEvent(EventHandle *handle)
 {
     if (0 == (const Event *) *handle) {
@@ -1224,6 +1236,8 @@ void EventScheduler::stop()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_running
 bool EventScheduler::isStarted() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
@@ -1343,6 +1357,8 @@ bsls::TimeInterval EventSchedulerTestTimeSource::advanceTime(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_data_p->currentTime()
 bsls::TimeInterval EventSchedulerTestTimeSource::now() const
 {
     return d_data_p->currentTime();

--- a/groups/bdl/bdlmt/bdlmt_fixedthreadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_fixedthreadpool.cpp
@@ -266,6 +266,8 @@ FixedThreadPool::~FixedThreadPool()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == 0) || (__out == -1)
 int FixedThreadPool::start()
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_metaMutex);

--- a/groups/bdl/bdlmt/bdlmt_multiprioritythreadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_multiprioritythreadpool.cpp
@@ -202,6 +202,8 @@ MultipriorityThreadPool::~MultipriorityThreadPool()
 }
 
 // MANIPULATORS
+// requires: (unsigned) priority < (unsigned) d_queue.numPriorities()
+// ensures: __out == d_queue.pushBack(job, priority)
 int MultipriorityThreadPool::enqueueJob(const ThreadFunctor& job,
                                         int                  priority)
 {
@@ -457,6 +459,8 @@ void MultipriorityThreadPool::shutdown()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_queue.isEnabled()
 bool MultipriorityThreadPool::isEnabled() const
 {
     return d_queue.isEnabled();

--- a/groups/bdl/bdlmt/bdlmt_multiqueuethreadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_multiqueuethreadpool.cpp
@@ -557,6 +557,8 @@ MultiQueueThreadPool::~MultiQueueThreadPool()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == d_nextId - 1 ⋆ d_queueRegistry[__out] ↦ _
 int MultiQueueThreadPool::createQueue()
 {
     bslmt::WriteLockGuard<bslmt::ReaderWriterMutex> guard(&d_lock);

--- a/groups/bdl/bdlmt/bdlmt_threadpool.cpp
+++ b/groups/bdl/bdlmt/bdlmt_threadpool.cpp
@@ -90,7 +90,9 @@ struct ThreadPoolWaitNode {
                             // ===============
 
 /// Entry point for processing threads.
-extern "C" void *ThreadPoolEntry(void *aThis)
+extern "C" // requires: aThis != 0
+// ensures: __out == 0
+void *ThreadPoolEntry(void *aThis)
 {
     ((bdlmt::ThreadPool*)aThis)->workerThread();
     return 0;
@@ -658,6 +660,8 @@ void ThreadPool::stop()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_numActiveThreads
 int ThreadPool::numActiveThreads() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);

--- a/groups/bdl/bdlmt/bdlmt_throttle.cpp
+++ b/groups/bdl/bdlmt/bdlmt_throttle.cpp
@@ -185,6 +185,8 @@ int Throttle::requestPermissionIfValid(bool                      *result,
 }
 
 // ACCESSOR
+// requires: true
+// ensures: (numActions <= 0 || d_maxSimultaneousActions < numActions || d_nanosecondsPerAction == k_ALLOW_NONE) ==> __out == -1 && (numActions > 0 && d_maxSimultaneousActions >= numActions && d_nanosecondsPerAction != k_ALLOW_NONE) ==> __out == 0
 int Throttle::nextPermit(bsls::TimeInterval *result, int numActions) const
 {
     if (numActions <= 0 || d_maxSimultaneousActions < numActions ||

--- a/groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp
+++ b/groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp
@@ -345,6 +345,8 @@ TimerEventSchedulerTestTimeSource_Data::TimerEventSchedulerTestTimeSource_Data(
 }
 
 // MANIPULATORS
+// requires: amount > 0
+// ensures: __out == d_currentTime && d_currentTime == old_d_currentTime + amount
 bsls::TimeInterval TimerEventSchedulerTestTimeSource_Data::advanceTime(
                                                      bsls::TimeInterval amount)
 {
@@ -356,6 +358,8 @@ bsls::TimeInterval TimerEventSchedulerTestTimeSource_Data::advanceTime(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_currentTime
 bsls::TimeInterval TimerEventSchedulerTestTimeSource_Data::currentTime() const
 {
     bslmt::LockGuard<bslmt::Mutex> lock(&d_currentTimeMutex);
@@ -995,6 +999,8 @@ TimerEventScheduler::~TimerEventScheduler()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: true
 int TimerEventScheduler::start()
 {
     bslmt::ThreadAttributes attr;
@@ -1316,6 +1322,8 @@ void TimerEventScheduler::cancelAllClocks(bool wait)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out.totalMicroseconds() == minTime
 bsls::TimeInterval TimerEventScheduler::nextPendingEventTime() const
 {
     bsls::Types::Int64 minTime =
@@ -1396,6 +1404,8 @@ TimerEventSchedulerTestTimeSource::TimerEventSchedulerTestTimeSource(
 }
 
 // MANIPULATORS
+// requires: amount > 0
+// ensures: __out == d_data_p->advanceTime(amount)
 bsls::TimeInterval TimerEventSchedulerTestTimeSource::advanceTime(
                                                      bsls::TimeInterval amount)
 {
@@ -1422,6 +1432,8 @@ bsls::TimeInterval TimerEventSchedulerTestTimeSource::advanceTime(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_data_p->currentTime()
 bsls::TimeInterval TimerEventSchedulerTestTimeSource::now() const
 {
     return d_data_p->currentTime();

--- a/groups/bdl/bdlpcre/bdlpcre_regex.cpp
+++ b/groups/bdl/bdlpcre/bdlpcre_regex.cpp
@@ -339,6 +339,8 @@ RegEx_MatchContext::~RegEx_MatchContext()
 }
 
 // PRIVATE ACCESSORS
+// requires: matchContextData != 0
+// ensures: (__out == 0 ==> (matchContextData->d_matchData_p != 0 ⋆ matchContextData->d_matchContext_p != 0 ⋆ (matchContextData->d_jitStack_p != 0 || d_jitStackSize == 0))) && (__out == k_INTERNAL_ERROR ==> (matchContextData->d_matchData_p == 0 ⋆ matchContextData->d_matchContext_p == 0 ⋆ matchContextData->d_jitStack_p == 0))
 int
 RegEx_MatchContext::allocateMatchContext(
                                 RegEx_MatchContextData *matchContextData) const
@@ -401,6 +403,8 @@ RegEx_MatchContext::deallocateMatchContext(
 }
 
 // MANIPULATORS
+// requires: pcre2Context != 0 && patternCode != 0
+// ensures: d_pcre2Context_p ↦ pcre2Context ⋆ d_pcre2PatternCode_p ↦ patternCode ⋆ d_depthLimit ↦ depthLimit ⋆ d_jitStackSize ↦ jitStackSize ⋆ __out == allocateMatchContext(&d_mainThreadMatchData)
 int RegEx_MatchContext::initialize(pcre2_general_context *pcre2Context,
                                    pcre2_code            *patternCode,
                                    int                    depthLimit,
@@ -430,6 +434,8 @@ void RegEx_MatchContext::setDepthLimit(int depthLimit)
 }
 
 // ACCESSORS
+// requires: matchContextData != NULL
+// ensures: (matchContextData != nullptr ==> __out == RegEx::k_STATUS_SUCCESS) || (matchContextData == nullptr ==> __out == allocateMatchContext(matchContextData))
 int
 RegEx_MatchContext::acquireMatchContext(
                                 RegEx_MatchContextData *matchContextData) const
@@ -468,6 +474,8 @@ const size_t RegEx::k_INVALID_OFFSET = ~(size_t)0;
 
 
 // PRIVATE MANIPULATORS
+// requires: errorMessage != NULL && errorOffset != NULL && pattern != NULL && (flags & ~VALID_FLAGS) == 0
+// ensures: (__out == k_STATUS_SUCCESS) || (__out == k_INTERNAL_ERROR)
 int RegEx::prepareImp(char       *errorMessage,
                       size_t      errorMessageLength,
                       size_t     *errorOffset,
@@ -820,6 +828,8 @@ int RegEx::replaceImp(STRING                  *result,
 }
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == k_IS_JIT_SUPPORTED
 bool RegEx::isJitAvailable()
 {
     unsigned int result = 0;
@@ -903,6 +913,8 @@ int RegEx::setDepthLimit(int depthLimit)
 }
 
 // ACCESSORS
+// requires: subject.data() != nullptr && subject.length() >= 0 && subjectOffset <= subject.length()
+// ensures: __out == match(subject.data(), subject.length(), subjectOffset)
 int RegEx::match(const bsl::string_view& subject,
                  size_t                  subjectOffset) const
 {

--- a/groups/bdl/bdls/bdls_fdstreambuf.cpp
+++ b/groups/bdl/bdls/bdls_fdstreambuf.cpp
@@ -68,6 +68,8 @@ typedef bdls::FilesystemUtil FileUtil;
 /// Return `true` if the specified file descriptor `fd` refers to a regular
 /// file and `false` otherwise.  Note that a regular file is a file and not
 /// a directory, pipe, printer, keyboard or other device.
+// requires: true
+// ensures: true
 static
 bool getRegularFileInfo(bdls::FilesystemUtil::FileDescriptor fd)
 {
@@ -463,6 +465,8 @@ void FdStreamBuf_FileHandler::unmap(void *mappedMemory, bsl::streamoff length)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (__out == 0 ==> (d_fileId == -1 || (buf.st_size <= 0))) && (__out != 0 ==> (d_fileId != -1 && __out == buf.st_size))
 bsl::streamoff
 FdStreamBuf_FileHandler::fileSize() const
 {
@@ -524,6 +528,8 @@ FdStreamBuf::~FdStreamBuf()
 }
 
 // PRIVATE MANIPULATORS
+// requires: true
+// ensures: (__out == 0 ==> d_mode == e_INPUT_MODE) && (__out == -1 ==> d_mode != e_INPUT_MODE)
 int FdStreamBuf::switchToInputMode()
 {
     switch (d_mode) {
@@ -812,6 +818,8 @@ int FdStreamBuf::flush()
 }
 
 // PROTECTED MANIPULATORS
+// requires: true
+// ensures: (__out == traits_type::to_int_type(*gptr()) ==> (d_mode == e_INPUT_PUTBACK_MODE || (d_mmapBase_p != 0 && d_mmapLen > 0))) && (__out == traits_type::eof() ==> (d_mode != e_INPUT_MODE && switchToInputMode() != 0)) && (__out == underflowRead() ==> (d_mmapBase_p == 0 || d_mmapLen == 0))
 bsl::streambuf::int_type
 FdStreamBuf::underflow()
 {
@@ -997,6 +1005,8 @@ FdStreamBuf::overflow(int_type c)
     return ret;
 }
 
+// requires: (buffer == 0 && numBytes == 0) ==> (d_mode == e_NULL_MODE && (d_buf_p ↦ sep_v && sep_v != 0)) && (buffer != 0 && numBytes > 0) ==> (d_buf_p ↦ buffer)
+// ensures: (buffer == 0 && numBytes == 0 ==> (d_mode == e_NULL_MODE && (d_buf_p ↦ sep_v && sep_v != 0))) && (buffer != 0 && numBytes > 0 ==> (d_buf_p ↦ buffer)) && (__out == this)
 FdStreamBuf *FdStreamBuf::setbuf(char *buffer, bsl::streamsize numBytes)
     // 'buffer == 0 && n == 0' means to make this object have a 1 byte buffer.
     // 'buffer != 0 && n > 0' means to use 'buffer' as this object's internal

--- a/groups/bdl/bdls/bdls_filesystemutil.cpp
+++ b/groups/bdl/bdls/bdls_filesystemutil.cpp
@@ -160,6 +160,8 @@ namespace u {
 
 /// Convert the specified `str` to a string view, and then return the result
 /// of `substr` on that passing the specified `idx` and `len`.
+// requires: (0 <= idx && idx <= str.size()) && (len == bsl::string::npos || (idx + len <= str.size()))
+// ensures: __out == bsl::string_view(str).substr(idx, len)
 bsl::string_view substr(const bsl::string& str,
                         const size_t       idx,
                         const size_t       len = bsl::string::npos)
@@ -512,6 +514,8 @@ struct NameRec {
 /// Return an identifier for the current running process.  Note that this
 /// duplicates functionality in `ProcessUtil`, and is reproduced here to
 /// avoid a cycle.
+// requires: true
+// ensures: true
 int getProcessId()
 {
 #ifdef BSLS_PLATFORM_OS_WINDOWS
@@ -525,6 +529,8 @@ int getProcessId()
 /// otherwise.  This is equivalent to `isDotOrDots`, except it is called in
 /// the case where we know there are no `/`s in the file name, making the
 /// check simpler and faster.
+// requires: path != NULL
+// ensures: (__out == true ==> (*path == '.' && (!path[1] || ('.' == path[1] && !path[2])))) && (__out == false ==> !(*path == '.' && (!path[1] || ('.' == path[1] && !path[2]))))
 static inline
 bool shortIsDotOrDots(const char *path)
 {
@@ -824,6 +830,8 @@ void invokeCloseFD(void *fd_p, void *)
 
 /// Return `true` if the specified `path` is "." or ".." or ends in
 /// "/." or "/..", and `false` otherwise.
+// requires: path != NULL
+// ensures: (__out == true ==> (path[0] == '.' && strlen(path) == 1) || (path[strlen(path) - 1] == '.' && path[strlen(path) - 2] == '.' && (strlen(path) == 2 || path[strlen(path) - 3] == '/'))) && (__out == false ==> !(path[0] == '.' && strlen(path) == 1) && !(path[strlen(path) - 1] == '.' && path[strlen(path) - 2] == '.' && (strlen(path) == 2 || path[strlen(path) - 3] == '/')))
 static inline
 bool isDotOrDots(const char *path)
 {
@@ -869,6 +877,8 @@ bool isDotOrDots(const char *path)
 /// exist or is not a directory, `k_ERROR_ALREADY_EXISTS` if the file system
 /// entry (not necessarily a directory) with the name `path` already exists,
 /// and a negative value for any other kind of error.
+// requires: path != nullptr
+// ensures: (__out == 0) || (__out == bdls::FilesystemUtil::k_ERROR_ALREADY_EXISTS) || (__out == bdls::FilesystemUtil::k_ERROR_PATH_NOT_FOUND) || (__out == -1)
 static inline
 int makeDirectory(const char *path, bool isPrivate)
 {
@@ -902,6 +912,8 @@ int makeDirectory(const char *path, bool isPrivate)
 /// specified open file descriptor `dirFD`, not including the root.  Close
 /// `dirFd`.  The behavior is undefined unless `dirFD` refers to a directory
 /// and not a symlink.  Return 0 on success and a non-zero value otherwise.
+// requires: dirFD >= 0
+// ensures: (__out == 0) || (__out != 0)
 static
 int u_removeContentsOfTree(
                  const BloombergLP::bdls::FilesystemUtil::FileDescriptor dirFD)

--- a/groups/bdl/bdls/bdls_pathutil.cpp
+++ b/groups/bdl/bdls/bdls_pathutil.cpp
@@ -192,6 +192,8 @@ void findFirstNonSeparatorChar(int *result, const char *path, int length = -1)
 /// `length` is not given, assume `path` is null-terminated.  Note that this
 /// file may be a directory.  Also note that trailing separators are
 /// ignored.
+// requires: path != nullptr && rootEnd >= 0 && rootEnd <= bsl::strlen(path) && (length == -1 || (length >= 0 && length <= bsl::strlen(path)))
+// ensures: (__out >= path + rootEnd && __out <= path + length) && (__out == path + rootEnd || isSeparator(*__out)) && (__out > path + rootEnd ==> SEPFORALL(__out - path + 1, length, i, !isSeparator(path[i])))
 static
 const char *leafDelimiter(const char *path, int rootEnd, int length = -1)
 {
@@ -436,6 +438,8 @@ const char PathUtil::k_SEPARATOR =
 #endif
 
 // CLASS METHODS
+// requires: path != nullptr
+// ensures: __out == u_appendIfValid(path, filename)
 int PathUtil::appendIfValid(bsl::string             *path,
                             const bsl::string_view&  filename)
 {

--- a/groups/bdl/bdls/bdls_pipeutil.cpp
+++ b/groups/bdl/bdls/bdls_pipeutil.cpp
@@ -103,6 +103,8 @@ namespace bdls {
                               // ---------------
 
 // CLASS METHODS
+// requires: pipeName != 0
+// ensures: __out == u_makeCanonicalName(pipeName, baseName)
 int PipeUtil::makeCanonicalName(bsl::string             *pipeName,
                                 const bsl::string_view&  baseName)
 {

--- a/groups/bdl/bdls/bdls_processutil.cpp
+++ b/groups/bdl/bdls/bdls_processutil.cpp
@@ -71,6 +71,8 @@ using namespace BloombergLP;
     } while (false)
 
 /// Return a ptr to a string describing whether "/proc" exists or not.
+// requires: true
+// ensures: (__out == "" || __out == "\"/proc\" exists." || __out == "\"/proc\" does not exist.")
 static
 const char *doesProcExist()
 {
@@ -85,6 +87,8 @@ const char *doesProcExist()
 
 /// Return the process id.  Having this be separate from `Obj::getProcessId`
 /// allows us to call it inline within the component.
+// requires: true
+// ensures: __out > 0
 static inline
 int getPid()
 {
@@ -99,6 +103,8 @@ int getPid()
 /// not a directory, and is executable (or is a symbolic link to such a
 /// file) and `false` otherwise.  On Windows, return `true` if the file
 /// exists and is not a directory.
+// requires: path != nullptr
+// ensures: (__out == true ==> (0 == rc && !(s.st_mode & S_IFDIR) && (s.st_mode & executableBits))) && (__out == false ==> !(0 == rc && !(s.st_mode & S_IFDIR) && (s.st_mode & executableBits)))
 static inline
 bool isExecutable(const char *path)
 {
@@ -179,6 +185,8 @@ namespace bdls {
                              // ------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 int ProcessUtil::getProcessId()
 {
     return u::getPid();

--- a/groups/bdl/bdls/bdls_tempdirectoryguard.cpp
+++ b/groups/bdl/bdls/bdls_tempdirectoryguard.cpp
@@ -49,6 +49,8 @@ void TempDirectoryGuard::release()
 
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_dirName
 const bsl::string& TempDirectoryGuard::getTempDirName() const
 {
     return d_dirName;

--- a/groups/bdl/bdlsb/bdlsb_fixedmeminput.cpp
+++ b/groups/bdl/bdlsb/bdlsb_fixedmeminput.cpp
@@ -16,6 +16,8 @@ namespace bdlsb {
                         // -------------------
 
 // MANIPULATORS
+// requires: (!(which & bsl::ios_base::in) || (position >= 0 && position <= d_bufferSize)) && (which & bsl::ios_base::in) ==> position >= 0
+// ensures: (__out == -1 ==> (!(which & bsl::ios_base::in) || position < 0 || position > d_bufferSize)) && (__out != -1 ==> __out == position)
 FixedMemInput::pos_type
 FixedMemInput::pubseekpos(pos_type                position,
                           bsl::ios_base::openmode which)

--- a/groups/bdl/bdlsb/bdlsb_fixedmeminstreambuf.cpp
+++ b/groups/bdl/bdlsb/bdlsb_fixedmeminstreambuf.cpp
@@ -13,6 +13,8 @@ namespace BloombergLP {
 namespace bdlsb {
 
 // PROTECTED MANIPULATORS
+// requires: (!(which & bsl::ios_base::in) || (way == bsl::ios_base::beg || way == bsl::ios_base::cur || way == bsl::ios_base::end)) && (way == bsl::ios_base::beg ==> offset >= 0) && (way == bsl::ios_base::end ==> offset <= 0)
+// ensures: (__out == -1 ==> (!(which & bsl::ios_base::in) || __out < 0 || static_cast<bsl::size_t>(__out) > d_bufferSize)) && (__out != -1 ==> __out >= 0 && static_cast<bsl::size_t>(__out) <= d_bufferSize)
 FixedMemInStreamBuf::pos_type
 FixedMemInStreamBuf::seekoff(off_type                offset,
                              bsl::ios_base::seekdir  way,

--- a/groups/bdl/bdlsb/bdlsb_memoutstreambuf.cpp
+++ b/groups/bdl/bdlsb/bdlsb_memoutstreambuf.cpp
@@ -49,6 +49,8 @@ void MemOutStreamBuf::grow(size_t newLength)
 }
 
 // PROTECTED MANIPULATORS
+// requires: true
+// ensures: (insertionChar == traits_type::eof() ==> __out == traits_type::not_eof(insertionChar)) && (insertionChar != traits_type::eof() ==> __out == sputc(static_cast<char_type>(insertionChar)))
 int MemOutStreamBuf::overflow(int_type insertionChar)
 {
     if (traits_type::eof() == insertionChar) {

--- a/groups/bdl/bdlsb/bdlsb_overflowmemoutput.cpp
+++ b/groups/bdl/bdlsb/bdlsb_overflowmemoutput.cpp
@@ -64,6 +64,7 @@ OverflowMemOutput::OverflowMemOutput(char             *buffer,
 }
 
 // MANIPULATORS
+// ensures: (!(which & bsl::ios_base::out) || way != bsl::ios_base::beg && way != bsl::ios_base::cur && way != bsl::ios_base::end || __out < 0 ==> __out == -1) && (!(which & bsl::ios_base::out) && way == bsl::ios_base::beg && way == bsl::ios_base::cur && way == bsl::ios_base::end && __out >= 0 ==> __out != -1)
 OverflowMemOutput::pos_type
 OverflowMemOutput::pubseekoff(off_type                offset,
                               bsl::ios_base::seekdir  way,

--- a/groups/bdl/bdlsb/bdlsb_overflowmemoutstreambuf.cpp
+++ b/groups/bdl/bdlsb/bdlsb_overflowmemoutstreambuf.cpp
@@ -53,6 +53,8 @@ void OverflowMemOutStreamBuf::privateSync() const
 
 
 // PROTECTED MANIPULATORS
+// requires: true
+// ensures: (c == EOF ==> __out == traits_type::not_eof(c)) && (c != EOF ==> __out == c)
 OverflowMemOutStreamBuf::int_type
 OverflowMemOutStreamBuf::overflow(OverflowMemOutStreamBuf::int_type c)
 {

--- a/groups/bdl/bdlt/bdlt_calendar.cpp
+++ b/groups/bdl/bdlt/bdlt_calendar.cpp
@@ -306,6 +306,8 @@ void Calendar::unionNonBusinessDays(const PackedCalendar& other)
 }
 
 // ACCESSORS
+// requires: nextBusinessDay != 0 && date < Date(9999, 12, 31) && nth > 0 && (nextBusinessDay ↦ _)
+// ensures: (__out == e_SUCCESS ==> (*nextBusinessDay == firstDate() + offset)) && (__out == e_FAILURE ==> (*nextBusinessDay == old_nextBusinessDay))
 int Calendar::getNextBusinessDay(Date        *nextBusinessDay,
                                  const Date&  date,
                                  int          nth) const
@@ -334,6 +336,8 @@ int Calendar::getNextBusinessDay(Date        *nextBusinessDay,
 #ifndef BDE_OMIT_INTERNAL_DEPRECATED  // BDE3.0
 
 // DEPRECATED METHODS
+// requires: true
+// ensures: __out > initialDate
 Date Calendar::getNextBusinessDay(const Date& initialDate) const
 {
     Date currentDate = initialDate;

--- a/groups/bdl/bdlt/bdlt_calendarcache.cpp
+++ b/groups/bdl/bdlt/bdlt_calendarcache.cpp
@@ -52,6 +52,8 @@ CalendarCache_Entry::~CalendarCache_Entry()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (this->d_ptr ↦ rhs.d_ptr) ⋆ (this->d_loadTime ↦ rhs.d_loadTime)
 CalendarCache_Entry& CalendarCache_Entry::operator=(
                                                 const CalendarCache_Entry& rhs)
 {
@@ -62,6 +64,8 @@ CalendarCache_Entry& CalendarCache_Entry::operator=(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_ptr && (d_ptr ↦ _)
 bsl::shared_ptr<const Calendar> CalendarCache_Entry::get() const
 {
     return d_ptr;
@@ -109,6 +113,8 @@ CalendarCache::~CalendarCache()
 }
 
 // MANIPULATORS
+// requires: calendarName != 0
+// ensures: (__out != nullptr) || (__out == nullptr)
 bsl::shared_ptr<const Calendar>
 CalendarCache::getCalendar(const char *calendarName)
 {
@@ -197,6 +203,8 @@ int CalendarCache::invalidateAll()
 }
 
 // ACCESSORS
+// requires: calendarName != NULL
+// ensures: (__out.use_count() > 0) || (__out == bsl::shared_ptr<const Calendar>())
 bsl::shared_ptr<const Calendar>
 CalendarCache::lookupCalendar(const char *calendarName) const
 {

--- a/groups/bdl/bdlt/bdlt_currenttime.cpp
+++ b/groups/bdl/bdlt/bdlt_currenttime.cpp
@@ -24,6 +24,8 @@ bsls::AtomicOperations::AtomicTypes::Pointer
                     CurrentTime::currentTimeDefault)) };
 
 // CLASS METHODS
+// requires: true
+// ensures: (-1440 < __out.offset()) && (__out.offset() < 1440)
 DatetimeTz CurrentTime::asDatetimeTz()
 {
     Datetime now = utc();

--- a/groups/bdl/bdlt/bdlt_date.cpp
+++ b/groups/bdl/bdlt/bdlt_date.cpp
@@ -33,6 +33,8 @@ static const char *const months[] = {
                                   // ----------
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == 0 || __out == -1
 int Date::addDaysIfValid(int numDays)
 {
     enum { k_SUCCESS = 0, k_FAILURE = -1 };
@@ -53,6 +55,8 @@ int Date::addDaysIfValid(int numDays)
 }
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: __out == stream
 bsl::ostream& Date::print(bsl::ostream& stream,
                           int           level,
                           int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_datetime.cpp
+++ b/groups/bdl/bdlt/bdlt_datetime.cpp
@@ -152,6 +152,8 @@ const bsls::Types::Uint64 Datetime::k_MAX_US_FROM_EPOCH =
 bsls::AtomicInt64 Datetime::s_invalidRepresentationCount(0);
 
 // ACCESSORS
+// requires: true
+// ensures: __out == stream && SEPFORALL(0, 25, i, (stream + i ↦ buffer[i]))
 bsl::ostream& Datetime::print(bsl::ostream& stream,
                               int           level,
                               int           spacesPerLevel) const
@@ -275,6 +277,8 @@ int Datetime::printToBuffer(char *result,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& bdlt::operator<<(bsl::ostream& stream, const Datetime& object)
 {
     return object.print(stream, 0, -1);

--- a/groups/bdl/bdlt/bdlt_datetimeimputil.cpp
+++ b/groups/bdl/bdlt/bdlt_datetimeimputil.cpp
@@ -50,6 +50,8 @@ BSLMF_ASSERT(  DatetimeImpUtil::k_1970_01_01_VALUE
              < DatetimeImpUtil::k_MAX_VALUE);
 
 // CLASS METHODS
+// requires: true
+// ensures: __out != 0
 const Datetime *DatetimeImpUtil::epoch_0001_01_01()
 {
     return reinterpret_cast<const bdlt::Datetime *>(&k_0001_01_01_VALUE);

--- a/groups/bdl/bdlt/bdlt_datetimeinterval.cpp
+++ b/groups/bdl/bdlt/bdlt_datetimeinterval.cpp
@@ -56,6 +56,8 @@ const double maxInt64AsDouble = static_cast<double>(k_MAX_INT64);
 const double minInt64AsDouble = static_cast<double>(k_MIN_INT64);
 
 // HELPER FUNCTIONS
+// requires: result != nullptr && numBytes > 0
+// ensures: __out >= 0
 int printToBufferFormatted(char       *result,
                            int         numBytes,
                            const char *spec,
@@ -245,6 +247,15 @@ int DatetimeInterval::assignIfValid(bsls::Types::Int64 days,
 }
 
 // CLASS METHODS
+// requires: To ensure the function behaves correctly, the input parameters should be within the specified bounds. The function checks:
+- `u::k_HOURS_FLOOR <= hours <= u::k_HOURS_CEILING`
+- `u::k_MINUTES_FLOOR <= minutes <= u::k_MINUTES_CEILING`
+- `u::k_SECONDS_FLOOR <= seconds <= u::k_SECONDS_CEILING`
+- `u::k_MILLISECONDS_FLOOR <= milliseconds <= u::k_MILLISECONDS_CEILING`
+
+Additionally, the total duration should not exceed the maximum allowed duration.
+
+###
 bool DatetimeInterval::isValid(int                days,
                                bsls::Types::Int64 hours,
                                bsls::Types::Int64 minutes,
@@ -632,6 +643,8 @@ bsl::ostream& DatetimeInterval::print(bsl::ostream& stream,
 #ifndef BDE_OMIT_INTERNAL_DEPRECATED  // BDE2.22
 
 // DEPRECATED METHODS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& DatetimeInterval::streamOut(bsl::ostream& stream) const
 {
     return stream << *this;

--- a/groups/bdl/bdlt/bdlt_datetimetz.cpp
+++ b/groups/bdl/bdlt/bdlt_datetimetz.cpp
@@ -33,6 +33,8 @@ BSLMF_ASSERT(bslmf::IsBitwiseCopyable<DatetimeTz>::value);
                              // ----------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: (__out == stream) && (!stream.bad())
 bsl::ostream& DatetimeTz::print(bsl::ostream& stream,
                                 int           level,
                                 int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_datetz.cpp
+++ b/groups/bdl/bdlt/bdlt_datetz.cpp
@@ -29,6 +29,8 @@ BSLMF_ASSERT(!bslmf::IsTriviallyCopyableCheck<DateTz>::value);
                              // ------------
 
 // ACCESSORS
+// requires: true
+// ensures: (stream.bad() == true ==> __out == stream) && (stream.bad() == false ==> __out == stream)
 bsl::ostream& DateTz::print(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_dateutil.cpp
+++ b/groups/bdl/bdlt/bdlt_dateutil.cpp
@@ -10,6 +10,8 @@ namespace {
 
 /// Return the difference in number of days from the specified `day1` to the
 /// specified `day2`.
+// requires: true
+// ensures: (day1 > day2 ==> __out == 7 - day1 + day2) && (day1 <= day2 ==> __out == day2 - day1) && (0 <= __out && __out <= 6)
 int dayOfWeekDifference(DayOfWeek::Enum day1, DayOfWeek::Enum day2)
 {
     if (day1 > day2) {
@@ -27,6 +29,8 @@ int dayOfWeekDifference(DayOfWeek::Enum day1, DayOfWeek::Enum day2)
                              // ---------------
 
 // PRIVATE CLASS METHODS
+// requires: (original.month() == 2) && (original.day() == 28 || original.day() == 29)
+// ensures: (__out.month() == 2) && (__out.year() == original.year() + numYears) && (__out.day() == 28 || __out.day() == 29)
 Date DateUtil::addYearsEomEndOfFebruary(const Date& original, int numYears)
 {
     // Implementation note: The complete 'addYearsEom' was too long to be
@@ -59,6 +63,8 @@ Date DateUtil::addYearsEomEndOfFebruary(const Date& original, int numYears)
 }
 
 // CLASS METHODS
+// requires: original.year() >= 1 && original.year() <= 9999 && original.month() >= 1 && original.month() <= 12 && original.day() >= 1 && original.day() <= 31
+// ensures: (__out.year() == ((original.year() * 12 + original.month() + numMonths - 1) / 12)) && (__out.month() == (((original.year() * 12 + original.month() + numMonths - 1) % 12) + 1)) && (__out.day() <= 31) && (__out.day() == original.day() || __out.day() == SerialDateImpUtil::lastDayOfMonth(__out.year(), __out.month()))
 Date DateUtil::addMonthsEom(const Date& original, int numMonths)
 {
     const int totalMonths = original.year() * 12 + original.month() +

--- a/groups/bdl/bdlt/bdlt_dayofweek.cpp
+++ b/groups/bdl/bdlt/bdlt_dayofweek.cpp
@@ -19,6 +19,8 @@ namespace bdlt {
                             // ---------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == stream && SEPFORALL(0, strlen(toAscii(value)), i, (stream + i ↦ toAscii(value)[i]))
 bsl::ostream& DayOfWeek::print(bsl::ostream&   stream,
                                DayOfWeek::Enum value,
                                int             level,

--- a/groups/bdl/bdlt/bdlt_dayofweekset.cpp
+++ b/groups/bdl/bdlt/bdlt_dayofweekset.cpp
@@ -53,6 +53,8 @@ DayOfWeekSet_Iter::DayOfWeekSet_Iter(int data, int index)
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (d_index < 8 ==> ((1 << d_index) & d_data) != 0) && (d_index >= 8 || ((1 << d_index) & d_data) != 0) && (__out == *this)
 DayOfWeekSet_Iter& DayOfWeekSet_Iter::operator++()
 {
     while (d_index < 8) {
@@ -82,6 +84,8 @@ DayOfWeekSet_Iter& DayOfWeekSet_Iter::operator--()
                          // ------------------
 
 // ACCESSORS
+// requires: !stream.bad() && (stream ↦ _)
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& DayOfWeekSet::print(bsl::ostream& stream,
                                   int           level,
                                   int           spacesPerLevel) const

--- a/groups/bdl/bdlt/bdlt_defaultcalendarcache.cpp
+++ b/groups/bdl/bdlt/bdlt_defaultcalendarcache.cpp
@@ -41,6 +41,8 @@ bsls::ObjectBuffer<CalendarCache>            g_buffer;
 
 /// Return the address of the lock used to initialize and destroy the
 /// default calendar cache in a thread-safe manner.
+// requires: true
+// ensures: __out != 0 && (__out != 0 ==> true)
 static
 bslmt::Mutex *getLock()
 {
@@ -68,6 +70,8 @@ bslmt::Mutex *getLock()
 /// `allocator` remain valid until a subsequent call to
 /// `bdlt::DefaultCalendarCache::destroy`, and
 /// `bsls::TimeInterval() <= timeout <= bsls::TimeInterval(INT_MAX, 0)`.
+// requires: loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)
+// ensures: (__out == 0 || __out == 1) && (__out == 0 ==> bsls::AtomicOperations::getPtrAcquire(&g_cachePtr) != NULL)
 static
 int initializePrivate(CalendarLoader            *loader,
                       bool                       hasTimeOutFlag,

--- a/groups/bdl/bdlt/bdlt_defaulttimetablecache.cpp
+++ b/groups/bdl/bdlt/bdlt_defaulttimetablecache.cpp
@@ -40,6 +40,8 @@ bsls::ObjectBuffer<TimetableCache>           g_buffer;
 
 /// Return the address of the lock used to initialize and destroy the
 /// default timetable cache in a thread-safe manner.
+// requires: true
+// ensures: __out != 0 && (__out != 0 ==> true)
 static
 bslmt::Mutex *getLock()
 {
@@ -67,6 +69,8 @@ bslmt::Mutex *getLock()
 /// `allocator` remain valid until a subsequent call to
 /// `bdlt::DefaultTimetableCache::destroy`, and
 /// `bsls::TimeInterval() <= timeout <= bsls::TimeInterval(INT_MAX, 0)`.
+// requires: loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)
+// ensures: (__out == 0 || __out == 1) && (__out == 0 ==> bsls::AtomicOperations::getPtrAcquire(&g_cachePtr) != NULL)
 static
 int initializePrivate(TimetableLoader           *loader,
                       bool                       hasTimeOutFlag,

--- a/groups/bdl/bdlt/bdlt_fixutil.cpp
+++ b/groups/bdl/bdlt/bdlt_fixutil.cpp
@@ -224,6 +224,8 @@ int Impl::generate(STRING                      *string,
 /// non-zero value (with no effect) otherwise.  All characters in the range
 /// `[begin .. end)` must be decimal digits.  The behavior is undefined
 /// unless `begin < end` and the parsed value does not exceed `INT_MAX`.
+// requires: nextPos != 0 && result != 0 && begin != 0 && end != 0 && begin < end && SEPFORALL(begin, end, i, (begin + i ↦ sep_v) && (sep_v >= '0' && sep_v <= '9'))
+// ensures: (__out == 0 ==> (*result ↦ tmp ⋆ *nextPos ↦ end)) && (__out == -1 ==> SEPEXISTS(0, end - begin, i, (begin + i ↦ sep_v) && !(sep_v >= '0' && sep_v <= '9')))
 int asciiToInt(const char **nextPos,
                int         *result,
                const char  *begin,
@@ -262,6 +264,8 @@ int asciiToInt(const char **nextPos,
 /// `*nextPos`) otherwise.  The behavior is undefined unless `begin <= end`.
 /// Note that successfully parsing a date before `end` is reached is not an
 /// error.
+// requires: nextPos != NULL && date != NULL && begin != NULL && end != NULL && begin <= end && (end - begin >= sizeof "YYYYMMDD" - 1)
+// ensures: __out == 0 || __out == -1
 int parseDate(const char **nextPos,
               Date        *date,
               const char  *begin,
@@ -376,6 +380,8 @@ int parseFractionalSecond(const char **nextPos,
 /// otherwise.  The behavior is undefined unless `begin <= end`.  Note that
 /// successfully parsing a timezone offset before `end` is reached is not an
 /// error.
+// requires: nextPos != nullptr && minuteOffset != nullptr && begin <= end && begin != end
+// ensures: (__out == -1) || (__out == 0 && (*nextPos == p) && (*minuteOffset == (sign == '-' ? -(hour * 60 + minute) : (hour * 60 + minute))))
 int parseTimezoneOffset(const char **nextPos,
                         int         *minuteOffset,
                         const char  *begin,
@@ -575,6 +581,8 @@ int parseTime(const char **nextPos,
 /// that if the decimal string representation of `value` is more than
 /// `paddedLen` digits, only the low-order `paddedLen` digits of `value` are
 /// output.
+// requires: buffer != NULL && 0 <= value && 0 <= paddedLen
+// ensures: __out == paddedLen
 int generateInt(char *buffer, int value, int paddedLen)
 {
     BSLS_ASSERT(buffer);
@@ -599,6 +607,8 @@ int generateInt(char *buffer, int value, int paddedLen)
 /// sufficient capacity to hold `paddedLen` characters.  Note that if the
 /// decimal string representation of `value` is more than `paddedLen`
 /// digits, only the low-order `paddedLen` digits of `value` are output.
+// requires: buffer != nullptr && paddedLen >= 0
+// ensures: __out == paddedLen + 1
 inline
 int generateInt(char *buffer, int value, int paddedLen, char separator)
 {
@@ -616,6 +626,8 @@ int generateInt(char *buffer, int value, int paddedLen, char separator)
 /// indicated by the specified `tzOffset` and `configuration`, and return
 /// the number of bytes written.  The behavior is undefined unless `buffer`
 /// has sufficient capacity and `-(24 * 60) < tzOffset < 24 * 60`.
+// requires: buffer != NULL && -(24 * 60) < tzOffset && tzOffset < 24 * 60
+// ensures: (0 == tzOffset && configuration.useZAbbreviationForUtc() ==> __out == 1) && (0 != tzOffset || !configuration.useZAbbreviationForUtc() ==> __out >= 4)
 int generateTimezoneOffset(char                        *buffer,
                            int                          tzOffset,
                            const FixUtilConfiguration&  configuration)
@@ -785,6 +797,8 @@ namespace bdlt {
                               // --------------
 
 // CLASS METHODS
+// requires: buffer != NULL && bufferLength >= 0
+// ensures: __out == k_DATE_STRLEN
 int FixUtil::generate(char                        *buffer,
                       int                          bufferLength,
                       const Date&                  object,

--- a/groups/bdl/bdlt/bdlt_fixutilconfiguration.cpp
+++ b/groups/bdl/bdlt/bdlt_fixutilconfiguration.cpp
@@ -61,6 +61,8 @@ FixUtilConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: (__out == stream) && (SEPFORALL(0, 2, i, (stream + i ↦ sep_v) && ((i == 0 && sep_v == object.fractionalSecondPrecision()) || (i == 1 && sep_v == object.useZAbbreviationForUtc()))))
 bsl::ostream& bdlt::operator<<(bsl::ostream&               stream,
                                const FixUtilConfiguration& object)
 {

--- a/groups/bdl/bdlt/bdlt_fuzzutil.cpp
+++ b/groups/bdl/bdlt/bdlt_fuzzutil.cpp
@@ -14,6 +14,8 @@ namespace bdlt {
                               // ---------------
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 DateTz FuzzUtil::consumeDateTz(bslim::FuzzDataView *fuzzDataView)
 {
     return DateTz(consumeDate(fuzzDataView), consumeTz(fuzzDataView));

--- a/groups/bdl/bdlt/bdlt_iso8601utilconfiguration.cpp
+++ b/groups/bdl/bdlt/bdlt_iso8601utilconfiguration.cpp
@@ -84,6 +84,8 @@ Iso8601UtilConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& bdlt::operator<<(bsl::ostream&                   stream,
                                const Iso8601UtilConfiguration& object)
 {

--- a/groups/bdl/bdlt/bdlt_iso8601utilparseconfiguration.cpp
+++ b/groups/bdl/bdlt/bdlt_iso8601utilparseconfiguration.cpp
@@ -36,6 +36,8 @@ Iso8601UtilParseConfiguration::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& bdlt::operator<<(bsl::ostream&                        stream,
                                const Iso8601UtilParseConfiguration& object)
 {

--- a/groups/bdl/bdlt/bdlt_monthofyear.cpp
+++ b/groups/bdl/bdlt/bdlt_monthofyear.cpp
@@ -16,6 +16,8 @@ namespace bdlt {
                      // ------------------
 
 // CLASS METHODS
+// requires: stream ↦ _
+// ensures: __out == stream && (stream ↦ _)
 bsl::ostream& MonthOfYear::print(bsl::ostream&     stream,
                                  MonthOfYear::Enum value,
                                  int               level,

--- a/groups/bdl/bdlt/bdlt_packedcalendar.cpp
+++ b/groups/bdl/bdlt/bdlt_packedcalendar.cpp
@@ -137,6 +137,8 @@ void appendHoliday(
 /// product of the specified `level` and `spacesPerLevel` to the specified
 /// output `stream` and return a reference to the modifiable `stream`.  If
 /// the `level` is negative, this function has no effect.
+// requires: level >= 0 && spacesPerLevel != 0
+// ensures: SEPFORALL(0, level * spacesPerLevel, i, (stream + i ↦ ' '))
 static
 bsl::ostream& indent(bsl::ostream& stream,
                      int           level,
@@ -166,6 +168,8 @@ bsl::ostream& indent(bsl::ostream& stream,
 /// `firstDate` to `lastDate` whose day-of-week are in the specified
 /// `weekendDays` set.  Note that this function returns 0 if
 /// `lastDate < firstDate`.
+// requires: true
+// ensures: __out == ((firstDate <= lastDate ? (lastDate - firstDate + 1) : 0) / 7) * weekendDays.length() + (s_partialWeeks[static_cast<int>(firstDate.dayOfWeek())][(firstDate <= lastDate ? (lastDate - firstDate + 1) : 0) % 7] & weekendDays).length()
 static
 int numWeekendDaysInRangeImp(const Date&         firstDate,
                              const Date&         lastDate,
@@ -499,6 +503,8 @@ void PackedCalendar::unionHolidays(
 }
 
 // PRIVATE MANIPULATORS
+// requires: 0 <= offset
+// ensures: __out >= 0 && __out < d_holidayOffsets.length() && d_holidayOffsets[__out] == offset
 int PackedCalendar::addHolidayImp(int offset)
 {
     BSLS_ASSERT(0 <= offset && d_lastDate - d_firstDate >= offset);
@@ -604,6 +610,8 @@ PackedCalendar::~PackedCalendar()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this && (*this == rhs)
 PackedCalendar& PackedCalendar::operator=(const PackedCalendar& rhs)
 {
     PackedCalendar(rhs, d_allocator_p).swap(*this);
@@ -1068,6 +1076,8 @@ void PackedCalendar::swap(PackedCalendar& other)
 }
 
 // ACCESSORS
+// requires: isHoliday(date)
+// ensures: (__out == d_holidayCodes.begin() + iterIndex) && (iterIndex == d_holidayCodes.length() || (iterIndex == d_holidayCodesIndex[i - offsetBegin] && i != offsetEnd && *i == offset))
 PackedCalendar::HolidayCodeConstIterator
                       PackedCalendar::beginHolidayCodes(const Date& date) const
 {
@@ -1360,6 +1370,8 @@ bsl::ostream& PackedCalendar::print(bsl::ostream& stream,
 }  // close package namespace
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == (lhs.d_firstDate == rhs.d_firstDate && lhs.d_lastDate == rhs.d_lastDate && lhs.d_weekendDaysTransitions == rhs.d_weekendDaysTransitions && lhs.d_holidayOffsets == rhs.d_holidayOffsets && lhs.d_holidayCodesIndex == rhs.d_holidayCodesIndex && lhs.d_holidayCodes == rhs.d_holidayCodes)
 bool bdlt::operator==(const PackedCalendar& lhs, const PackedCalendar& rhs)
 {
     return lhs.d_firstDate              == rhs.d_firstDate
@@ -1526,6 +1538,8 @@ void PackedCalendar_BusinessDayConstIterator::previousBusinessDay()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out.d_offsetIter == rhs.d_offsetIter ⋆ __out.d_calendar_p == rhs.d_calendar_p ⋆ __out.d_currentOffset == rhs.d_currentOffset ⋆ __out.d_endFlag == rhs.d_endFlag
 PackedCalendar_BusinessDayConstIterator&
 PackedCalendar_BusinessDayConstIterator::operator=(
                             const PackedCalendar_BusinessDayConstIterator& rhs)

--- a/groups/bdl/bdlt/bdlt_posixdateimputil.cpp
+++ b/groups/bdl/bdlt/bdlt_posixdateimputil.cpp
@@ -101,6 +101,8 @@ static const int leapDaysPerMonth[] = { 0,
 /// indicated by an integer index in the range `[ 0 .. k_MAX_MONTH ]`, where
 /// an index of 0 always results in the value 0.  The behavior is undefined
 /// unless `k_MIN_YEAR <= year <= k_MAX_YEAR`.
+// requires: k_MIN_YEAR <= year && year <= k_MAX_YEAR
+// ensures: (bdlt::PosixDateImpUtil::isLeapYear(year) && year == k_YEAR_1752 ==> __out == y1752DaysThroughMonth) && (bdlt::PosixDateImpUtil::isLeapYear(year) && year != k_YEAR_1752 ==> __out == leapDaysThroughMonth) && (!bdlt::PosixDateImpUtil::isLeapYear(year) ==> __out == normDaysThroughMonth)
 static inline
 const int *getArrayDaysThroughMonth(int year)
 {
@@ -117,6 +119,8 @@ const int *getArrayDaysThroughMonth(int year)
 /// Return the total number of days in all years, beginning with the year 1,
 /// up to but not including the specified `year`.  The behavior is undefined
 /// unless `k_MIN_YEAR <= year <= k_MAX_YEAR`.
+// requires: k_MIN_YEAR <= year && year <= k_MAX_YEAR
+// ensures: __out == (year - 1) * k_DAYS_IN_NON_LEAP_YEAR + (year - 1) / 4 - (year > k_YEAR_1752 ? k_YEAR_1752_NUM_MISSING_DAYS + (year > k_YEAR_1800 ? (year - k_YEAR_1701) / 100 - (year - k_YEAR_1601) / 400 : 0) : 0)
 static
 int numDaysInPreviousYears(int year)
 {
@@ -148,6 +152,8 @@ int numDaysInPreviousYears(int year)
 
 /// Return the number of leap years from year 1 to the specified `year`.
 /// The behavior is undefined unless `0 <= year <= k_MAX_YEAR`.
+// requires: 0 <= year
+// ensures: (year >= k_YEAR_2000 ==> __out == k_NUM_LEAP_YEARS_UNTIL_YEAR_2000 + (year - k_YEAR_2000) / 4 - (year - k_YEAR_2000) / 100 + (year - k_YEAR_2000) / 400) && (year >= k_YEAR_1800 && year < k_YEAR_2000 ==> __out == k_NUM_LEAP_YEARS_UNTIL_YEAR_1800 + (year - k_YEAR_1800) / 4 - (year - k_YEAR_1800) / 100) && (year < k_YEAR_1800 ==> __out == year / 4)
 static
 int numLeapYearsSoFar(int year)
 {
@@ -184,6 +190,8 @@ int numLeapYearsSoFar(int year)
                            // -----------------------
 
 // CLASS METHODS
+// requires: k_MIN_YEAR <= year && year <= k_MAX_YEAR && k_MIN_MONTH <= month && month <= k_MAX_MONTH
+// ensures: (month == k_FEBRUARY && isLeapYear(year) ==> __out == normDaysPerMonth[month] + 1) && (month != k_FEBRUARY || !isLeapYear(year) ==> __out == normDaysPerMonth[month])
 int PosixDateImpUtil::lastDayOfMonth(int year, int month)
 {
     BSLS_ASSERT(k_MIN_YEAR  <= year);

--- a/groups/bdl/bdlt/bdlt_prolepticdateimputil.cpp
+++ b/groups/bdl/bdlt/bdlt_prolepticdateimputil.cpp
@@ -164,6 +164,8 @@ int numLeapYearsSoFar(int);
 /// `year` and including the days in the specified `month`.  The behavior is
 /// undefined unless `k_MIN_YEAR <= year <= k_MAX_YEAR` and
 /// `0 <= month <= k_MAX_MONTH`.
+// requires: k_MIN_YEAR <= year && year <= k_MAX_YEAR && 0 <= month && month <= k_MAX_MONTH
+// ensures: __out == getArrayDaysThroughMonth(year)[month]
 static inline
 int calendarDaysThroughMonth(int year, int month)
 {
@@ -189,6 +191,8 @@ const int *getArrayDaysThroughMonth(int year)
 /// Return the total number of days in all years, beginning with the year 1,
 /// up to but not including the specified `year`.  The behavior is undefined
 /// unless `k_MIN_YEAR <= year <= k_MAX_YEAR`.
+// requires: k_MIN_YEAR <= year && year <= k_MAX_YEAR
+// ensures: __out == (year - 1) * k_DAYS_IN_NON_LEAP_YEAR + numLeapYearsSoFar(year - 1)
 static inline
 int numDaysInPreviousYears(int year)
 {
@@ -216,6 +220,8 @@ int numLeapYearsSoFar(int year)
                            // ---------------------------
 
 // CLASS METHODS
+// requires: (k_MIN_YEAR <= year && year <= k_MAX_YEAR) && (k_MIN_MONTH <= month && month <= k_MAX_MONTH)
+// ensures: (month == k_FEB && isLeapYear(year) ==> __out == normDaysPerMonth[month] + 1) && (month != k_FEB || !isLeapYear(year) ==> __out == normDaysPerMonth[month])
 int ProlepticDateImpUtil::lastDayOfMonth(int year, int month)
 {
     BSLS_ASSERT(k_MIN_YEAR  <= year);

--- a/groups/bdl/bdlt/bdlt_time.cpp
+++ b/groups/bdl/bdlt/bdlt_time.cpp
@@ -49,6 +49,8 @@ BSLMF_ASSERT(!bslmf::IsTriviallyCopyableCheck<Time>::value);
 /// ```
 /// *number == *number % base + (*number / base) * base
 /// ```
+// requires: number ↦ _ && base >= 1
+// ensures: (__out == old_initial / base) && (number ↦ old_initial % base) && (old_initial == *number + __out * base)
 static
 bsls::Types::Int64 fastMod(int *number, int base)
 {
@@ -75,6 +77,8 @@ bsls::Types::Int64 fastMod(int *number, int base)
 /// ```
 /// *number == *number % base + (*number / base) * base
 /// ```
+// requires: number ↦ _ && base >= 1
+// ensures: (__out == old_number / base) && (number ↦ old_number % base) && (old_number == *number + __out * base)
 static
 bsls::Types::Int64 fastMod(bsls::Types::Int64 *number, bsls::Types::Int64 base)
 {
@@ -100,6 +104,8 @@ bsls::Types::Int64 fastMod(bsls::Types::Int64 *number, bsls::Types::Int64 base)
 /// *number == *number % base + (*number / base) * base
 /// ```
 /// The behavior is undefined unless `1 <= base`.
+// requires: base > 0 && number ↦ _
+// ensures: (__out == old_number / base) && (number ↦ old_number % base) && (0 <= *number) && (*number < base)
 static
 bsls::Types::Int64 modulo(bsls::Types::Int64 *number, bsls::Types::Int64 base)
 {
@@ -203,6 +209,8 @@ int printToBufferFormatted(char       *result,
 bsls::AtomicInt64 Time::s_invalidRepresentationCount(0);
 
 // PRIVATE ACCESSORS
+// requires: true
+// ensures: __out == (BSLS_PLATFORM_IS_LITTLE_ENDIAN ? d_value * TimeUnitRatio::k_US_PER_MS : (d_value >> 32) * TimeUnitRatio::k_US_PER_MS)
 bsls::Types::Int64 Time::invalidMicrosecondsFromMidnight() const
 {
     BSLS_ASSERT(k_REP_MASK > d_value);
@@ -217,6 +225,8 @@ bsls::Types::Int64 Time::invalidMicrosecondsFromMidnight() const
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == static_cast<int>(wholeDays)
 int Time::addHours(int hours)
 {
     bsls::Types::Int64 totalMicroseconds =

--- a/groups/bdl/bdlt/bdlt_timetable.cpp
+++ b/groups/bdl/bdlt/bdlt_timetable.cpp
@@ -92,6 +92,8 @@ bsl::ostream& TimetableTransition::print(bsl::ostream& stream,
                            // -------------------
 
 // MANIPULATORS
+// requires: 24 > time.hour() && (0 <= code || code == Timetable::k_UNSET_TRANSITION_CODE)
+// ensures: (__out == true ==> finalTransitionCode() != old_finalTransitionCode) && (__out == false ==> finalTransitionCode() == old_finalTransitionCode)
 bool Timetable_Day::addTransition(const Time& time, int code)
 {
     BSLS_ASSERT(24 > time.hour());
@@ -137,6 +139,8 @@ bool Timetable_Day::removeTransition(const Time& time)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: (time.hour() < 24) ==> (__out == finalTransitionCode() || __out == d_initialTransitionCode || __out == iter->d_code)
 int Timetable_Day::transitionCodeInEffect(const Time& time) const
 {
     BSLS_ASSERT(24 > time.hour());
@@ -438,6 +442,8 @@ void Timetable::setValidRange(const Date& firstDate, const Date& lastDate)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == Timetable_ConstIterator(*this, dayIndex, 0)
 Timetable::const_iterator Timetable::begin() const
 {
     bsl::size_t dayIndex = 0;
@@ -479,6 +485,8 @@ bsl::ostream& Timetable::print(bsl::ostream& stream,
                       // -----------------------------
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this
 Timetable_ConstIterator& Timetable_ConstIterator::operator++()
 {
     BSLS_ASSERT(d_dayIndex < d_timetable_p->d_timetable.length());

--- a/groups/bdl/bdlt/bdlt_timetablecache.cpp
+++ b/groups/bdl/bdlt/bdlt_timetablecache.cpp
@@ -53,6 +53,8 @@ TimetableCache_Entry::~TimetableCache_Entry()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: d_ptr ↦ rhs.d_ptr ⋆ d_loadTime ↦ rhs.d_loadTime
 TimetableCache_Entry& TimetableCache_Entry::operator=(
                                                const TimetableCache_Entry& rhs)
 {
@@ -63,6 +65,8 @@ TimetableCache_Entry& TimetableCache_Entry::operator=(
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_ptr && (d_ptr ↦ _)
 bsl::shared_ptr<const Timetable> TimetableCache_Entry::get() const
 {
     return d_ptr;
@@ -110,6 +114,8 @@ TimetableCache::~TimetableCache()
 }
 
 // MANIPULATORS
+// requires: timetableName != NULL
+// ensures: (__out.get() != nullptr) ==> (__out.use_count() > 0)
 bsl::shared_ptr<const Timetable>
 TimetableCache::getTimetable(const char *timetableName)
 {
@@ -195,6 +201,8 @@ int TimetableCache::invalidateAll()
 }
 
 // ACCESSORS
+// requires: timetableName != NULL
+// ensures: (__out != nullptr) ==> (__out.use_count() > 0)
 bsl::shared_ptr<const Timetable>
 TimetableCache::lookupTimetable(const char *timetableName) const
 {

--- a/groups/bdl/bdlt/bdlt_timetz.cpp
+++ b/groups/bdl/bdlt/bdlt_timetz.cpp
@@ -30,6 +30,8 @@ BSLMF_ASSERT(!bslmf::IsTriviallyCopyableCheck<TimeTz>::value);
                              // ------------
 
 // ACCESSORS
+// requires: !stream.bad()
+// ensures: (__out == stream) && (!stream.bad() || stream.bad()) && (__out != 0) && (__out->str() ↦ oss.str())
 bsl::ostream& TimeTz::print(bsl::ostream& stream,
                             int           level,
                             int           spacesPerLevel) const

--- a/groups/bsl/bslalg/bslalg_hashutil.cpp
+++ b/groups/bsl/bslalg/bslalg_hashutil.cpp
@@ -65,6 +65,8 @@ unsigned int hash(const char *data, int length)
 /// would do them, so that this function, when called on a little-endian
 /// machine, will return the same value as `hash` called on a big-endian
 /// machine.
+// requires: 0 <= length && (length == 0 || data != 0)
+// ensures: true
 static
 unsigned int reverse_hash(const char *data, int length)
 {

--- a/groups/bsl/bslalg/bslalg_rbtreeutil.cpp
+++ b/groups/bsl/bslalg/bslalg_rbtreeutil.cpp
@@ -17,6 +17,8 @@ namespace BloombergLP {
 namespace bslalg {
 
 /// Return `true` if `node` is 0 or colored black, and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (node == 0 || node->isBlack())) && (__out == false ==> (node != 0 && !node->isBlack()))
 static inline bool isBlackOrNull(const RbTreeNode *node)
 {
     return !node || node->isBlack();
@@ -157,6 +159,8 @@ static void recolorTreeAfterRemoval(RbTreeAnchor *tree,
                         // class RbTreeUtil
                         // ----------------
 // CLASS METHODS
+// requires: subtree != 0 && FORALL(subtree, nullptr, node, node->leftChild() != 0 || node == subtree)
+// ensures: __out != 0 && __out->leftChild() == 0
 const RbTreeNode *RbTreeUtil::leftmost(const RbTreeNode *subtree)
 {
     BSLS_ASSERT(subtree);

--- a/groups/bsl/bslfmt/bslfmt_unicodecodepoint.cpp
+++ b/groups/bsl/bslfmt/bslfmt_unicodecodepoint.cpp
@@ -90,6 +90,8 @@ struct EndCompare
 /// Determine whether the start of the specified array `bytes`, up to a maximum
 /// length of the specified `maxBytes` contains a UTF Byte Order Marker, and
 /// return the result.
+// requires: maxBytes >= 2
+// ensures: true
 inline
 static bool isByteOrderMarker(const void *bytes, size_t maxBytes)
 {
@@ -147,6 +149,8 @@ static bool isByteOrderMarker(const void *bytes, size_t maxBytes)
 /// 2-byte UTF-8 sequence referred to by the specified `pc`.  The behavior is
 /// undefined unless the 2 bytes starting at `pc` contain a UTF-8 sequence
 /// describing a single valid code point.
+// requires: (pc ↦ _ ⋆ (pc + 1) ↦ _)
+// ensures: __out == ((*pc & 0x1f) << 6) | ((pc[1] & k_UTF8_CONT_VALUE_MASK))
 inline
 static int get2ByteUtf8Value(const unsigned char *pc)
 {
@@ -157,6 +161,8 @@ static int get2ByteUtf8Value(const unsigned char *pc)
 /// 3-byte UTF-8 sequence referred to by the specified `pc`.  The behavior is
 /// undefined unless the 3 bytes starting at `pc` contain a UTF-8 sequence
 /// describing a single valid code point.
+// requires: (pc ↦ _ ⋆ (pc + 1) ↦ _ ⋆ (pc + 2) ↦ _)
+// ensures: __out == ((*pc & 0xf) << 12) | ((pc[1] & k_UTF8_CONT_VALUE_MASK) << 6) | (pc[2] & k_UTF8_CONT_VALUE_MASK)
 inline
 static int get3ByteUtf8Value(const unsigned char *pc)
 {
@@ -168,6 +174,8 @@ static int get3ByteUtf8Value(const unsigned char *pc)
 /// 4-byte UTF-8 sequence referred to by the specified `pc`.  The behavior is
 /// undefined unless the 4 bytes starting at `pc` contain a UTF-8 sequence
 /// describing a single valid code point.
+// requires: pc != NULL && pc + 3 < (unsigned char*)-1
+// ensures: true
 inline
 static int get4ByteUtf8Value(const unsigned char *pc)
 {
@@ -179,6 +187,8 @@ static int get4ByteUtf8Value(const unsigned char *pc)
 /// Determine the width of the specified `codepoint` per the rules in the C++
 /// standard in [format.string.std].  Note that this width may differ from that
 /// specified by the Unicode standard.
+// requires: true
+// ensures: __out == 1 || __out == 2
 inline
 static int getCodepointWidth(unsigned long int codepoint)
 {
@@ -211,6 +221,8 @@ static int getCodepointWidth(unsigned long int codepoint)
 
 /// Return `true` if the specified `value` is NOT a UTF-8 continuation byte,
 /// and `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> (value & 0xc0) != 0x80) && (__out == false ==> (value & 0xc0) == 0x80)
 inline
 static bool isNotUtf8Continuation(unsigned char value)
 {
@@ -219,6 +231,8 @@ static bool isNotUtf8Continuation(unsigned char value)
 
 /// Return `true` if the specified `value` is a surrogate value, and `false`
 /// otherwise.
+// requires: true
+// ensures: (__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTBOTH & value) == k_UTF16_HIGH_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTBOTH & value) != k_UTF16_HIGH_SURROGATE_START))
 inline
 static bool isSurrogateValue(unsigned int value)
 {
@@ -230,6 +244,8 @@ static bool isSurrogateValue(unsigned int value)
 
 /// Return `true` if the specified `value` is a high surrogate value, and
 /// `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) == k_UTF16_HIGH_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) != k_UTF16_HIGH_SURROGATE_START))
 inline
 static bool isHighSurrogateValue(unsigned int value)
 {
@@ -241,6 +257,8 @@ static bool isHighSurrogateValue(unsigned int value)
 
 /// Return `true` if the specified `value` is a high surrogate value, and
 /// `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) == k_UTF16_LOW_SURROGATE_START)) && (__out == false ==> ((k_UTF16_SURROGATE_MASK_TESTONE & value) != k_UTF16_LOW_SURROGATE_START))
 inline
 static bool isLowSurrogateValue(unsigned int value)
 {

--- a/groups/bsl/bslh/bslh_siphashalgorithm.cpp
+++ b/groups/bsl/bslh/bslh_siphashalgorithm.cpp
@@ -86,6 +86,8 @@ typedef unsigned char       u8;
 /// Return the bits of the specified `x` rotated to the left by the
 /// specified `b` number of bits.  Bits that are rotated off the end are
 /// wrapped around to the beginning.
+// requires: true
+// ensures: __out == ((x << b) | (x >> (64 - b)))
 inline
 static u64 rotl(u64 x, u64 b)
 {
@@ -116,6 +118,8 @@ static void sipround(u64& v0, u64& v1, u64& v2, u64& v3)
 /// Return the 64-bit integer representation of the specified `p` taking
 /// into account endianness.  Undefined unless `p` points to at least eight
 /// bytes of initialized memory.
+// requires: p ↦ _ ⋆ (p + 1) ↦ _ ⋆ (p + 2) ↦ _ ⋆ (p + 3) ↦ _ ⋆ (p + 4) ↦ _ ⋆ (p + 5) ↦ _ ⋆ (p + 6) ↦ _ ⋆ (p + 7) ↦ _
+// ensures: __out == BSLS_BYTEORDER_LE_U64_TO_HOST(*((u64*)p))
 inline
 static u64 u8to64_le(const u8* p)
 {

--- a/groups/bsl/bslim/bslim_printer.cpp
+++ b/groups/bsl/bslim/bslim_printer.cpp
@@ -80,6 +80,8 @@ Printer::~Printer()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_level
 int Printer::absLevel() const
 {
     return d_level;

--- a/groups/bsl/bslma/bslma_allocator.cpp
+++ b/groups/bsl/bslma/bslma_allocator.cpp
@@ -36,6 +36,8 @@ Allocator::~Allocator()
 }
 
 // PROTECTED MANIPULATORS
+// requires: bytes >= 0 && align > 0
+// ensures: (bytes == 0 ==> __out != nullptr) && (bytes != 0 ==> __out != nullptr)
 void *Allocator::do_allocate(std::size_t bytes, std::size_t align)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(0 == bytes)) {

--- a/groups/bsl/bslma/bslma_bufferallocator.cpp
+++ b/groups/bsl/bslma/bslma_bufferallocator.cpp
@@ -26,6 +26,7 @@ namespace BloombergLP {
 /// allocation.  The behavior is undefined unless
 /// `0 < alignment <= bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT` and alignment
 /// is an integral power of 2.
+// ensures: (__out == nullptr ==> *cursor + bsls::AlignmentUtil::calculateAlignmentOffset(buffer + *cursor, alignment) + size > bufSize) && (__out != nullptr ==> __out >= buffer && __out < buffer + bufSize)
 static
 void *allocateFromBufferImp(int                               *cursor,
                             char                              *buffer,

--- a/groups/bsl/bslma/bslma_infrequentdeleteblocklist.cpp
+++ b/groups/bsl/bslma/bslma_infrequentdeleteblocklist.cpp
@@ -26,6 +26,8 @@ InfrequentDeleteBlockList::~InfrequentDeleteBlockList()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == 0 ==> numBytes == 0) && (__out != 0 ==> (d_head_p->d_next_p ↦ old_d_head_p ⋆ d_head_p->d_memory ↦ _ ⋆ (d_head_p ↦ _ && (d_head_p->d_next_p ↦ old_d_head_p))))
 void *InfrequentDeleteBlockList::allocate(int numBytes)
 {
     if (0 == numBytes) {

--- a/groups/bsl/bslma/bslma_mallocfreeallocator.cpp
+++ b/groups/bsl/bslma/bslma_mallocfreeallocator.cpp
@@ -41,6 +41,8 @@ static bsls::AtomicOperations::AtomicTypes::Pointer
 
 /// Construct a `bslma::MallocFreeAllocator` at the location specified by
 /// `p` in a thread-safe way.  Return `p`.
+// requires: p != 0
+// ensures: __out == &p->object()
 static inline
 bslma::MallocFreeAllocator *initSingleton(
                                         bslma_MallocFreeAllocator_Singleton *p)
@@ -84,6 +86,8 @@ namespace bslma {
                         // -------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 MallocFreeAllocator& MallocFreeAllocator::singleton()
 {
     // This initialization is not guaranteed to happen once, but repeated
@@ -103,6 +107,8 @@ MallocFreeAllocator& MallocFreeAllocator::singleton()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *MallocFreeAllocator::allocate(size_type size)
 {
     if (!size) {

--- a/groups/bsl/bslma/bslma_newdeleteallocator.cpp
+++ b/groups/bsl/bslma/bslma_newdeleteallocator.cpp
@@ -28,6 +28,8 @@ static bsls::AtomicOperations::AtomicTypes::Pointer
 
 /// Construct a `bslma::NewDeleteAllocator` at the specified `address` in a
 /// thread-safe way, and return `address`.
+// requires: address != 0
+// ensures: __out != 0 && (__out == &address->object())
 static inline
 bslma::NewDeleteAllocator *
 initSingleton(bslma_NewDeleteAllocator_Singleton *address)
@@ -71,6 +73,8 @@ namespace bslma {
                         // ------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 NewDeleteAllocator& NewDeleteAllocator::singleton()
 {
     // This initialization is not guaranteed to happen once, but repeated
@@ -95,6 +99,8 @@ NewDeleteAllocator::~NewDeleteAllocator()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *NewDeleteAllocator::allocate(size_type size)
 {
     return 0 == size ? 0 : ::operator new(size);

--- a/groups/bsl/bslma/bslma_sequentialpool.cpp
+++ b/groups/bsl/bslma/bslma_sequentialpool.cpp
@@ -191,6 +191,8 @@ SequentialPool::SequentialPool(
 }
 
 // MANIPULATORS
+// requires: (size == 0 ==> true) && (size != 0 ==> 0 < size)
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> (__out != 0 ⋆ __out ↦ _))
 void *SequentialPool::allocate(int size)
 {
     BSLS_ASSERT(0 <= size);

--- a/groups/bsl/bslma/bslma_testallocator.cpp
+++ b/groups/bsl/bslma/bslma_testallocator.cpp
@@ -106,6 +106,8 @@ const std::size_t k_MAX_ALIGNMENT = bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT;
 
 /// Return `true` if the specified `address` is aligned on the specified
 /// `alignment` or `false` otherwise.
+// requires: true
+// ensures: (__out == true ==> bsls::AlignmentUtil::calculateAlignmentOffset(address, int(alignment)) == 0) && (__out == false ==> bsls::AlignmentUtil::calculateAlignmentOffset(address, int(alignment)) != 0)
 inline bool isAligned(const void *address, std::size_t alignment)
 {
     return 0 == bsls::AlignmentUtil::calculateAlignmentOffset(address,
@@ -412,6 +414,8 @@ TestAllocator::~TestAllocator()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (size == 0 ==> __out == 0) && (size != 0 ==> __out != 0)
 void *TestAllocator::allocate(size_type size)
 {
     // All updates are protected by a mutex lock, so as to not interleave the
@@ -704,6 +708,8 @@ void TestAllocator::deallocate(void *address)
 }
 
 // PRIVATE ACCESSORS
+// requires: output != NULL && blockList != NULL
+// ensures: 0 < __out && __out < k_BLOCKID_LINE_SZ
 std::size_t
 TestAllocator::formatEightBlockIds(const TestAllocator_BlockHeader** blockList,
                                    char*                             output)

--- a/groups/bsl/bslmt/bslmt_configuration.cpp
+++ b/groups/bsl/bslmt/bslmt_configuration.cpp
@@ -68,6 +68,8 @@ static int nativeDefaultThreadStackSizeImp()
 }
 # endif
 #else // WIN32_THREADS
+// requires: true
+// ensures: (1 <= __out) && (__out <= INT_MAX)
 static int nativeDefaultThreadStackSizeImp()
     // Return the native thread stack size for Windows.
 {

--- a/groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp
+++ b/groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp
@@ -8,6 +8,8 @@ namespace BloombergLP {
 
 /// Interpreting `argument` as an `EntryPointFunctorAdapter_Base*`, invoke
 /// `argument->function(argument)`.  Do not use outside this component.
+// requires: argument != nullptr
+// ensures: __out == 0
 void *bslmt_EntryPointFunctorAdapter_invoker(void* argument)
 {
     bslmt::EntryPointFunctorAdapter_Base* threadArg =

--- a/groups/bsl/bslmt/bslmt_latch.cpp
+++ b/groups/bsl/bslmt/bslmt_latch.cpp
@@ -99,6 +99,8 @@ void Latch::wait()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == d_sigCount
 int Latch::currentCount() const
 {
     // Point 2: The following operation requires acquire semantics to ensure

--- a/groups/bsl/bslmt/bslmt_qlock.cpp
+++ b/groups/bsl/bslmt/bslmt_qlock.cpp
@@ -35,6 +35,8 @@ bsls::AtomicOperations::AtomicTypes::Pointer s_semaphoreKey = {0};
 /// Obtain an allocator object suitable for allocating memory for a thread
 /// local semaphore object which potentially outlives stateful allocators
 /// with static storage.
+// requires: true
+// ensures: __out == bslma::NewDeleteAllocator::singleton()
 inline
 bslma::Allocator& semaphoreAllocator()
 {
@@ -109,6 +111,8 @@ extern "C" void deleteThreadLocalSemaphore(void *semaphore)
 /// thread-safe: calling it multiple times simultaneously will result in the
 /// initialization of a single TLS key.  Note that the returned key can be
 /// used to access the thread-local semaphore for the current thread.
+// requires: true
+// ensures: (__out == key) || (__out == reinterpret_cast<TlsKey *>(oldKey))
 TlsKey *initializeSemaphoreTLSKey()
 {
     TlsKey *key = new (semaphoreAllocator()) TlsKey;
@@ -143,6 +147,8 @@ TlsKey *initializeSemaphoreTLSKey()
 /// Create and initialize a new key if one has not been previously been
 /// created.  This operation is thread-safe: calling it multiple times
 /// simultaneously will return the same address to an initialized key.
+// requires: true
+// ensures: __out != 0
 inline
 TlsKey *getSemaphoreTLSKey()
 {
@@ -157,6 +163,8 @@ TlsKey *getSemaphoreTLSKey()
 }
 
 /// Return the address of the semaphore unique to the calling thread.
+// requires: true
+// ensures: __out != 0 && (__out != 0 ==> true)
 SemaphorePtr getSemaphoreForCurrentThread()
 {
 #ifdef BSLMT_THREAD_LOCAL_VARIABLE

--- a/groups/bsl/bslmt/bslmt_sluice.cpp
+++ b/groups/bsl/bslmt/bslmt_sluice.cpp
@@ -90,6 +90,8 @@ bslmt::Sluice::~Sluice()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out != NULL
 const void *bslmt::Sluice::enter()
 {
     LockGuard<Mutex> lock(&d_mutex);

--- a/groups/bsl/bslmt/bslmt_testutil.cpp
+++ b/groups/bsl/bslmt/bslmt_testutil.cpp
@@ -18,6 +18,8 @@ namespace bslmt {
                                 // ---------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == ptr
 void *TestUtil::identityPtr(void *ptr)
 {
     return ptr;
@@ -28,6 +30,8 @@ void *TestUtil::identityPtr(void *ptr)
                              // --------------------
 
 /// Return a reference to the recursive mutex created by this singleton.
+// requires: true
+// ensures: &__out == mutex_p && (true ==> &__out == mutex_p)
 RecursiveMutex& TestUtil_Guard::singletonMutex()
 {
     static RecursiveMutex *mutex_p;

--- a/groups/bsl/bslmt/bslmt_threadattributes.cpp
+++ b/groups/bsl/bslmt/bslmt_threadattributes.cpp
@@ -56,6 +56,8 @@ bslmt::ThreadAttributes::ThreadAttributes(
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: d_detachedState ↦ rhs.d_detachedState ⋆ d_guardSize ↦ rhs.d_guardSize ⋆ d_inheritScheduleFlag ↦ rhs.d_inheritScheduleFlag ⋆ d_schedulingPolicy ↦ rhs.d_schedulingPolicy ⋆ d_schedulingPriority ↦ rhs.d_schedulingPriority ⋆ d_stackSize ↦ rhs.d_stackSize ⋆ d_threadName ↦ rhs.d_threadName
 bslmt::ThreadAttributes& bslmt::ThreadAttributes::operator=(
                                             const bslmt::ThreadAttributes& rhs)
 {
@@ -71,6 +73,8 @@ bslmt::ThreadAttributes& bslmt::ThreadAttributes::operator=(
 }
 
 // ACCESSORS
+// requires: stream ↦ _ && level >= 0 && spacesPerLevel >= 0
+// ensures: __out == stream && (__out ↦ _)
 bsl::ostream& bslmt::ThreadAttributes::print(
                                             bsl::ostream& stream,
                                             int           level,
@@ -92,6 +96,8 @@ bsl::ostream& bslmt::ThreadAttributes::print(
 }
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == (lhs.detachedState() == rhs.detachedState() && lhs.guardSize() == rhs.guardSize() && lhs.inheritSchedule() == rhs.inheritSchedule() && lhs.schedulingPolicy() == rhs.schedulingPolicy() && lhs.schedulingPriority() == rhs.schedulingPriority() && lhs.stackSize() == rhs.stackSize() && lhs.threadName() == rhs.threadName())
 bool bslmt::operator==(const ThreadAttributes& lhs,
                        const ThreadAttributes& rhs)
 {

--- a/groups/bsl/bslmt/bslmt_threadutil.cpp
+++ b/groups/bsl/bslmt/bslmt_threadutil.cpp
@@ -64,6 +64,8 @@ extern "C"
 /// thread, using information in the specified `arg`, which points to a
 /// `u::NamedFuncPtrRecord` that must be freed by this function.  The
 /// behavior is undefined if the thread name is empty.
+// requires: true
+// ensures: true
 void *bslmt_threadutil_namedFuncPtrThunk(void *arg)
 {
     u::NamedFuncPtrRecord *nfpr_p = static_cast<u::NamedFuncPtrRecord *>(arg);
@@ -92,6 +94,8 @@ void *bslmt_threadutil_namedFuncPtrThunk(void *arg)
                             // -----------------
 
 // CLASS METHODS
+// requires: ((int) policy >= ThreadAttributes::e_SCHED_MIN && (int) policy <= ThreadAttributes::e_SCHED_MAX) && (normalizedSchedulingPriority >= 0.0 && normalizedSchedulingPriority <= 1.0)
+// ensures: (minPri == ThreadAttributes::e_UNSET_PRIORITY || maxPri == ThreadAttributes::e_UNSET_PRIORITY) ==> __out == ThreadAttributes::e_UNSET_PRIORITY
 int bslmt::ThreadUtil::convertToSchedulingPriority(
                ThreadAttributes::SchedulingPolicy policy,
                double                             normalizedSchedulingPriority)

--- a/groups/bsl/bslmt/bslmt_throughputbenchmark.cpp
+++ b/groups/bsl/bslmt/bslmt_throughputbenchmark.cpp
@@ -29,6 +29,8 @@ namespace bslmt {
                         // -------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == s_antiOptimization
 unsigned int ThroughputBenchmark::antiOptimization()
 {
     return s_antiOptimization;
@@ -110,6 +112,8 @@ ThroughputBenchmark::ThroughputBenchmark(bslma::Allocator *basicAllocator)
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: true
 int ThroughputBenchmark::addThreadGroup(const RunFunction& runFunction,
                                         int                numThreads,
                                         bsls::Types::Int64 busyWorkAmount)

--- a/groups/bsl/bslmt/bslmt_turnstile.cpp
+++ b/groups/bsl/bslmt/bslmt_turnstile.cpp
@@ -18,6 +18,8 @@ enum { k_MICROSECS_PER_SECOND = 1000 * 1000 };
 /// Increase the value stored at the specified `timestamp` to the current time.
 /// If another thread has updated `timestamp`, this method might not modify the
 /// stored value.  Return the current value of the `timestamp`.
+// requires: timestamp != 0
+// ensures: (__out == *timestamp) && (*timestamp ↦ __out)
 static bsls::Types::Int64 updateTimestamp(bsls::AtomicInt64 *timestamp)
 {
     bsls::Types::Int64 nowUSec =
@@ -98,6 +100,8 @@ bsls::Types::Int64 bslmt::Turnstile::waitTurn(bool sleep)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == (nowUSecs - d_nextTurn > 0 ? nowUSecs - d_nextTurn : 0)
 bsls::Types::Int64 bslmt::Turnstile::lagTime() const
 {
     Int64 nowUSecs = updateTimestamp(&d_timestamp);

--- a/groups/bsl/bsls/bsls_alignment.cpp
+++ b/groups/bsl/bsls/bsls_alignment.cpp
@@ -16,6 +16,8 @@ namespace bsls {
                             // ----------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (value == Alignment::BSLS_MAXIMUM ==> __out == "MAXIMUM") && (value == Alignment::BSLS_NATURAL ==> __out == "NATURAL") && (value == Alignment::BSLS_BYTEALIGNED ==> __out == "BYTEALIGNED") && (value != Alignment::BSLS_MAXIMUM && value != Alignment::BSLS_NATURAL && value != Alignment::BSLS_BYTEALIGNED ==> __out == "(* UNKNOWN *)")
 const char *Alignment::toAscii(Alignment::Strategy value)
 {
 #define CASE(X) case(BSLS_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_asserttest.cpp
+++ b/groups/bsl/bsls/bsls_asserttest.cpp
@@ -132,6 +132,8 @@ ComponentName::ComponentName(const char *sourceFilename)
 }
 
 // ACCESSORS
+// requires: true
+// ensures: __out == (d_str_p == 0 && d_length == 0)
 bool ComponentName::isEmpty() const
 {
     return d_str_p == 0 && d_length == 0;
@@ -160,6 +162,8 @@ const char* ComponentName::str() const
 /// characters that compare equal.  Since the compare operation dereferences
 /// this type, and this type has two non-reference values (empty and error):
 /// The behavior is undefined if either `lhs` or `rhs` is empty or an error.
+// requires: true
+// ensures: (__out == (lhs.length() == rhs.length() && 0 == memcmp(lhs.str(), rhs.str(), lhs.length())))
 bool operator==(const ComponentName& lhs, const ComponentName& rhs)
 {
     return lhs.length() == rhs.length() &&
@@ -170,6 +174,8 @@ bool operator==(const ComponentName& lhs, const ComponentName& rhs)
 /// names are considered the same in testing:
 /// * If either of the names was missing, we assume they are the same.
 /// * If both component names are provided they must match, including case.
+// requires: true
+// ensures: __out == (testName.isEmpty() || throwName.isEmpty() || throwName == testName)
 static
 bool areTheSameComponent(const ComponentName& throwName,
                          const ComponentName& testName)

--- a/groups/bsl/bsls/bsls_blockgrowth.cpp
+++ b/groups/bsl/bsls/bsls_blockgrowth.cpp
@@ -13,6 +13,8 @@ namespace bsls {
                         // ------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (value == BlockGrowth::BSLS_GEOMETRIC ==> __out == "GEOMETRIC") && (value == BlockGrowth::BSLS_CONSTANT ==> __out == "CONSTANT") && (value != BlockGrowth::BSLS_GEOMETRIC && value != BlockGrowth::BSLS_CONSTANT ==> __out == "(* UNKNOWN *)")
 const char *BlockGrowth::toAscii(BlockGrowth::Strategy value)
 {
 #define CASE(X) case(BSLS_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_bslonce.cpp
+++ b/groups/bsl/bsls/bsls_bslonce.cpp
@@ -36,6 +36,8 @@ static void yield()
                         // -------------
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == true || __out == false
 bool BslOnce::doEnter()
 {
     int state = bsls::AtomicOperations::testAndSwapInt(&d_onceState,

--- a/groups/bsl/bsls/bsls_bslsourcenameparserutil.cpp
+++ b/groups/bsl/bsls/bsls_bslsourcenameparserutil.cpp
@@ -71,6 +71,8 @@ bool hasAtLeastCountChar(const char *       begin,
 /// right after it, or `end` if it is the last character.  If `ch` is not
 /// found return `begin`.  The behavior is undefined if `begin` is greater
 /// than `end`.
+// requires: begin <= end && SEPFORALL(0, end - begin, i, (begin + i ↦ _))
+// ensures: (__out == begin) || (__out != begin ==> SEPEXISTS(0, end - begin, i, (begin + i ↦ ch) && __out == (begin + i + 1)))
 static
 inline
 const char *onePastLastChr(const char *const begin, const char *end, char ch)
@@ -89,6 +91,8 @@ const char *onePastLastChr(const char *const begin, const char *end, char ch)
 
 /// Return `true` if the specified `tag` is a lowercase US alphabetic/letter
 /// character or return `false` if it is some other character.
+// requires: true
+// ensures: (__out == true ==> (tag >= 'a' && tag <= 'z')) && (__out == false ==> !(tag >= 'a' && tag <= 'z'))
 static
 inline
 bool isAlphaTag(char tag)
@@ -112,6 +116,8 @@ bool isAlphaTag(char tag)
 
 /// Return `true` if the specified `tag` is a valid test driver tag
 /// character from a source name (`t` or `g`).
+// requires: true
+// ensures: (__out == true ==> (tag == 't' || tag == 'g')) && (__out == false ==> (tag != 't' && tag != 'g'))
 static
 inline
 bool isTestDriverTag(char tag)
@@ -121,6 +127,8 @@ bool isTestDriverTag(char tag)
 
 /// Return `true` if the specified `sourceType` is a test driver type
 /// according to `SourceTypes`.
+// requires: true
+// ensures: (__out == true ==> (sourceType & BslSourceNameParserUtil::k_MASK_TEST) != 0) && (__out == false ==> (sourceType & BslSourceNameParserUtil::k_MASK_TEST) == 0)
 static
 inline
 bool isTestDriverType(unsigned sourceType)
@@ -131,6 +139,8 @@ bool isTestDriverType(unsigned sourceType)
 
 /// Return a pointer to the first character of the specified `filename`
 /// after the last path delimiter.
+// requires: filename != nullptr && EXISTS(0, strlen(filename), i, SEPEXISTS(0, sizeof(pathSeparators) - 1, j, filename[i] == pathSeparators[j]))
+// ensures: (__out == filename) || (FORALL(0, __out - filename, i, SEPEXISTS(0, sizeof(pathSeparators), j, filename + i == pathSeparators[j])))
 static
 const char *skipPath(const char *filename)
 {
@@ -157,6 +167,8 @@ namespace bsls {
                       //-------------------------------
 
 // CLASS METHODS
+// requires: componentNamePtr != NULL && componentNameLength != NULL && sourceName != NULL && type_p != NULL
+// ensures: (__out == 0) || (__out == -1) || (__out == -2) || (__out == -3)
 int BslSourceNameParserUtil::getComponentName(const char **componentNamePtr,
                                               size_t      *componentNameLength,
                                               const char  *sourceName,

--- a/groups/bsl/bsls/bsls_bsltestutil.cpp
+++ b/groups/bsl/bsls/bsls_bsltestutil.cpp
@@ -14,6 +14,8 @@ namespace bsls {
                            // ------------------
 
 // PRIVATE CLASS METHODS
+// requires: true
+// ensures: __out == ptr
 void *BslTestUtil::identityPtr(void *ptr)
 {
     return ptr;

--- a/groups/bsl/bsls/bsls_log.cpp
+++ b/groups/bsl/bsls/bsls_log.cpp
@@ -95,6 +95,8 @@ BufferScopedGuard::~BufferScopedGuard()
 }
 
 // MANIPULATORS
+// requires: numBytes >= 0
+// ensures: (__out == d_buffer_p) && ((numBytes == 0 ==> __out == 0) && (numBytes > 0 ==> (__out != 0 ⋆ SEPFORALL(0, numBytes, i, (__out + i) ↦ _))))
 char* BufferScopedGuard::allocate(size_t numBytes) {
 
     // Note that we don't want to use realloc, because it guarantees that the
@@ -125,6 +127,8 @@ char* BufferScopedGuard::allocate(size_t numBytes) {
 /// undefined unless `buffer` contains sufficient space to store `size`
 /// bytes and `format` is a valid `printf`-style format string with all
 /// expected substitutions present in `substitutions`.
+// requires: size > 0 && buffer != NULL && format != NULL
+// ensures: (size > 0 && buffer != NULL && format != NULL) ==> __out >= 0
 int vsnprintf_alwaysCount(char       *buffer,
                           size_t      size,
                           const char *format,

--- a/groups/bsl/bsls/bsls_logseverity.cpp
+++ b/groups/bsl/bsls/bsls_logseverity.cpp
@@ -14,6 +14,8 @@ namespace bsls {
                      // ------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (value == LogSeverity::e_FATAL ==> __out == "FATAL") && (value == LogSeverity::e_ERROR ==> __out == "ERROR") && (value == LogSeverity::e_WARN ==> __out == "WARN") && (value == LogSeverity::e_DEBUG ==> __out == "DEBUG") && (value == LogSeverity::e_INFO ==> __out == "INFO") && (value == LogSeverity::e_TRACE ==> __out == "TRACE") && (value != LogSeverity::e_FATAL && value != LogSeverity::e_ERROR && value != LogSeverity::e_WARN && value != LogSeverity::e_DEBUG && value != LogSeverity::e_INFO && value != LogSeverity::e_TRACE ==> __out == "(* UNKNOWN *)")
 const char *LogSeverity::toAscii(LogSeverity::Enum value)
 {
 #define CASE(X) case(e_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_nameof.cpp
+++ b/groups/bsl/bsls/bsls_nameof.cpp
@@ -85,6 +85,8 @@ namespace bsls {
 /// Initialize the specified `*buffer` with the type name contained in the
 /// specified `functionName`, where `functionName` is the function name of
 /// the `NameOf` constructor.
+// requires: buffer != nullptr && functionName != nullptr && std::strlen(functionName) > 0
+// ensures: (__out == functionName ==> std::strncmp(uselessPreamble, functionName, k_USELESS_PREAMBLE_LEN) != 0) && (__out == buffer ==> std::strncmp(uselessPreamble, functionName, k_USELESS_PREAMBLE_LEN) == 0)
 const char *NameOf_Base::initBuffer(char       *buffer,
                                     const char *functionName)
 {

--- a/groups/bsl/bsls/bsls_outputredirector.cpp
+++ b/groups/bsl/bsls/bsls_outputredirector.cpp
@@ -405,6 +405,8 @@ void OutputRedirector::clear()
 }
 
 // ACCESSORS
+// requires: expected != 0
+// ensures: __out == compare(expected, strlen(expected))
 int OutputRedirector::compare(const char *expected) const
 {
     BSLS_ASSERT(expected);

--- a/groups/bsl/bsls/bsls_stackaddressutil.cpp
+++ b/groups/bsl/bsls/bsls_stackaddressutil.cpp
@@ -290,6 +290,8 @@ namespace {
 /// undefined unless `tag` is a non-empty null-terminated string.  Return
 /// `0` if the `plink_timestamp___` global variable does not contain the
 /// `tag` or is not well formed.
+// requires: tag != NULL && strlen(tag) > 0
+// ensures: __out == 0 || *__out != '\0'
 const char *getPwhatVar(const char *const tag)
 {
     // This is a modified version of 'sysutil_pwhat_getvar', adjusted to not

--- a/groups/bsl/bsls/bsls_systemclocktype.cpp
+++ b/groups/bsl/bsls/bsls_systemclocktype.cpp
@@ -14,6 +14,8 @@ namespace bsls {
                      // ----------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out != 0 && ((value == SystemClockType::Enum::e_REALTIME ==> __out == "REALTIME") || (value == SystemClockType::Enum::e_MONOTONIC ==> __out == "MONOTONIC") || (value != SystemClockType::Enum::e_REALTIME && value != SystemClockType::Enum::e_MONOTONIC ==> __out == "(* UNKNOWN *)"))
 const char *SystemClockType::toAscii(SystemClockType::Enum value)
 {
 #define CASE(X) case(e_ ## X): return #X;

--- a/groups/bsl/bsls/bsls_systemtime.cpp
+++ b/groups/bsl/bsls/bsls_systemtime.cpp
@@ -107,6 +107,8 @@ TimeInterval SystemTime::nowMonotonicClock()
                             //- - - - - - - - - - - -
 
 /// Return the current time for the specified `clockId`.
+// requires: true
+// ensures: true
 static inline
 TimeInterval getNowTime(clockid_t clockId)
 {
@@ -121,6 +123,8 @@ TimeInterval getNowTime(clockid_t clockId)
 
 
 // CLASS METHODS
+// requires: true
+// ensures: true
 TimeInterval SystemTime::nowMonotonicClock()
 {
     return getNowTime(

--- a/groups/bsl/bsls/bsls_timeinterval.cpp
+++ b/groups/bsl/bsls/bsls_timeinterval.cpp
@@ -81,6 +81,8 @@ TimeInterval::TimeInterval(double seconds)
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this
 TimeInterval& TimeInterval::addInterval(bsls::Types::Int64 seconds,
                                         int                nanoseconds)
 {

--- a/groups/bsl/bslstl/bslstl_error.cpp
+++ b/groups/bsl/bslstl/bslstl_error.cpp
@@ -37,6 +37,8 @@ class generic_category_impl : public error_category {
                         // ---------------------------
 
 // ACCESSORS
+// requires: true
+// ensures: __out == error_category::message(value)
 std::string generic_category_impl::message(int value) const
 {
     return error_category::message(value);
@@ -50,6 +52,8 @@ const char *generic_category_impl::name() const BSLS_KEYWORD_NOEXCEPT
 }  // close unnamed namespace
 
 // FREE FUNCTIONS
+// requires: true
+// ensures: true
 const error_category& generic_category()
 {
     static generic_category_impl generic_category_object;
@@ -74,6 +78,8 @@ class system_category_impl : public error_category {
 };
 
 // ACCESSORS
+// requires: true
+// ensures: __out == error_category::message(value)
 std::string system_category_impl::message(int value) const
 {
     return error_category::message(value);
@@ -87,6 +93,8 @@ const char *system_category_impl::name() const BSLS_KEYWORD_NOEXCEPT
 }  // close unnamed namespace
 
 // FREE FUNCTIONS
+// requires: true
+// ensures: true
 const error_category& system_category()
 {
     static system_category_impl system_category_object;

--- a/groups/bsl/bslstl/bslstl_sharedptr.cpp
+++ b/groups/bsl/bslstl/bslstl_sharedptr.cpp
@@ -21,6 +21,8 @@ namespace bslstl {
                              // -------------------
 
 // MANIPULATORS
+// requires: bufferSize > 0 && basicAllocator != nullptr
+// ensures: __out != nullptr && (__out.get() ↦ _ ⋆ SEPFORALL(0, bufferSize, i, (__out.get() + i) ↦ _))
 bsl::shared_ptr<char>
 SharedPtrUtil::createInplaceUninitializedBuffer(
                                               size_t            bufferSize,

--- a/groups/bsl/bslstl/bslstl_stopstate.cpp
+++ b/groups/bsl/bslstl/bslstl_stopstate.cpp
@@ -25,6 +25,8 @@ namespace {
 
 /// Return the thread ID of the calling thread.  We cannot depend on
 /// `bslmt_threadutil`, so we reimplement this functionality.
+// requires: true
+// ensures: __out != 0
 unsigned long long currentThreadId()
 {
 #if defined(BSLS_PLATFORM_OS_WINDOWS)
@@ -138,6 +140,8 @@ bool StopState::requestStop()
 }
 
 // ACCESSORS
+// requires: true
+// ensures: true
 bool StopState::stopRequested() const
 {
     return d_stopRequested.loadAcquire();

--- a/groups/bsl/bsltf/bsltf_allocemplacabletesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_allocemplacabletesttype.cpp
@@ -446,6 +446,8 @@ AllocEmplacableTestType::~AllocEmplacableTestType()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == s_numDeletes
 int AllocEmplacableTestType::getNumDeletes()
 {
     return s_numDeletes;

--- a/groups/bsl/bsltf/bsltf_alloctesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_alloctesttype.cpp
@@ -62,6 +62,8 @@ AllocTestType::~AllocTestType()
 }
 
 // MANIPULATORS
+// requires: rhs.d_data_p ↦ _
+// ensures: (__out == *this) && (d_data_p ↦ *rhs.d_data_p)
 AllocTestType& AllocTestType::operator=(const AllocTestType& rhs)
 {
     if (&rhs != this)

--- a/groups/bsl/bsltf/bsltf_copymovestate.cpp
+++ b/groups/bsl/bsltf/bsltf_copymovestate.cpp
@@ -14,6 +14,8 @@ namespace bsltf {
                      // --------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: __out != 0
 const char *CopyMoveState::toAscii(CopyMoveState::Enum value)
 {
 #define CASE(X) case int(e_ ## X): return #X

--- a/groups/bsl/bsltf/bsltf_emplacabletesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_emplacabletesttype.cpp
@@ -15,6 +15,8 @@ namespace bsltf {
 int EmplacableTestType::s_numDeletes = 0;
 
 // CLASS METHODS
+// requires: true
+// ensures: __out == s_numDeletes
 int EmplacableTestType::getNumDeletes()
 {
     return s_numDeletes;
@@ -300,6 +302,8 @@ EmplacableTestType::~EmplacableTestType()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: __out == *this ⋆ d_arg01 ↦ rhs.d_arg01 ⋆ d_arg02 ↦ rhs.d_arg02 ⋆ d_arg03 ↦ rhs.d_arg03 ⋆ d_arg04 ↦ rhs.d_arg04 ⋆ d_arg05 ↦ rhs.d_arg05 ⋆ d_arg06 ↦ rhs.d_arg06 ⋆ d_arg07 ↦ rhs.d_arg07 ⋆ d_arg08 ↦ rhs.d_arg08 ⋆ d_arg09 ↦ rhs.d_arg09 ⋆ d_arg10 ↦ rhs.d_arg10 ⋆ d_arg11 ↦ rhs.d_arg11 ⋆ d_arg12 ↦ rhs.d_arg12 ⋆ d_arg13 ↦ rhs.d_arg13 ⋆ d_arg14 ↦ rhs.d_arg14
 EmplacableTestType& EmplacableTestType::operator=(
                                                  const EmplacableTestType& rhs)
 {

--- a/groups/bsl/bsltf/bsltf_movestate.cpp
+++ b/groups/bsl/bsltf/bsltf_movestate.cpp
@@ -12,6 +12,8 @@ namespace bsltf {
                      // ----------------
 
 // CLASS METHODS
+// requires: (value == MoveState::e_NOT_MOVED) || (value == MoveState::e_MOVED) || (value == MoveState::e_UNKNOWN)
+// ensures: (value == MoveState::e_NOT_MOVED ==> __out == "NOT_MOVED") && (value == MoveState::e_MOVED ==> __out == "MOVED") && (value == MoveState::e_UNKNOWN ==> __out == "UNKNOWN") && (value != MoveState::e_NOT_MOVED && value != MoveState::e_MOVED && value != MoveState::e_UNKNOWN ==> __out == "(* UNKNOWN *)")
 const char *MoveState::toAscii(MoveState::Enum value)
 {
 #define CASE(X) case(e_ ## X): return #X;

--- a/groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.cpp
+++ b/groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.cpp
@@ -64,6 +64,8 @@ NonOptionalAllocTestType::~NonOptionalAllocTestType()
 }
 
 // MANIPULATORS
+// requires: (rhs.d_data_p ↦ _) && (d_data_p ↦ _)
+// ensures: (__out == *this) && ((&rhs != this) ==> (d_data_p ↦ *rhs.d_data_p))
 NonOptionalAllocTestType& NonOptionalAllocTestType::operator=(
                                            const NonOptionalAllocTestType& rhs)
 {

--- a/groups/bsl/bsltf/bsltf_stdtestallocator.cpp
+++ b/groups/bsl/bsltf/bsltf_stdtestallocator.cpp
@@ -29,6 +29,8 @@ namespace bsltf {
                         // -----------------------------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (s_StdTestAllocatorConfiguration_allocator_p != 0 ==> __out == s_StdTestAllocatorConfiguration_allocator_p) && (s_StdTestAllocatorConfiguration_allocator_p == 0 ==> __out == &bslma::NewDeleteAllocator::singleton())
 bslma::Allocator* StdTestAllocatorConfiguration::delegateAllocator()
 {
     return s_StdTestAllocatorConfiguration_allocator_p

--- a/groups/bsl/bslx/bslx_byteinstream.cpp
+++ b/groups/bsl/bslx/bslx_byteinstream.cpp
@@ -18,6 +18,8 @@ namespace bslx {
                         // ------------------
 
 // FREE OPERATORS
+// requires: object.length() >= 0 && stream.good()
+// ensures: __out == stream && stream.flags() == old_flags
 bsl::ostream& operator<<(bsl::ostream& stream, const ByteInStream& object)
 {
     const bsl::size_t   len   = object.length();

--- a/groups/bsl/bslx/bslx_byteoutstream.cpp
+++ b/groups/bsl/bslx/bslx_byteoutstream.cpp
@@ -58,6 +58,8 @@ ByteOutStream& ByteOutStream::putString(const bsl::string& value)
 }
 
 // FREE OPERATORS
+// requires: stream.good()
+// ensures: (__out == stream) && (stream.flags() == old_flags)
 bsl::ostream& operator<<(bsl::ostream& stream, const ByteOutStream& object)
 {
     const int           len   = static_cast<int>(object.d_buffer.size());

--- a/groups/bsl/bslx/bslx_testinstream.cpp
+++ b/groups/bsl/bslx/bslx_testinstream.cpp
@@ -132,6 +132,8 @@ TestInStream::~TestInStream()
 }
 
 // MANIPULATORS
+// requires: true
+// ensures: (__out == *this) && (isValid() ==> variable >= 0)
 TestInStream& TestInStream::getLength(int& variable)
 {
     if (length() - cursor() < k_SIZEOF_CODE + Util::k_SIZEOF_INT8) {
@@ -843,6 +845,8 @@ TestInStream& TestInStream::getArrayFloat32(float *variables, int numVariables)
 }
 
 // FREE OPERATORS
+// requires: (object.length() >= 0) && SEPFORALL(0, object.length(), i, (object.data() + i ↦ _))
+// ensures: __out == stream && (stream.flags() == old_stream.flags())
 bsl::ostream& operator<<(bsl::ostream& stream, const TestInStream& object)
 {
     const bsl::size_t   len   = object.length();

--- a/groups/bsl/bslx/bslx_testoutstream.cpp
+++ b/groups/bsl/bslx/bslx_testoutstream.cpp
@@ -39,6 +39,8 @@ TestOutStream::~TestOutStream()
 }
 
 // MANIPULATORS
+// requires: 0 <= length
+// ensures: &__out == this
 TestOutStream& TestOutStream::putLength(int length)
 {
     BSLS_ASSERT(0 <= length);
@@ -833,6 +835,8 @@ TestOutStream& TestOutStream::putArrayFloat32(const float *values,
 }
 
 // FREE OPERATORS
+// requires: true
+// ensures: __out == stream
 bsl::ostream& operator<<(bsl::ostream& stream, const TestOutStream& object)
 {
     return stream << object.d_imp;

--- a/groups/bsl/bslx/bslx_typecode.cpp
+++ b/groups/bsl/bslx/bslx_typecode.cpp
@@ -16,6 +16,8 @@ namespace bslx {
                      // ---------------
 
 // CLASS METHODS
+// requires: true
+// ensures: (stream.bad() ==> __out == stream) && (!stream.bad() ==> (__out == (stream << TypeCode::toAscii(value) << bsl::flush)))
 bsl::ostream& TypeCode::print(bsl::ostream&  stream,
                               TypeCode::Enum value,
                               int            level,


### PR DESCRIPTION
This is autogenerated specifications for the given function

---
### Preconditions found
- **groups/bal/balb/balb_pipetaskmanager.cpp**
  - `controlManager != 0 && basicAllocator != 0`
- **groups/bal/balb/balb_ratelimiter.cpp**
  - `limit > 0 && window > bsls::TimeInterval()`
- **groups/bal/balber/balber_berdecoderoptions.cpp**
  - `(nameLength == 8 || nameLength == 10 || nameLength == 15 || nameLength == 19) && SEPFORALL(0, nameLength, i, (name + i) ↦ _)`
- **groups/bal/balcl/balcl_commandline.cpp**
  - `SEPFORALL(0, options.size(), i, (options[i].val ↦ _))`
  - `specTable != 0 && length >= 0`
- **groups/bal/balcl/balcl_optiontype.cpp**
  - `stream ↦ _`
- **groups/bal/balcl/balcl_typeinfo.cpp**
  - `value != NULL`
- **groups/bal/baljsn/baljsn_datumutil.cpp**
  - `formatter != nullptr && strictTypesCheckStatus != nullptr`
  - `result != nullptr && jsonBuffer != nullptr`
  - `result != nullptr && tokenizer != nullptr`
  - `result != nullptr && tokenizer != nullptr && maxNestedDepth >= 0`
- **groups/bal/baljsn/baljsn_encoder_testtypes.cpp**
  - `(number == EncoderTestChoiceWithAllCategoriesEnumeration::A) || (number == EncoderTestChoiceWithAllCategoriesEnumeration::B)`
  - `(value == EncoderTestChoiceWithAllCategoriesEnumeration::A) || (value == EncoderTestChoiceWithAllCategoriesEnumeration::B)`
  - `(value == EncoderTestSequenceWithAllCategoriesEnumeration::A) || (value == EncoderTestSequenceWithAllCategoriesEnumeration::B)`
  - `name != nullptr && nameLength >= 0 && (nameLength == 0 || (name[nameLength - 1] == '\0' && FORALL(0, nameLength - 1, i, name[i] != '\0')))`
  - `name != nullptr && nameLength >= 0 && FORALL(0, nameLength, i, name[i] != 0) && name[nameLength] == 0`
  - `name != nullptr && nameLength >= 0 && name[nameLength - 1] == '\0'`
  - `result != 0 && (number == EncoderTestSequenceWithAllCategoriesEnumeration::A || number == EncoderTestSequenceWithAllCategoriesEnumeration::B)`
  - `result != 0 && string != 0 && stringLength >= 0`
- **groups/bal/baljsn/baljsn_parserutil.cpp**
  - `value != 0 && data.size() >= 0`
- **groups/bal/ball/ball_administration.cpp**
  - `categoryName != NULL`
- **groups/bal/ball/ball_attribute.cpp**
  - `size > 0`
  - `stream ↦ _`
- **groups/bal/ball/ball_attributecontext.cpp**
  - `category != 0`
  - `stream ↦ _`
- **groups/bal/ball/ball_category.cpp**
  - `Category::areValidThresholdLevels(recordLevel, passLevel, triggerLevel, triggerAllLevel)`
- **groups/bal/ball/ball_categorymanager.cpp**
  - `categoryName != nullptr`
- **groups/bal/ball/ball_context.cpp**
  - `stream ↦ _`
- **groups/bal/ball/ball_defaultattributecontainer.cpp**
  - `(lhs.numAttributes() != rhs.numAttributes()) || (lhs.numAttributes() == rhs.numAttributes() && FORALL(lhs.begin(), lhs.end(), iter, rhs.hasValue(*iter)))`
- **groups/bal/ball/ball_fileobserver2.cpp**
  - `0 < interval.totalMilliseconds()`
  - `0 <= interval.totalMilliseconds()`
  - `logFilePattern != nullptr`
  - `stream != NULL && filename != NULL`
- **groups/bal/ball/ball_loggercategoryutil.cpp**
  - `loggerManager != 0 && categoryName != 0 && !(loggerManager->lookupCategory(categoryName))`
- **groups/bal/ball/ball_loggermanager.cpp**
  - `filteredNameBuffer != NULL && originalName != NULL`
- **groups/bal/ball/ball_managedattributeset.cpp**
  - `0 < size`
  - `FORALL(0, containerList.size(), i, containerList.hasValue(containerList[i].attribute()))`
- **groups/bal/ball/ball_recordjsonformatter.cpp**
  - `SEPEXISTS(0, 9, i, v == DatumParser::k_KEY_TIMESTAMP + i)`
  - `format.empty() ==> res_tmp == -1 && !format.empty() ==> res_tmp >= 0`
- **groups/bal/ball/ball_rule.cpp**
  - `0 < size`
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bal/ball/ball_ruleset.cpp**
  - `d_ruleHashtable.find(value) != d_ruleHashtable.end()`
  - `lhs.numRules() >= 0 && rhs.numRules() >= 0 && lhs.maxNumRules() >= lhs.numRules() && rhs.maxNumRules() >= rhs.numRules()`
- **groups/bal/ball/ball_scopedattribute.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bal/ball/ball_severity.cpp**
  - `level != nullptr && string != nullptr`
- **groups/bal/ball/ball_severityutil.cpp**
  - `level != NULL && name != NULL`
- **groups/bal/ball/ball_thresholdaggregate.cpp**
  - `size > 0`
- **groups/bal/ball/ball_userfields.cpp**
  - `!stream.bad()`
- **groups/bal/ball/ball_userfieldtype.cpp**
  - `stream ↦ _`
- **groups/bal/balm/balm_configurationutil.cpp**
  - `manager == 0 ==> res_tmp == -1 ⋆ manager != 0 ==> res_tmp == 0`
- **groups/bal/balm/balm_metricformat.cpp**
  - `stream ↦ _`
- **groups/bal/balm/balm_metricregistry.cpp**
  - `SEPFORALL(0, strlen(candidatePrefix), i, (candidatePrefix + i ↦ _ ⋆ string + i ↦ _)) ⋆ (candidatePrefix + strlen(candidatePrefix) ↦ 0 ⋆ string + strlen(string) ↦ 0)`
- **groups/bal/balm/balm_metricsample.cpp**
  - `stream ↦ _ ⋆ level >= 0 ⋆ spacesPerLevel >= 0`
- **groups/bal/balm/balm_publicationscheduler.cpp**
  - `SEPFORALL(0, categories.size(), i, (*std::next(categories.begin(), i))->name() ↦ _)`
  - `result != 0 && category != 0`
- **groups/bal/balst/balst_stacktraceframe.cpp**
  - `!stream.bad()`
- **groups/bal/balst/balst_stacktraceprintutil.cpp**
  - `(0 <= maxFrames || maxFrames == -1) && (0 <= additionalIgnoreFrames) && (&stream != 0)`
- **groups/bal/balst/balst_stacktracetestallocator.cpp**
  - `blockHdr != 0 && blockHdr->d_magic ↦ _ && blockHdr->d_allocator_p ↦ _ && blockHdr->d_prevNext_p ↦ _ && (blockHdr->d_next_p == 0 || blockHdr->d_next_p->d_magic ↦ _)`
  - `size >= 0`
  - `specifiedMaxRecordedFrames >= 0`
- **groups/bal/balst/balst_stacktraceutil.cpp**
  - `pathName != nullptr && EXISTS(0, bsl::strlen(pathName) + 1, i, pathName[i] == '\0')`
- **groups/bal/baltzo/baltzo_datafileloader.cpp**
  - `path != 0`
  - `result != 0 && timeZoneId != 0`
  - `result == nullptr || (result ↦ _)`
  - `timeZoneId != nullptr && SEPFORALL(0, strlen(timeZoneId), i, timeZoneId[i] ↦ _)`
- **groups/bal/baltzo/baltzo_localdatetime.cpp**
  - `!stream.bad()`
- **groups/bal/baltzo/baltzo_localtimeoffsetutil.cpp**
  - `timezone != NULL`
- **groups/bal/baltzo/baltzo_localtimeperiod.cpp**
  - `stream.good()`
- **groups/bal/baltzo/baltzo_localtimevalidity.cpp**
  - `stream ↦ _ ⋆ SEPFORALL(0, toAscii(value).size(), i, (stream + i) ↦ _)`
- **groups/bal/baltzo/baltzo_timezoneutil.cpp**
  - `result != 0`
- **groups/bal/baltzo/baltzo_timezoneutilimp.cpp**
  - `result != 0 && resultTimeZoneId != 0 && cache != 0`
  - `start >= timeZone.beginTransitions() && start < timeZone.endTransitions()`
  - `timeZone != 0 && timeZoneId != 0 && cache != 0`
- **groups/bal/baltzo/baltzo_windowstimezoneutil.cpp**
  - `result != 0 && windowsTimeZoneId != 0`
- **groups/bal/baltzo/baltzo_zoneinfo.cpp**
  - `!stream.bad() && (stream ↦ _)`
  - `stream != nullptr`
- **groups/bal/baltzo/baltzo_zoneinfobinaryreader.cpp**
  - `address != 0 && SEPFORALL(0, 4, i, address + i ↦ _)`
  - `buffer != 0 && length >= 0 && SEPFORALL(0, length, i, (buffer + i) ↦ _)`
  - `result != nullptr && stream.good()`
  - `stream.good() && headerResult != nullptr && zoneinfoResult != nullptr && (mode == k_READ_NORMALIZED || mode == k_READ_UNNORMALIZED)`
  - `zoneinfoResult ↦ _ && stream.good()`
- **groups/bal/baltzo/baltzo_zoneinfocache.cpp**
  - `rc != 0 && timeZoneId != 0`
  - `timeZoneId != 0) && (d_cache.find(timeZoneId) != d_cache.end() ==> EXISTS(d_cache.find(timeZoneId), d_cache.find(timeZoneId) + 1, it, it->second != 0)`
- **groups/bal/balxml/balxml_formatter_prettyimpl.cpp**
  - `state != nullptr`
- **groups/bal/balxml/balxml_minireader.cpp**
  - `(error >= ErrorInfo::e_ERROR ==> res_tmp == -1) && (error < ErrorInfo::e_ERROR ==> res_tmp == 0)`
  - `val >= 0x0000U && val <= 0x10FFFFU`
- **groups/bal/balxml/balxml_namespaceregistry.cpp**
  - `(EXISTS(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri == predefinedNamespaces[i]) ==> true) && (FORALL(0, ARRAY_LEN(predefinedNamespaces), i, namespaceUri != predefinedNamespaces[i]) ==> true)`
- **groups/bal/balxml/balxml_typesparserutil.cpp**
  - `(inputLength == 1 || inputLength == 4 || inputLength == 5) && result != 0`
  - `input != 0 && inputLength >= 0 && result != 0`
  - `input != 0 && result != 0 && inputLength >= 0 && SEPFORALL(0, inputLength, i, (input + i) ↦ _)`
  - `inputLength >= 0`
  - `result != 0 && input != 0 && SEPFORALL(0, strlen(input) + 1, i, input + i ↦ _)`
  - `result != nullptr && input != nullptr`
- **groups/bal/balxml/balxml_typesprintutil.cpp**
  - `(dataLength >= 0 && SEPFORALL(0, dataLength, i, (data + i ↦ _))) && (options == 0 || options != 0)`
  - `stream && maxTotalDigits >= 2 && maxTotalDigits <= 326 && maxFractionDigits >= 1 && maxFractionDigits <= 17 && maxFractionDigits <= maxTotalDigits - 1`
- **groups/bal/balxml/balxml_utf8readerwrapper.cpp**
  - `url != nullptr && encoding != nullptr`
- **groups/bbl/bblb/bblb_schedulegenerationutil.cpp**
  - `1 <= year && 9999 >= year && 1 <= month && 12 >= month && bdlt::Date::isValidYearMonthDay(year, month, bsl::min(bdlt::SerialDateImpUtil::lastDayOfMonth(year, month), (dayOfFeb == 0 || month != 2) ? day : dayOfFeb))`
  - `denominator > 0`
  - `u::k_MIN_SERIAL_MONTH <= exampleSerialMonth && exampleSerialMonth <= u::k_MAX_SERIAL_MONTH && earliestSerialMonth <= latestSerialMonth && startSerialMonth != nullptr && endSerialMonth != nullptr`
- **groups/bbl/bbldc/bbldc_basicdaycountutil.cpp**
  - `convention == DayCountConvention::e_ACTUAL_360 || convention == DayCountConvention::e_ACTUAL_365_25 || convention == DayCountConvention::e_ACTUAL_365_FIXED || convention == DayCountConvention::e_ISDA_1_1 || convention == DayCountConvention::e_ISDA_30_360_EOM || convention == DayCountConvention::e_ISDA_ACTUAL_ACTUAL || convention == DayCountConvention::e_ISMA_30_360 || convention == DayCountConvention::e_NL_365 || convention == DayCountConvention::e_PSA_30_360_EOM || convention == DayCountConvention::e_SIA_30_360_EOM || convention == DayCountConvention::e_SIA_30_360_NEOM`
- **groups/bbl/bbldc/bbldc_basicisdaactualactual.cpp**
  - `beginDate <= endDate`
- **groups/bbl/bbldc/bbldc_basicpsa30360eom.cpp**
  - `bdlt::Date::isValidYearMonthDay(year, month, day)`
- **groups/bbl/bbldc/bbldc_basicsia30360eom.cpp**
  - `bdlt::Date::isValidYearMonthDay(year, month, day)`
- **groups/bbl/bbldc/bbldc_calendardaycountutil.cpp**
  - `calendar.isInRange(beginDate) && calendar.isInRange(endDate)`
- **groups/bbl/bbldc/bbldc_daycountconvention.cpp**
  - `stream.good() && EXISTS(0, DayCountConvention::Enum_MAX, val, value == val)`
- **groups/bbl/bbldc/bbldc_periodicmaactualactual.cpp**
  - `2 <= (periodDateEnd - periodDateBegin) && *periodDateBegin <= beginDate && beginDate <= *(periodDateEnd - 1) && *periodDateBegin <= endDate && endDate <= *(periodDateEnd - 1)`
- **groups/bdl/bdlb/bdlb_bigendian.cpp**
  - `!stream.bad()`
  - `!stream.bad() && (level >= 0) && (spacesPerLevel >= 0)`
  - `stream.bad() == false`
- **groups/bdl/bdlb/bdlb_bitstringutil.cpp**
  - `(0 <= numBits) && (numBits < 64)`
  - `(lhs.d_lo < rhs.d_lo) ==> (lhs.d_hi <= rhs.d_hi)`
  - `numBits + pos1 <= k_BITS_PER_UINT64 && numBits + pos2 <= k_BITS_PER_UINT64`
  - `spacesPerLevel >= 0`
- **groups/bdl/bdlb/bdlb_caselessstringviewhash.cpp**
  - `argument.data() != nullptr && argument.length() >= 0`
- **groups/bdl/bdlb/bdlb_doublecompareutil.cpp**
  - `bdlb::Float::isFinite(relTol) && bdlb::Float::signBit(relTol) == false && bdlb::Float::isFinite(absTol) && bdlb::Float::signBit(absTol) == false && (a == a) && (b == b)`
- **groups/bdl/bdlb/bdlb_guid.cpp**
  - `0 <= x && x <= 15`
- **groups/bdl/bdlb/bdlb_hashutil.cpp**
  - `0 <= length && (length == 0 || data != nullptr)`
- **groups/bdl/bdlb/bdlb_numericparseutil.cpp**
  - `!positiveNum.empty()`
  - `(('0' <= character && character <= '9') || ('a' <= character && character <= 'z') || ('A' <= character && character <= 'Z')) && (2 <= base && base <= 36)`
  - `stdlibInput.size() >= 2`
- **groups/bdl/bdlb/bdlb_randomdevice.cpp**
  - `(numBytes == 0) || (buffer != NULL)`
- **groups/bdl/bdlb/bdlb_string.cpp**
  - `lhsString != nullptr && rhsString != nullptr && SEPFORALL(0, strlen(lhsString), i, (lhsString + i ↦ _)) ⋆ SEPFORALL(0, strlen(rhsString), i, (rhsString + i ↦ _))`
- **groups/bdl/bdlbb/bdlbb_blob.cpp**
  - `stream ↦ _`
- **groups/bdl/bdlbb/bdlbb_blobutil.cpp**
  - `0 <= bufferIndex && 0 <= numBytes && bufferIndex < source.numDataBuffers()`
- **groups/bdl/bdlc/bdlc_bitarray.cpp**
  - `0 <= numBits && numBits < BitArray::k_BITS_PER_UINT64`
- **groups/bdl/bdlc/bdlc_hashtable.cpp**
  - `hint != 0`
- **groups/bdl/bdlc/bdlc_indexclerk.cpp**
  - `(unsigned int)index < (unsigned int)d_nextNewIndex`
  - `FORALL(0, unusedStack.size(), i, (unsigned int) unusedStack[i] < (unsigned int) nextNewIndex`
- **groups/bdl/bdld/bdld_datum.cpp**
  - `!stream.bad()`
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
  - `stream.good()`
- **groups/bdl/bdld/bdld_datumarraybuilder.cpp**
  - `length < (bsl::numeric_limits<DatumArrayBuilder::SizeType>::max() / 2)`
- **groups/bdl/bdld/bdld_datumbinaryref.cpp**
  - `stream.good()`
- **groups/bdl/bdld/bdld_datumerror.cpp**
  - `(stream ↦ _) && !stream.bad()`
- **groups/bdl/bdld/bdld_datumintmapbuilder.cpp**
  - `size >= 0 && size < bsl::numeric_limits<DatumIntMapBuilder::SizeType>::max() / 2`
- **groups/bdl/bdld/bdld_datummaker.cpp**
  - `size >= 0 && elements != NULL`
- **groups/bdl/bdld/bdld_datummapbuilder.cpp**
  - `(capacity == 0 ==> size < (bsl::numeric_limits<DatumMapBuilder::SizeType>::max() / 2)) && (capacity != 0 ==> (capacity >= 1 && size < (bsl::numeric_limits<DatumMapBuilder::SizeType>::max() / 2)))`
- **groups/bdl/bdld/bdld_datummapowningkeysbuilder.cpp**
  - `size >= 0`
- **groups/bdl/bdld/bdld_datumudt.cpp**
  - `!stream.bad()`
- **groups/bdl/bdlde/bdlde_base64alphabet.cpp**
  - `(stream.bad() ==> true) && (!stream.bad() ==> (stream ↦ _)) && (level >= 0) && (spacesPerLevel >= 0)`
  - `stream.good()`
- **groups/bdl/bdlde/bdlde_base64decoderoptions.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bdl/bdlde/bdlde_base64encoderoptions.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bdl/bdlde/bdlde_byteorder.cpp**
  - `stream ↦ _ && !stream.bad()`
- **groups/bdl/bdlde/bdlde_charconvertstatus.cpp**
  - `(stream.bad() ==> true) && (!stream.bad() ==> (stream ↦ _))`
- **groups/bdl/bdlde/bdlde_charconvertutf32.cpp**
  - `SEPFORALL(0, 3, i, octBuf + i ↦ _)`
  - `SEPFORALL(0, 4, i, octBuf + i ↦ _)`
  - `n >= 0`
  - `oct >= 0 && oct <= 255`
  - `octBuf ↦ _ ⋆ (octBuf + 1) ↦ _`
  - `position != NULL`
  - `position <= d_end`
  - `position ↦ _`
  - `ptr != nullptr`
- **groups/bdl/bdlde/bdlde_crc32c.cpp**
  - `length == 0 || data != NULL`
- **groups/bdl/bdlde/bdlde_hexdecoder.cpp**
  - `(d_state == e_ERROR_STATE || d_firstDigit) ==> res_tmp == -1 && (!d_firstDigit) ==> res_tmp == 0`
- **groups/bdl/bdlde/bdlde_quotedprintabledecoder.cpp**
  - `out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL`
- **groups/bdl/bdlde/bdlde_quotedprintableencoder.cpp**
  - `out != NULL && numOut != NULL && numIn != NULL && begin != NULL && end != NULL`
- **groups/bdl/bdlde/bdlde_sha2.cpp**
  - `lhs.d_bufferSize >= 0 && rhs.d_bufferSize >= 0 && SEPFORALL(0, lhs.d_bufferSize, i, lhs.d_buffer + i ↦ _) && SEPFORALL(0, rhs.d_bufferSize, i, rhs.d_buffer + i ↦ _) && SEPFORALL(0, 8, i, lhs.d_state + i ↦ _) && SEPFORALL(0, 8, i, rhs.d_state + i ↦ _)`
- **groups/bdl/bdlde/bdlde_utf8util.cpp**
  - `(pc ↦ _) ⋆ (pc + 1 ↦ _) ⋆ (pc + 2 ↦ _)`
  - `input.length() >= 1`
  - `invalidString != NULL && (string != NULL || length == 0)`
  - `invalidString != nullptr && string != nullptr`
  - `pc ↦ _ ⋆ (pc + 1) ↦ _`
  - `pc ↦ _ ⋆ (pc + 1) ↦ _ ⋆ (pc + 2) ↦ _ ⋆ (pc + 3) ↦ _`
- **groups/bdl/bdldfp/bdldfp_decimal.cpp**
  - `!stream.bad()`
- **groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp**
  - `count >= 0`
  - `low <= high`
- **groups/bdl/bdldfp/bdldfp_decimalutil.cpp**
  - `str != nullptr && SEPFORALL(0, 6, i, (str + i) ↦ _)`
- **groups/bdl/bdljsn/bdljsn_jsontestsuiteutil.cpp**
  - `index < s_numData`
- **groups/bdl/bdljsn/bdljsn_jsonutil.cpp**
  - `d_it != d_end`
  - `d_it != d_sortedMembers.end() && (d_it == d_sortedMembers.begin() || EXISTS(d_sortedMembers.begin(), d_sortedMembers.end(), it, it == d_it))`
  - `lhs->first ↦ _ ⋆ rhs->first ↦ _`
  - `maxNestedDepth >= 0 && tokenizer != NULL && error != NULL`
  - `maxNestedDepth >= 0 && tokenizer != nullptr && result != nullptr && error != nullptr`
  - `tokenizer != nullptr && result != nullptr && error != nullptr`
- **groups/bdl/bdljsn/bdljsn_numberutil.cpp**
  - `(lhs.d_isExpNegative != rhs.d_isExpNegative || lhs.d_significantDigits != rhs.d_significantDigits) ==> (res_tmp == false) && (lhs.d_isExpNegative == rhs.d_isExpNegative && lhs.d_significantDigits == rhs.d_significantDigits && lhs.d_exponent == rhs.d_exponent) ==> (res_tmp == true)`
  - `begin <= end`
- **groups/bdl/bdljsn/bdljsn_tokenizer.cpp**
  - `d_streambuf_p != nullptr && (d_cursor < d_stringBuffer.size() || d_stringBuffer.size() == 0)`
- **groups/bdl/bdlma/bdlma_aligningallocator.cpp**
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_bufferimputil.cpp**
  - `(cursor != 0) && (buffer != 0) && (0 < size) && (0 <= *cursor) && (*cursor + size <= bufferSize)`
- **groups/bdl/bdlma/bdlma_concurrentallocatoradapter.cpp**
  - `numBytes >= 0`
- **groups/bdl/bdlma/bdlma_concurrentmultipool.cpp**
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_concurrentmultipoolallocator.cpp**
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_concurrentpool.cpp**
  - `x >= 0 && y > 0`
- **groups/bdl/bdlma/bdlma_concurrentpoolallocator.cpp**
  - `size >= 0`
  - `totalSize >= 0`
- **groups/bdl/bdlma/bdlma_countingallocator.cpp**
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_guardingallocator.cpp**
  - `address != 0 && pageSize == getSystemPageSize()`
  - `size > 0`
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_multipool.cpp**
  - `size <= d_maxBlockSize`
  - `size >= 0`
- **groups/bdl/bdlma/bdlma_pool.cpp**
  - `1 <= y`
- **groups/bdl/bdlma/bdlma_sequentialpool.cpp**
  - `initialSize >= 0`
  - `size >= 0`
- **groups/bdl/bdlmt/bdlmt_eventscheduler.cpp**
  - `(*handle == 0) || (*handle ↦ _)`
  - `amount > 0`
- **groups/bdl/bdlmt/bdlmt_multiprioritythreadpool.cpp**
  - `(unsigned) priority < (unsigned) d_queue.numPriorities()`
- **groups/bdl/bdlmt/bdlmt_threadpool.cpp**
  - `aThis != 0`
- **groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp**
  - `amount > 0`
- **groups/bdl/bdlpcre/bdlpcre_regex.cpp**
  - `errorMessage != NULL && errorOffset != NULL && pattern != NULL && (flags & ~VALID_FLAGS) == 0`
  - `matchContextData != 0 && (d_jitStackSize == 0 || d_jitStackSize > 0)`
  - `matchContextData != NULL`
  - `pcre2Context != 0 && patternCode != 0`
  - `subject.data() != nullptr && subject.length() >= 0 && subjectOffset <= subject.length()`
- **groups/bdl/bdls/bdls_fdstreambuf.cpp**
  - `(buffer == 0 && numBytes == 0) || (buffer != 0 && numBytes > 0)`
- **groups/bdl/bdls/bdls_filesystemutil.cpp**
  - `dirFD >= 0`
  - `idx < str.size() && (len == bsl::string::npos || idx + len <= str.size())`
  - `path != NULL && EXISTS(0, strlen(path) + 1, i, path[i] == '\0')`
  - `path != nullptr`
  - `path && (*path == '.' && (!path[1] || ('.' == path[1] && !path[2])))`
- **groups/bdl/bdls/bdls_pathutil.cpp**
  - `path != nullptr`
  - `rootEnd >= 0 && rootEnd <= static_cast<int>(bsl::strlen(path)) && (length == -1 || (length >= 0 && length <= static_cast<int>(bsl::strlen(path))))`
- **groups/bdl/bdls/bdls_pipeutil.cpp**
  - `pipeName != nullptr`
- **groups/bdl/bdls/bdls_processutil.cpp**
  - `path != nullptr`
- **groups/bdl/bdlsb/bdlsb_fixedmeminput.cpp**
  - `(which & 1) ==> (position >= 0 && position <= static_cast<bsl::size_t>(position))`
- **groups/bdl/bdlsb/bdlsb_fixedmeminstreambuf.cpp**
  - `which & bsl::ios_base::in && (way == bsl::ios_base::beg || way == bsl::ios_base::cur || way == bsl::ios_base::end)`
- **groups/bdl/bdlsb/bdlsb_fixedmemoutstreambuf.cpp**
  - `(!(which & 1`
- **groups/bdl/bdlt/bdlt_calendar.cpp**
  - `nextBusinessDay != 0 && Date(9999, 12, 31) > date && isInRange(date + 1) && 0 < nth`
- **groups/bdl/bdlt/bdlt_calendarcache.cpp**
  - `calendarName != NULL`
- **groups/bdl/bdlt/bdlt_date.cpp**
  - `!stream.bad()`
  - `bsl::numeric_limits<int>::max() - numDays > 0`
- **groups/bdl/bdlt/bdlt_datetimetz.cpp**
  - `stream != nullptr && !stream.bad()`
- **groups/bdl/bdlt/bdlt_datetz.cpp**
  - `stream.bad() == false`
- **groups/bdl/bdlt/bdlt_dateutil.cpp**
  - `original.month() == 2 && (original.day() == 28 || original.day() == 29)`
  - `original.year() >= 1 && original.year() <= 9999 && original.month() >= 1 && original.month() <= 12 && original.day() >= 1 && original.day() <= SerialDateImpUtil::lastDayOfMonth(original.year(), original.month())`
- **groups/bdl/bdlt/bdlt_dayofweek.cpp**
  - `stream && value >= 0 && value <= 6`
- **groups/bdl/bdlt/bdlt_dayofweekset.cpp**
  - `stream.bad() == false`
- **groups/bdl/bdlt/bdlt_defaultcalendarcache.cpp**
  - `loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)`
- **groups/bdl/bdlt/bdlt_defaulttimetablecache.cpp**
  - `loader != NULL && allocator != NULL && bsls::TimeInterval() <= timeout && timeout <= bsls::TimeInterval(INT_MAX, 0)`
- **groups/bdl/bdlt/bdlt_fixutil.cpp**
  - `begin < end && (SEPFORALL(begin, end, i, isdigit(*(i))) || !isdigit(*begin))`
  - `begin <= end && SEPEXISTS(0, 7, i, (begin + i ↦ _ && isdigit(*(begin + i)))) && *nextPos == begin`
  - `buffer != NULL && 0 <= value && 0 <= paddedLen`
  - `buffer != NULL && bufferLength >= 0`
  - `buffer != nullptr && -(24 * 60) < tzOffset && tzOffset < 24 * 60`
  - `nextPos != NULL && time != NULL && tzOffset != NULL && isNextDay != NULL && begin != NULL && end != NULL && begin <= end`
  - `nextPos && date && begin && end && (begin <= end) && (end - begin >= 8)`
- **groups/bdl/bdlt/bdlt_iso8601utilconfiguration.cpp**
  - `stream.good() && object.fractionalSecondPrecision() == object.fractionalSecondPrecision() && object.omitColonInZoneDesignator() == object.omitColonInZoneDesignator() && object.useCommaForDecimalSign() == object.useCommaForDecimalSign() && object.useZAbbreviationForUtc() == object.useZAbbreviationForUtc()`
- **groups/bdl/bdlt/bdlt_monthofyear.cpp**
  - `stream ↦ _`
- **groups/bdl/bdlt/bdlt_packedcalendar.cpp**
  - `0 <= offset`
  - `firstDate.isValid() && lastDate.isValid() && weekendDays.isValid()`
  - `level >= 0 && spacesPerLevel != 0`
  - `this->isHoliday(date)`
- **groups/bdl/bdlt/bdlt_posixdateimputil.cpp**
  - `0 <= year`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR && k_MIN_MONTH <= month && month <= k_MAX_MONTH`
- **groups/bdl/bdlt/bdlt_prolepticdateimputil.cpp**
  - `(k_MIN_YEAR <= year && year <= k_MAX_YEAR) && (k_MIN_MONTH <= month && month <= k_MAX_MONTH)`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR`
  - `k_MIN_YEAR <= year && year <= k_MAX_YEAR && 0 <= month && month <= k_MAX_MONTH`
- **groups/bdl/bdlt/bdlt_time.cpp**
  - `base > 0 && number != nullptr`
- **groups/bdl/bdlt/bdlt_timetable.cpp**
  - `24 > time.hour() && (0 <= code || code == Timetable::k_UNSET_TRANSITION_CODE)`
  - `d_dayIndex < d_timetable_p->d_timetable.length()`
  - `d_timetable.size() >= 0 && SEPFORALL(0, d_timetable.length(), i, d_timetable[i].size() >= 0)`
- **groups/bdl/bdlt/bdlt_timetablecache.cpp**
  - `timetableName != NULL`
- **groups/bdl/bdlt/bdlt_timetz.cpp**
  - `!stream.bad()`
- **groups/bsl/bslalg/bslalg_hashutil.cpp**
  - `(length >= 0) && (length == 0 || data != NULL)`
- **groups/bsl/bslalg/bslalg_rbtreeutil.cpp**
  - `subtree != 0 && SEPFORALL(subtree, nullptr, node, (node != nullptr ==> node->leftChild() != nullptr)) && SEPEXISTS(subtree, nullptr, node, (node != nullptr && node->leftChild() == nullptr))`
- **groups/bsl/bslfmt/bslfmt_unicodecodepoint.cpp**
  - `(pc ↦ _) ⋆ (pc + 1 ↦ _) ⋆ (pc + 2 ↦ _)`
  - `maxBytes >= 2`
  - `pc != NULL`
  - `pc ↦ _ ⋆ (pc + 1) ↦ _`
- **groups/bsl/bslh/bslh_siphashalgorithm.cpp**
  - `p ↦ _ ⋆ (p + 1) ↦ _ ⋆ (p + 2) ↦ _ ⋆ (p + 3) ↦ _ ⋆ (p + 4) ↦ _ ⋆ (p + 5) ↦ _ ⋆ (p + 6) ↦ _ ⋆ (p + 7) ↦ _`
- **groups/bsl/bslma/bslma_allocator.cpp**
  - `bytes >= 0`
- **groups/bsl/bslma/bslma_infrequentdeleteblocklist.cpp**
  - `numBytes >= 0`
- **groups/bsl/bslma/bslma_mallocfreeallocator.cpp**
  - `p ↦ _ ⋆ p->object ↦ _`
  - `size >= 0`
- **groups/bsl/bslma/bslma_newdeleteallocator.cpp**
  - `address != 0`
- **groups/bsl/bslma/bslma_sequentialpool.cpp**
  - `size >= 0`
- **groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp**
  - `argument != 0 && ((bslmt::EntryPointFunctorAdapter_Base*)argument)->function != nullptr`
- **groups/bsl/bslmt/bslmt_threadattributes.cpp**
  - `stream ↦ _ && level >= 0 && spacesPerLevel >= 0`
- **groups/bsl/bslmt/bslmt_threadutil.cpp**
  - `((int) policy >= ThreadAttributes::e_SCHED_MIN && (int) policy <= ThreadAttributes::e_SCHED_MAX) && (normalizedSchedulingPriority >= 0.0 && normalizedSchedulingPriority <= 1.0)`
- **groups/bsl/bsls/bsls_bslsourcenameparserutil.cpp**
  - `componentNamePtr != NULL && componentNameLength != NULL && sourceName != NULL`
  - `end >= begin`
  - `filename != nullptr && EXISTS(0, strlen(filename) + 1, i, filename[i] == '\0')`
- **groups/bsl/bsls/bsls_log.cpp**
  - `numBytes >= 0`
  - `size > 0 && buffer != NULL && format != NULL`
- **groups/bsl/bsls/bsls_nameof.cpp**
  - `buffer != nullptr && functionName != nullptr && std::strlen(functionName) > 0`
- **groups/bsl/bsls/bsls_outputredirector.cpp**
  - `expected != 0 && SEPFORALL(0, strlen(expected) + 1, i, (expected + i) ↦ _)`
- **groups/bsl/bsls/bsls_stackaddressutil.cpp**
  - `output != 0 && length > 0`
  - `tag != NULL && strlen(tag) > 0 ==> FORALL(0, strlen(tag), i, tag[i] != '\0')`
- **groups/bsl/bsls/bsls_timeinterval.cpp**
  - `isSumValidInt64(d_seconds, seconds`
- **groups/bsl/bslstl/bslstl_sharedptr.cpp**
  - `bufferSize > 0`
- **groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.cpp**
  - `rhs.d_data_p != 0`
- **groups/bsl/bslx/bslx_byteinstream.cpp**
  - `object.length() >= 0 && SEPFORALL(0, object.length(), i, object.data() + i ↦ _)`
- **groups/bsl/bslx/bslx_testoutstream.cpp**
  - `0 <= length`
